### PR TITLE
fix: serialize per-user message dispatch to prevent duplicate sessions

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -88,6 +88,7 @@ export class WeChatAcpBridge {
     this.log("Stopping bridge...");
     this.abortController.abort();
     await this.sessionManager?.stop();
+    this.userLocks.clear();
     this.log("Bridge stopped");
   }
 
@@ -107,8 +108,17 @@ export class WeChatAcpBridge {
     // Fire-and-forget (don't block the poll loop), but serialize per-user
     // to prevent concurrent session creation
     const prev = this.userLocks.get(userId) ?? Promise.resolve();
-    const next = prev.then(() => this.enqueueMessage(msg, userId, contextToken));
-    this.userLocks.set(userId, next.catch(() => {}));
+    const next = prev
+      .then(() => this.enqueueMessage(msg, userId, contextToken))
+      .catch((err) => {
+        this.log(`Failed to enqueue message from ${userId}: ${String(err)}`);
+      })
+      .finally(() => {
+        if (this.userLocks.get(userId) === next) {
+          this.userLocks.delete(userId);
+        }
+      });
+    this.userLocks.set(userId, next);
   }
 
   private async enqueueMessage(

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -116,15 +116,19 @@ export class WeChatAcpBridge {
 
     this.log(`Message from ${userId}: ${this.previewMessage(msg)}`);
 
+    // Capture the current session manager so async enqueueing does not
+    // race with stop() nulling out this.sessionManager.
+    const sessionManager = this.sessionManager;
+
     // Fire-and-forget (don't block the poll loop), but serialize per-user
     // to prevent concurrent session creation
     const prev = this.userLocks.get(userId) ?? Promise.resolve();
     const next = prev
       .then(() => {
-        if (this.stopping || this.stopped || this.sessionManager == null) {
+        if (this.stopping || this.stopped || sessionManager == null) {
           return;
         }
-        return this.enqueueMessage(msg, userId, contextToken);
+        return this.enqueueMessage(msg, userId, contextToken, sessionManager);
       })
       .catch((err) => {
         this.log(`Failed to enqueue message from ${userId}: ${String(err)}`);

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -25,6 +25,7 @@ export class WeChatAcpBridge {
   private tokenData: TokenData | null = null;
   // Per-user typing ticket cache
   private typingTickets = new Map<string, { ticket: string; expiresAt: number }>();
+  private userLocks = new Map<string, Promise<void>>();
   private log: (msg: string) => void;
 
   constructor(config: WeChatAcpConfig, log?: (msg: string) => void) {
@@ -103,10 +104,11 @@ export class WeChatAcpBridge {
 
     this.log(`Message from ${userId}: ${this.previewMessage(msg)}`);
 
-    // Convert and enqueue — fire-and-forget (don't block the poll loop)
-    this.enqueueMessage(msg, userId, contextToken).catch((err) => {
-      this.log(`Failed to enqueue message from ${userId}: ${String(err)}`);
-    });
+    // Fire-and-forget (don't block the poll loop), but serialize per-user
+    // to prevent concurrent session creation
+    const prev = this.userLocks.get(userId) ?? Promise.resolve();
+    const next = prev.then(() => this.enqueueMessage(msg, userId, contextToken));
+    this.userLocks.set(userId, next.catch(() => {}));
   }
 
   private async enqueueMessage(

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -26,6 +26,8 @@ export class WeChatAcpBridge {
   // Per-user typing ticket cache
   private typingTickets = new Map<string, { ticket: string; expiresAt: number }>();
   private userLocks = new Map<string, Promise<void>>();
+  private stopping = false;
+  private stopped = false;
   private log: (msg: string) => void;
 
   constructor(config: WeChatAcpConfig, log?: (msg: string) => void) {
@@ -85,14 +87,23 @@ export class WeChatAcpBridge {
   }
 
   async stop(): Promise<void> {
+    if (this.stopped || this.stopping) {
+      return;
+    }
+
+    this.stopping = true;
     this.log("Stopping bridge...");
     this.abortController.abort();
     await this.sessionManager?.stop();
+    this.sessionManager = null;
     this.userLocks.clear();
+    this.stopped = true;
     this.log("Bridge stopped");
   }
 
   private handleMessage(msg: WeixinMessage): void {
+    if (this.stopping || this.stopped) return;
+
     // Only process user messages (not bot's own messages)
     if (msg.message_type !== MessageType.USER) return;
 
@@ -109,7 +120,12 @@ export class WeChatAcpBridge {
     // to prevent concurrent session creation
     const prev = this.userLocks.get(userId) ?? Promise.resolve();
     const next = prev
-      .then(() => this.enqueueMessage(msg, userId, contextToken))
+      .then(() => {
+        if (this.stopping || this.stopped || this.sessionManager == null) {
+          return;
+        }
+        return this.enqueueMessage(msg, userId, contextToken);
+      })
       .catch((err) => {
         this.log(`Failed to enqueue message from ${userId}: ${String(err)}`);
       })


### PR DESCRIPTION
When multiple messages arrive concurrently for the same user, the fire-and-forget dispatch causes parallel enqueue() calls that each spawn a new agent process before the session map is populated.

Chain per-user dispatches so messages are enqueued sequentially.