### PR TITLE
ci: publish to npm on GitHub Release (trusted publishing)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,6 +30,16 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
-      - run: npm install -g npm@latest
+      - name: Verify package.json version matches release tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          pkg_version="$(node -p "require('./package.json').version")"
+          tag_version="${RELEASE_TAG#v}"
+          if [ "$pkg_version" != "$tag_version" ]; then
+            echo "::error::Release tag '$RELEASE_TAG' does not match package.json version '$pkg_version'."
+            echo "Bump package.json to $tag_version (or retag) and re-run."
+            exit 1
+          fi
       - run: npm ci
       - run: npm publish --provenance --access public

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,35 @@
+# Publish the npm package on GitHub Release.
+#
+# Uses npm trusted publishing (OIDC) via `--provenance`, so no NPM_TOKEN is
+# required in the repo secrets. The maintainer must register this workflow
+# as a trusted publisher on npmjs.com once:
+#   https://www.npmjs.com/package/wechat-acp/access -> Publishing access
+#     -> "Trusted Publisher" -> GitHub Actions
+#     repo: formulahendry/wechat-acp
+#     workflow: npm-publish.yml
+#     environment: (leave blank)
+#
+# After that, create a GitHub Release (tagged e.g. v0.1.5) and this workflow
+# will publish wechat-acp@0.1.5 to npm with build provenance attached.
+
+name: publish-on-release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: npm install -g npm@latest
+      - run: npm ci
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
## What

Adds `.github/workflows/npm-publish.yml`. When a GitHub Release is created, the workflow runs `npm ci && npm publish --provenance --access public` to push the package to npmjs.

## Why

Right now publishing is presumably manual (`npm publish` from a local machine). Releasing via GitHub Release makes the build reproducible from a known SHA, attaches npm build provenance attestations, and removes the need for any maintainer to keep a long-lived `NPM_TOKEN` on their machine.

## How

- Trigger: `on.release.types: [created]`.
- Auth: npm OIDC trusted publishing via `permissions.id-token: write` and `npm publish --provenance`. No `NPM_TOKEN` secret required in this repo.
- `npm ci` installs deps, then `npm publish` triggers `prepack` (`npm run build`), so the published tarball always reflects a fresh `tsc` from the tagged source.
- Pinned `actions/checkout@v4` and `actions/setup-node@v4`; Node 20 to match `engines.node >=20.0.0` in `package.json`.

## One-time setup needed on npmjs.com (not in this PR)

Before the first release after merge, the package owner has to register this workflow as a Trusted Publisher on https://www.npmjs.com/package/wechat-acp/access:

- Provider: GitHub Actions
- Repository: `formulahendry/wechat-acp`
- Workflow file: `npm-publish.yml`
- Environment: leave blank

Header comment in the workflow file documents the same. @Eskibear is going to reach out separately to walk through that step.

## How to release after merge

1) Bump version in `package.json` (e.g. `0.1.4` -> `0.1.5`), update `CHANGELOG.md`, merge.
2) Create a GitHub Release tagged `v0.1.5` against `main`.
3) Workflow runs, `wechat-acp@0.1.5` appears on npm with a green provenance badge.

## Reference

Modeled directly on https://github.com/Eskibear/vscode-extension-telemetry-wrapper/blob/master/.github/workflows/npm-publish.yml, which has been running this pattern in production for a while.