### PR TITLE
ci: bump publish workflow to Node 24 for npm 11.x (fixes E404 on trusted publishing)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,7 +28,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # Node 24 ships npm 11.x which supports OIDC trusted publishing.
+          # Node 20 ships npm 10.8.2 and silently falls back to token auth,
+          # which surfaces as a misleading 404 from the registry.
+          # See https://github.com/npm/cli/issues/8730.
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - name: Verify package.json version matches release tag
         env:


### PR DESCRIPTION
## Why

The first real run of the publish workflow [failed twice](https://github.com/formulahendry/wechat-acp/actions/runs/26021426363) with:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/wechat-acp
npm error 404  'wechat-acp@0.2.0' is not in this registry.
```

Trusted Publisher is correctly configured on npmjs.com (verified after the first failure, re-run still 404'd). The real issue is documented in [npm/cli#8730](https://github.com/npm/cli/issues/8730): **Node 20 ships npm 10.8.2, which silently falls back to token auth instead of doing the OIDC handshake.** The fallback path then 404s because there is no token.

Multiple reporters confirmed the fix is bumping to Node 24 (npm 11.x). The npm docs were eventually updated to require 11.5.1+ but still show Node 20 in examples, which is the trap we hit.

## Why this regressed

PR #26 originally had `npm install -g npm@latest` (copied from `Eskibear/vscode-extension-telemetry-wrapper` which is known to work). Copilot's review flagged it as non-deterministic and I dropped it. That review comment was technically right, but the real fix was always "use an npm version that supports OIDC", which on Node 20 only happens because of that manual upgrade. Bumping the runtime is cleaner.

## Verification path

After merge, formulahendry can:
1) Cut a fresh release (e.g. `v0.2.1`), or
2) Delete + recreate the `v0.2.0` release to retrigger the workflow.

Re-running the existing failed run will not pick up the new workflow file, since release-triggered runs check out the tag SHA which is frozen.

Refs: https://github.com/npm/cli/issues/8730