### PR TITLE
feat: --instance flag for isolated multi-bridge setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `--instance <name>` to run multiple bridges side by side on one machine, each with its own WeChat account, project cwd, daemon pid/log, sync state, and telemetry id. Storage moves under `~/.wechat-acp/instances/<name>/`. Default (no `--instance`) is unchanged.
+
 ## 0.1.4
 
 - Update `claude` preset to use `@agentclientprotocol/claude-agent-acp` (the deprecated `@zed-industries/claude-code-acp` was renamed)

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Options:
 - `--login`: force QR re-login and replace the saved token
 - `--daemon`: run in background after startup
 - `--config <file>`: load JSON config file
+- `--instance <name>`: run as a named, isolated instance. See "Running multiple instances" below.
 - `--idle-timeout <minutes>`: session idle timeout, default `1440` (use `0` for unlimited)
 - `--max-sessions <count>`: maximum concurrent user sessions, default `10`
 - `--hide-thoughts`: do not forward agent thinking to WeChat (default: forwarded)
@@ -93,6 +94,31 @@ npx wechat-acp --agent claude --cwd D:\code\project
 npx wechat-acp --agent "npx @github/copilot --acp"
 npx wechat-acp --agent gemini --daemon
 ```
+
+## Running multiple instances
+
+By default everything (saved login token, daemon pid/log, sync state, telemetry id) lives under `~/.wechat-acp/`, which means a single machine can only host one bridge at a time. Pass `--instance <name>` to namespace all of that under `~/.wechat-acp/instances/<name>/` and run several bridges side by side, each with its own WeChat account and project directory.
+
+Typical setup: WeChat account 1 drives project A, WeChat account 2 drives project B.
+
+```bash
+# Terminal 1: scan with WeChat account 1
+npx wechat-acp --instance projA --agent copilot --cwd D:\code\repo-a
+
+# Terminal 2: scan with WeChat account 2
+npx wechat-acp --instance projB --agent copilot --cwd D:\code\repo-b
+```
+
+The first run of each instance prints its own QR code. Tokens are saved per instance, so subsequent runs reuse them independently.
+
+The `stop` and `status` subcommands also honor `--instance`:
+
+```bash
+npx wechat-acp status --instance projA
+npx wechat-acp stop   --instance projB
+```
+
+Without `--instance`, paths fall back to `~/.wechat-acp/` exactly as before, so existing installs are unaffected.
 
 ## Configuration File
 
@@ -154,6 +180,8 @@ This directory is used for:
 - daemon log file
 - sync state
 - anonymous telemetry install id (`telemetry-id`, see Telemetry section)
+
+When `--instance <name>` is used, the same files live under `~/.wechat-acp/instances/<name>/` instead, fully isolated from other instances.
 
 ## Current Limitations
 

--- a/bin/wechat-acp.ts
+++ b/bin/wechat-acp.ts
@@ -22,6 +22,7 @@ import {
   defaultStorageDir,
   listBuiltInAgents,
   resolveAgentSelection,
+  validateInstanceName,
 } from "../src/config.js";
 import type { WeChatAcpConfig } from "../src/config.js";
 import {
@@ -243,6 +244,15 @@ async function main(): Promise<void> {
   if (args.help) {
     usage();
     process.exit(0);
+  }
+
+  if (args.instance !== undefined) {
+    try {
+      validateInstanceName(args.instance);
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      process.exit(1);
+    }
   }
 
   const config = defaultConfig({ instance: args.instance });

--- a/bin/wechat-acp.ts
+++ b/bin/wechat-acp.ts
@@ -19,6 +19,7 @@ import qrcodeTerminal from "qrcode-terminal";
 import { WeChatAcpBridge } from "../src/bridge.js";
 import {
   defaultConfig,
+  defaultStorageDir,
   listBuiltInAgents,
   resolveAgentSelection,
 } from "../src/config.js";
@@ -53,6 +54,11 @@ Options:
   --login             Force re-login (new QR code)
   --daemon            Run in background after login
   --config <file>     Config file path (JSON)
+  --instance <name>   Run as a named, isolated instance.
+                      Storage, token, daemon pid/log, and telemetry id are
+                      scoped to ~/.wechat-acp/instances/<name>/.
+                      Lets you run multiple bridges side by side, each with
+                      its own WeChat account and project cwd.
   --idle-timeout <m>  Session idle timeout in minutes (default: 1440)
                       Use 0 to disable idle cleanup
   --max-sessions <n>  Max concurrent user sessions (default: 10)
@@ -69,6 +75,7 @@ function parseArgs(argv: string[]): {
   forceLogin: boolean;
   daemon: boolean;
   configFile?: string;
+  instance?: string;
   idleTimeout?: number;
   maxSessions?: number;
   hideThoughts: boolean;
@@ -109,6 +116,9 @@ function parseArgs(argv: string[]): {
         break;
       case "--config":
         result.configFile = args[++i];
+        break;
+      case "--instance":
+        result.instance = args[++i];
         break;
       case "--idle-timeout":
         result.idleTimeout = parseInt(args[++i], 10);
@@ -235,7 +245,7 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  const config = defaultConfig();
+  const config = defaultConfig({ instance: args.instance });
 
   // Load config file if specified
   if (args.configFile) {
@@ -246,6 +256,15 @@ async function main(): Promise<void> {
     Object.assign(config.session, fileConfig.session ?? {});
     Object.assign(config.daemon, fileConfig.daemon ?? {});
     Object.assign(config.storage, fileConfig.storage ?? {});
+  }
+
+  // CLI --instance always wins over config-file storage.dir so users can
+  // run a config in multiple isolated instances without editing the file.
+  if (args.instance) {
+    config.storage.instance = args.instance;
+    config.storage.dir = defaultStorageDir(args.instance);
+    config.daemon.logFile = path.join(config.storage.dir, "wechat-acp.log");
+    config.daemon.pidFile = path.join(config.storage.dir, "daemon.pid");
   }
 
   // Handle subcommands

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,9 +91,28 @@ export interface WeChatAcpConfig {
   };
 }
 
+const INSTANCE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+/**
+ * Validate an instance name. Names are used as a directory segment under
+ * `~/.wechat-acp/instances/`, so we restrict them to a safe character set
+ * to prevent path traversal (`..`, absolute paths) and platform-specific
+ * issues with hidden / reserved names.
+ */
+export function validateInstanceName(instance: string): void {
+  if (!INSTANCE_NAME_PATTERN.test(instance)) {
+    throw new Error(
+      `Invalid --instance name: ${JSON.stringify(instance)}. ` +
+        "Must be 1-64 chars, start with a letter or digit, " +
+        "and contain only letters, digits, '.', '_', or '-'.",
+    );
+  }
+}
+
 export function defaultStorageDir(instance?: string): string {
   const root = path.join(os.homedir(), ".wechat-acp");
   if (!instance) return root;
+  validateInstanceName(instance);
   return path.join(root, "instances", instance);
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,15 +87,19 @@ export interface WeChatAcpConfig {
   };
   storage: {
     dir: string;
+    instance?: string;
   };
 }
 
-export function defaultStorageDir(): string {
-  return path.join(os.homedir(), ".wechat-acp");
+export function defaultStorageDir(instance?: string): string {
+  const root = path.join(os.homedir(), ".wechat-acp");
+  if (!instance) return root;
+  return path.join(root, "instances", instance);
 }
 
-export function defaultConfig(): WeChatAcpConfig {
-  const storageDir = defaultStorageDir();
+export function defaultConfig(opts?: { instance?: string }): WeChatAcpConfig {
+  const instance = opts?.instance;
+  const storageDir = defaultStorageDir(instance);
   return {
     wechat: {
       baseUrl: "https://ilinkai.weixin.qq.com",
@@ -121,6 +125,7 @@ export function defaultConfig(): WeChatAcpConfig {
     },
     storage: {
       dir: storageDir,
+      instance,
     },
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,4 +16,5 @@ export {
 	listBuiltInAgents,
 	parseAgentCommand,
 	resolveAgentSelection,
+	validateInstanceName,
 } from "./config.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export type {
 export {
 	BUILT_IN_AGENTS,
 	defaultConfig,
+	defaultStorageDir,
 	listBuiltInAgents,
 	parseAgentCommand,
 	resolveAgentSelection,


### PR DESCRIPTION
Closes #24

## What

Adds `--instance <name>` so one machine can host multiple `wechat-acp` bridges side by side. Each instance gets its own WeChat account login (separate QR), its own saved token, its own daemon pid/log, its own sync state, and its own telemetry install id. Without the flag, behavior is unchanged.

## Why

Today every per-bridge file lives in `~/.wechat-acp/`, so a second instance clobbers the first. The use case (which #24 spells out) is "WeChat account 1 drives project A in one cwd, account 2 drives project B in another, on the same machine, no interference".

## How

- `defaultStorageDir(instance?)` returns `~/.wechat-acp/instances/<name>` when given an instance name, else `~/.wechat-acp` (same as today).
- `defaultConfig({ instance })` threads it through into `storage.dir`, `daemon.logFile`, and `daemon.pidFile`.
- CLI parses `--instance <name>` and applies it after config-file merge so it always wins.
- `stop` and `status` subcommands also honor `--instance`, since they look up the pid file via `config.daemon.pidFile`.
- `WeChatAcpConfig.storage` gains an optional `instance` field, exposed in the public types.
- README gets a "Running multiple instances" section showing the two-account, two-project flow.

The rest of the bridge already routed every path through `storage.dir`, so this is the minimum surgical change.

## Verified locally

```text
$ node dist/bin/wechat-acp.js --help | grep -A4 instance
  --instance <name>   Run as a named, isolated instance.
                      Storage, token, daemon pid/log, and telemetry id are
                      scoped to ~/.wechat-acp/instances/<name>/.
                      Lets you run multiple bridges side by side, each with
                      its own WeChat account and project cwd.

$ node dist/bin/wechat-acp.js status
Not running

$ node dist/bin/wechat-acp.js status --instance projA
Not running

$ echo 99999999 > ~/.wechat-acp/instances/projA/daemon.pid
$ node dist/bin/wechat-acp.js status --instance projA
Not running (stale PID 99999999)
$ node dist/bin/wechat-acp.js status --instance projB
Not running
```

(Per-instance pid lookup confirmed; default-instance and other-instance paths stay independent.)

End-to-end with real WeChat logins is the obvious next test; I'm holding off scanning two accounts until you've sanity-checked the design, since this is a draft. Happy to iterate.

## Backwards compatibility

No existing code path changes when `--instance` is absent. Existing installs keep using `~/.wechat-acp/` directly.

## Notes / open questions

1) `defaultConfig` signature change. I added an optional `opts` arg. Existing `defaultConfig()` callers still work. If you'd rather keep the no-arg form and ship a separate `defaultConfig(opts)` overload or a builder, easy to refactor.
2) `WeChatAcpConfig.storage.instance` is a new optional field on a public type. Strictly additive, but flagging in case you want to version the config schema.
3) I went with `--instance` over `--profile` for the name; happy to rename if you prefer the latter.
4) Out of scope (call out if you'd rather I include): a `wechat-acp instances` subcommand that lists all known instance directories.

Drafted because I'd like your read on the flag shape and the `defaultConfig` signature before polishing.