### PR TITLE
增加拓展cursor cli 方式调用模型

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Add built-in `cursor` agent preset (`cursor agent acp`)
+- Authenticate with advertised ACP auth methods before creating sessions (supports Cursor `cursor_login`)
+- Broaden auto-allow permission option matching to support both snake_case and kebab-case kinds
+- Improve enqueue error logging by printing structured error details
+
 ## 0.1.2
 
 - Add `--show-thoughts` flag to forward agent thinking to WeChat (off by default)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ npx wechat-acp agents
 
 Current presets:
 
+- `cursor`
 - `copilot`
 - `claude`
 - `gemini`
@@ -88,8 +89,15 @@ Examples:
 ```bash
 npx wechat-acp --agent copilot
 npx wechat-acp --agent claude --cwd D:\code\project
+npx wechat-acp --agent cursor
 npx wechat-acp --agent "npx @github/copilot --acp"
 npx wechat-acp --agent gemini --daemon
+```
+
+For the `cursor` preset, make sure Cursor CLI is authenticated first:
+
+```bash
+cursor agent login
 ```
 
 ## Configuration File

--- a/src/acp/agent-manager.ts
+++ b/src/acp/agent-manager.ts
@@ -73,6 +73,13 @@ export async function spawnAgent(params: {
   });
   log(`ACP initialized (protocol v${initResult.protocolVersion})`);
 
+  const authMethod = pickAuthMethod(initResult.authMethods);
+  if (authMethod) {
+    log(`Authenticating ACP client via "${authMethod}"...`);
+    await connection.authenticate({ methodId: authMethod });
+    log("ACP authentication completed");
+  }
+
   // Create session
   log("Creating ACP session...");
   const sessionResult = await connection.newSession({
@@ -86,6 +93,16 @@ export async function spawnAgent(params: {
     connection,
     sessionId: sessionResult.sessionId,
   };
+}
+
+function pickAuthMethod(
+  authMethods?: Array<{ id: string }> | null,
+): string | null {
+  if (!authMethods || authMethods.length === 0) return null;
+
+  // Prefer cursor_login when available, then fallback to first advertised method.
+  const cursorLogin = authMethods.find((method) => method.id === "cursor_login");
+  return cursorLogin?.id ?? authMethods[0]?.id ?? null;
 }
 
 export function killAgent(proc: ChildProcess): void {

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -38,9 +38,18 @@ export class WeChatAcpClient implements acp.Client {
   async requestPermission(
     params: acp.RequestPermissionRequest,
   ): Promise<acp.RequestPermissionResponse> {
-    // Auto-allow: find first "allow" option
+    // Auto-allow: find first "allow" option.
+    // Different agents may use snake_case or kebab-case option kinds.
     const allowOpt = params.options.find(
-      (o) => o.kind === "allow_once" || o.kind === "allow_always",
+      (o) => {
+        const kind = String((o as { kind?: string }).kind ?? "");
+        return (
+          kind === "allow_once" ||
+          kind === "allow_always" ||
+          kind === "allow-once" ||
+          kind === "allow-always"
+        );
+      },
     );
     const optionId = allowOpt?.optionId ?? params.options[0]?.optionId ?? "allow";
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -105,7 +105,7 @@ export class WeChatAcpBridge {
 
     // Convert and enqueue — fire-and-forget (don't block the poll loop)
     this.enqueueMessage(msg, userId, contextToken).catch((err) => {
-      this.log(`Failed to enqueue message from ${userId}: ${String(err)}`);
+      this.log(`Failed to enqueue message from ${userId}: ${formatError(err)}`);
     });
   }
 
@@ -211,5 +211,17 @@ export class WeChatAcpBridge {
       if (item.type === 5) return "[video]";
     }
     return "[empty]";
+  }
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.stack ?? `${err.name}: ${err.message}`;
+  }
+  if (typeof err === "string") return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,12 @@ export interface ResolvedAgentConfig extends AgentCommandConfig {
 }
 
 export const BUILT_IN_AGENTS: Record<string, AgentPreset> = {
+  cursor: {
+    label: "Cursor Agent (ACP)",
+    command: "cursor",
+    args: ["agent", "acp"],
+    description: "Cursor CLI ACP",
+  },
   copilot: {
     label: "GitHub Copilot",
     command: "npx",


### PR DESCRIPTION
增加拓展cursor cli 方式调用模型，需要先安装cursor cli脚手架，然后登陆cursor cli，启动项目(node dist/bin/wechat-acp.js --agent cursor
)就可以调用cursor