### PR TITLE
feat: save received binary files to inbox so agents can read them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Save received binary files to disk under `~/.wechat-acp/inbox/` so the agent can read them by absolute path instead of getting only a size notice. Customize with `--inbox-dir <path>` or `storage.inboxDir`; disable with `--no-inbox`. Default location is instance-scoped when `--instance` is used.
+
 ## 0.2.0
 
 - Add `--instance <name>` to run multiple bridges side by side on one machine, each with its own WeChat account, project cwd, daemon pid/log, sync state, and telemetry id. Storage moves under `~/.wechat-acp/instances/<name>/`. Default (no `--instance`) is unchanged.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Options:
 - `--instance <name>`: run as a named, isolated instance. See "Running multiple instances" below.
 - `--idle-timeout <minutes>`: session idle timeout, default `1440` (use `0` for unlimited)
 - `--max-sessions <count>`: maximum concurrent user sessions, default `10`
+- `--inbox-dir <dir>`: directory where received binary files are saved (default: `<storage.dir>/inbox`). The agent sees the absolute saved path in the prompt and can read the file directly.
+- `--no-inbox`: do not save received files; the agent only sees a size notice.
 - `--hide-thoughts`: do not forward agent thinking to WeChat (default: forwarded)
 - `-h, --help`: show help
 
@@ -165,6 +167,29 @@ You can also override or add agent presets:
 - Typing indicators are sent when supported by the WeChat API.
 - Sessions are cleaned up after inactivity (set `idleTimeoutMs` to `0` to disable idle cleanup).
 
+## Receiving files
+
+When a WeChat user sends a binary file (PDF, image, audio recording exported as a file, ZIP, etc.), `wechat-acp` downloads and decrypts it from the WeChat CDN, then **saves it to disk** so the ACP agent can read it by absolute path. The agent receives a text block like:
+
+```
+[Received file: 报告.pdf (484067 bytes) — saved to: /Users/me/.wechat-acp/inbox/2026-05-21T09-29-12-492Z-报告.pdf]
+```
+
+Any ACP agent that can read local files (Copilot CLI, Claude Code, Codex, …) can then open the saved path with its normal file tools.
+
+Defaults:
+
+- Save location: `<storage.dir>/inbox`, i.e. `~/.wechat-acp/inbox` by default, or `~/.wechat-acp/instances/<name>/inbox` when `--instance` is used.
+- Filename: `<ISO-timestamp>-<original-name>`, with filesystem-unsafe characters in the original name replaced by `_`. Unicode (including Chinese) filenames are preserved.
+- No automatic cleanup. Files live until you delete them; agents may reference them long after the WeChat message arrives. Periodically run e.g. `find ~/.wechat-acp/inbox -mtime +30 -delete` if you want to prune.
+
+Overrides:
+
+- `--inbox-dir /some/path` — write files somewhere else (handy if you want them under iCloud Drive, a project folder, etc.)
+- `--no-inbox` — keep the pre-0.3 behavior where the file buffer is dropped after download and the agent only sees `[Received file: name, N bytes]`.
+
+Text-typed files (`.md`, `.json`, source code, …) and images keep their previous behavior: their content is embedded inline in the prompt as a `resource` / `image` block, no disk write needed.
+
 ## Storage
 
 By default, runtime files are stored under:
@@ -180,6 +205,7 @@ This directory is used for:
 - daemon log file
 - sync state
 - anonymous telemetry install id (`telemetry-id`, see Telemetry section)
+- `inbox/` — binary files received from WeChat (see "Receiving files"); disable with `--no-inbox` or relocate with `--inbox-dir`
 
 When `--instance <name>` is used, the same files live under `~/.wechat-acp/instances/<name>/` instead, fully isolated from other instances.
 

--- a/bin/wechat-acp.ts
+++ b/bin/wechat-acp.ts
@@ -60,6 +60,13 @@ Options:
                       scoped to ~/.wechat-acp/instances/<name>/.
                       Lets you run multiple bridges side by side, each with
                       its own WeChat account and project cwd.
+  --inbox-dir <path>  Directory to save binary files received from WeChat
+                      (default: <storage.dir>/inbox). The agent sees the
+                      saved absolute path in the prompt so it can read the
+                      file directly.
+  --no-inbox          Disable saving received files. The agent will only
+                      see a "[Received file: name, N bytes]" notice and
+                      will not be able to read the file content.
   --idle-timeout <m>  Session idle timeout in minutes (default: 1440)
                       Use 0 to disable idle cleanup
   --max-sessions <n>  Max concurrent user sessions (default: 10)
@@ -77,6 +84,8 @@ function parseArgs(argv: string[]): {
   daemon: boolean;
   configFile?: string;
   instance?: string;
+  inboxDir?: string;
+  disableInbox: boolean;
   idleTimeout?: number;
   maxSessions?: number;
   hideThoughts: boolean;
@@ -86,6 +95,7 @@ function parseArgs(argv: string[]): {
   const result = {
     forceLogin: false,
     daemon: false,
+    disableInbox: false,
     hideThoughts: false,
     verbose: false,
     help: false,
@@ -120,6 +130,12 @@ function parseArgs(argv: string[]): {
         break;
       case "--instance":
         result.instance = args[++i];
+        break;
+      case "--inbox-dir":
+        result.inboxDir = args[++i];
+        break;
+      case "--no-inbox":
+        result.disableInbox = true;
         break;
       case "--idle-timeout":
         result.idleTimeout = parseInt(args[++i], 10);
@@ -275,6 +291,21 @@ async function main(): Promise<void> {
     config.storage.dir = defaultStorageDir(args.instance);
     config.daemon.logFile = path.join(config.storage.dir, "wechat-acp.log");
     config.daemon.pidFile = path.join(config.storage.dir, "daemon.pid");
+    // Re-derive the default inbox to the new storage root. A later
+    // --inbox-dir / --no-inbox below still wins.
+    config.storage.inboxDir = path.join(config.storage.dir, "inbox");
+  }
+
+  // Inbox overrides. --no-inbox wins over --inbox-dir if both are given,
+  // since "disable" is the more explicit intent.
+  if (args.disableInbox) {
+    config.storage.inboxDir = null;
+  } else if (args.inboxDir) {
+    config.storage.inboxDir = path.resolve(args.inboxDir);
+  } else if (config.storage.inboxDir && !path.isAbsolute(config.storage.inboxDir)) {
+    // A config-file-supplied relative path is resolved against cwd at
+    // startup so the agent always sees an absolute path in prompts.
+    config.storage.inboxDir = path.resolve(config.storage.inboxDir);
   }
 
   // Handle subcommands

--- a/bin/wechat-acp.ts
+++ b/bin/wechat-acp.ts
@@ -274,6 +274,7 @@ async function main(): Promise<void> {
   const config = defaultConfig({ instance: args.instance });
 
   // Load config file if specified
+  let configFileSetInboxDir = false;
   if (args.configFile) {
     const fileConfig = loadConfigFile(args.configFile);
     Object.assign(config.wechat, fileConfig.wechat ?? {});
@@ -281,6 +282,16 @@ async function main(): Promise<void> {
     Object.assign(config.agents, fileConfig.agents ?? {});
     Object.assign(config.session, fileConfig.session ?? {});
     Object.assign(config.daemon, fileConfig.daemon ?? {});
+    // Track whether the user explicitly set inboxDir so we don't
+    // overwrite their choice with a re-derived default below. We check
+    // before Object.assign because checking after can't distinguish
+    // "user wrote inboxDir: null to disable" from "user didn't write it".
+    if (
+      fileConfig.storage &&
+      Object.prototype.hasOwnProperty.call(fileConfig.storage, "inboxDir")
+    ) {
+      configFileSetInboxDir = true;
+    }
     Object.assign(config.storage, fileConfig.storage ?? {});
   }
 
@@ -291,21 +302,28 @@ async function main(): Promise<void> {
     config.storage.dir = defaultStorageDir(args.instance);
     config.daemon.logFile = path.join(config.storage.dir, "wechat-acp.log");
     config.daemon.pidFile = path.join(config.storage.dir, "daemon.pid");
-    // Re-derive the default inbox to the new storage root. A later
-    // --inbox-dir / --no-inbox below still wins.
-    config.storage.inboxDir = path.join(config.storage.dir, "inbox");
   }
 
-  // Inbox overrides. --no-inbox wins over --inbox-dir if both are given,
-  // since "disable" is the more explicit intent.
+  // Resolve the final inbox directory. Precedence (highest first):
+  //   1. --no-inbox            (explicit disable)
+  //   2. --inbox-dir <path>    (explicit CLI override)
+  //   3. config.storage.inboxDir explicitly set in the config file
+  //      (relative paths are resolved against cwd)
+  //   4. Default: <storage.dir>/inbox, re-derived from whatever the
+  //      final storage.dir is. This is what keeps a config file that
+  //      only sets storage.dir consistent with the documented
+  //      "default: <storage.dir>/inbox", and also covers the
+  //      --instance case for free.
   if (args.disableInbox) {
     config.storage.inboxDir = null;
   } else if (args.inboxDir) {
     config.storage.inboxDir = path.resolve(args.inboxDir);
-  } else if (config.storage.inboxDir && !path.isAbsolute(config.storage.inboxDir)) {
-    // A config-file-supplied relative path is resolved against cwd at
-    // startup so the agent always sees an absolute path in prompts.
-    config.storage.inboxDir = path.resolve(config.storage.inboxDir);
+  } else if (configFileSetInboxDir) {
+    if (config.storage.inboxDir && !path.isAbsolute(config.storage.inboxDir)) {
+      config.storage.inboxDir = path.resolve(config.storage.inboxDir);
+    }
+  } else {
+    config.storage.inboxDir = path.join(config.storage.dir, "inbox");
   }
 
   // Handle subcommands

--- a/src/adapter/inbound.ts
+++ b/src/adapter/inbound.ts
@@ -201,30 +201,52 @@ async function buildBinaryFileText(
 // Permissions: 0o600 on the file and 0o700 on the inbox dir so that on
 // multi-user POSIX systems received files (which often contain personal
 // info: IDs, contracts, photos…) aren't readable by other local users.
-// Ignored by Windows but harmless there.
+// We apply both via the {mode} option AND an explicit chmod after the
+// op, because:
+//   - mkdir's {mode} is only applied to dirs we *create*; if the inbox
+//     dir already exists with looser perms (e.g. from a previous bridge
+//     version, or a hand-created dir), {mode} silently does nothing.
+//   - writeFile's {mode} is subject to the process umask: in practice
+//     umask can only *remove* bits, so 0o600 → at most 0o600, which is
+//     fine for confidentiality — the explicit chmod is just belt-and-
+//     braces against a future change that uses a less minimal mode.
+// Both chmods are best-effort: failures (e.g. on Windows where chmod
+// is largely a no-op, or on a network mount with restricted perms)
+// don't block the save itself.
 const INBOX_DIR_MODE = 0o700;
 const INBOX_FILE_MODE = 0o600;
-// Safety cap on the EEXIST retry loop. Each retry uses a new millisecond
-// timestamp, so colliding past this count is essentially impossible — the
-// cap is just a belt-and-braces guard against an unforeseen infinite loop.
+// Safety cap on the EEXIST retry loop. With a deterministic numeric
+// suffix per attempt, true collision past this count is essentially
+// impossible; the cap exists only to bound a pathological hot loop.
 const INBOX_MAX_COLLISION_RETRIES = 100;
 
 /**
  * Write `buffer` into `inboxDir` and return the absolute path.
  *
- * Filename convention: `${ISO-timestamp}-${safeName}`, where
- *   - the timestamp uses ISO 8601 with colons replaced by dashes so the
- *     name is valid on Windows/macOS/Linux,
- *   - `safeName` replaces filesystem-unsafe characters (`/`, `\`, ASCII
- *     control chars, leading dots) with `_`, while preserving Unicode
- *     (so Chinese filenames stay readable),
+ * Filename convention: `${ISO-timestamp}-${safeName}` for the first
+ * attempt, `${ISO-timestamp}-${N}-${safeName}` on the Nth retry, where
+ *   - the timestamp uses ISO 8601 with colons and dots replaced by
+ *     dashes (so the name avoids characters reserved on Windows),
+ *   - `safeName` is `fileName` with path separators stripped, ASCII
+ *     control + Windows-reserved chars (`<>:"/\|?*`) replaced by `_`,
+ *     leading dots and trailing dots/spaces (which Windows silently
+ *     trims) normalized to `_`, while Unicode is preserved so Chinese
+ *     filenames stay readable,
  *   - if the sanitized name is empty, it falls back to `"file"`.
  *
- * Writes use the `wx` flag (fail-if-exists) so a same-millisecond
- * collision — e.g. two bridge instances writing into a shared inbox, or
- * a user re-sending the same file twice in quick succession — never
- * silently overwrites an existing file. On `EEXIST` we re-stamp and
- * retry with a fresh timestamp.
+ * Writes use the `wx` flag (fail-if-exists) so a collision — two
+ * bridge instances sharing an inbox, the user re-sending the same
+ * file twice in quick succession, a stubbed/frozen clock — never
+ * silently overwrites an existing file. On `EEXIST` we keep the
+ * original timestamp and bump a deterministic numeric suffix
+ * (`-1-`, `-2-`, …) capped at `INBOX_MAX_COLLISION_RETRIES`.
+ *
+ * Reserved-name corner case (Windows `CON`, `PRN`, `NUL`, `COM1`, …):
+ * Windows matches reserved device names against the basename exactly
+ * (case-insensitive, with or without extension). Because we always
+ * prefix the saved name with a timestamp like `2026-05-21T...Z-`,
+ * the basename is never one of those reserved tokens, so no extra
+ * handling is needed here.
  */
 export async function saveToInbox(
   buffer: Buffer,
@@ -232,24 +254,31 @@ export async function saveToInbox(
   inboxDir: string,
 ): Promise<string> {
   await fsp.mkdir(inboxDir, { recursive: true, mode: INBOX_DIR_MODE });
+  // Best-effort chmod the dir in case it pre-existed with looser
+  // permissions — mkdir's {mode} only applies to dirs we just created.
+  await fsp.chmod(inboxDir, INBOX_DIR_MODE).catch(() => {});
+
   const safeBase = sanitizeFilename(fileName);
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
 
   for (let attempt = 0; attempt < INBOX_MAX_COLLISION_RETRIES; attempt++) {
     // attempt 0 → "stamp-name"; subsequent retries → "stamp-N-name".
-    // Putting the counter ahead of the user-supplied name keeps the file
-    // extension at the tail (so OS open-by-extension still works) and
-    // guarantees a fresh path even when the wall clock hasn't ticked
-    // between retries (super-fast disk, stubbed time, etc.).
+    // Putting the counter ahead of the user-supplied name keeps the
+    // file extension at the tail (so OS open-by-extension still works)
+    // and guarantees a fresh path even when the wall clock hasn't
+    // ticked between retries (super-fast disk, stubbed time, etc.).
     const suffix = attempt === 0 ? "" : `-${attempt}`;
     const target = path.resolve(inboxDir, `${stamp}${suffix}-${safeBase}`);
     try {
       await fsp.writeFile(target, buffer, { flag: "wx", mode: INBOX_FILE_MODE });
+      // Best-effort chmod the file too — belt-and-braces against
+      // a future change to a less minimal {mode} above.
+      await fsp.chmod(target, INBOX_FILE_MODE).catch(() => {});
       return target;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
-      // Yield to the event loop between retries so we don't starve the
-      // bridge's poll loop on a pathological hot loop.
+      // Yield to the event loop between retries so we don't starve
+      // the bridge's poll loop on a pathological hot loop.
       await new Promise<void>((resolve) => setImmediate(resolve));
     }
   }
@@ -261,7 +290,14 @@ export async function saveToInbox(
 function sanitizeFilename(name: string): string {
   // Drop any path separators a remote sender might have included.
   const tail = name.split(/[\\/]/).pop() ?? "";
-  // Replace control chars and reserved chars; leave Unicode alone.
-  const cleaned = tail.replace(/[\x00-\x1f<>:"/\\|?*]/g, "_").replace(/^\.+/, "_");
+  // Replace ASCII control chars and Windows-reserved chars. Then:
+  //   - leading dots → `_` (no hidden files / no path-walk-via-dot)
+  //   - trailing dots and spaces → `_` (Windows silently trims them
+  //     when creating files, which would make the path we return to
+  //     the agent differ from the on-disk name).
+  const cleaned = tail
+    .replace(/[\x00-\x1f<>:"/\\|?*]/g, "_")
+    .replace(/^\.+/, "_")
+    .replace(/[. ]+$/, "_");
   return cleaned.length > 0 ? cleaned : "file";
 }

--- a/src/adapter/inbound.ts
+++ b/src/adapter/inbound.ts
@@ -3,6 +3,7 @@
  */
 
 import fs from "node:fs";
+import path from "node:path";
 import type * as acp from "@agentclientprotocol/sdk";
 import type { WeixinMessage, MessageItem } from "../weixin/types.js";
 import { MessageItemType } from "../weixin/types.js";
@@ -55,6 +56,7 @@ export async function weixinMessageToPrompt(
   msg: WeixinMessage,
   cdnBaseUrl: string,
   log: (msg: string) => void,
+  inboxDir?: string | null,
 ): Promise<acp.ContentBlock[]> {
   const blocks: acp.ContentBlock[] = [];
 
@@ -68,7 +70,7 @@ export async function weixinMessageToPrompt(
   const mediaItem = findMediaItem(msg.item_list);
   if (mediaItem) {
     try {
-      const attached = await convertMediaItem(mediaItem, cdnBaseUrl, log);
+      const attached = await convertMediaItem(mediaItem, cdnBaseUrl, log, inboxDir ?? null);
       if (attached) blocks.push(attached);
     } catch (err) {
       log(`Media download failed, skipping: ${String(err)}`);
@@ -94,6 +96,7 @@ async function convertMediaItem(
   item: MessageItem,
   cdnBaseUrl: string,
   log: (msg: string) => void,
+  inboxDir: string | null,
 ): Promise<acp.ContentBlock | null> {
   if (item.type === MessageItemType.IMAGE && item.image_item?.media) {
     const media = item.image_item.media;
@@ -133,7 +136,7 @@ async function convertMediaItem(
       } as acp.ContentBlock;
     }
 
-    return { type: "text", text: `[Received file: ${fileName}, ${buffer.length} bytes]` };
+    return { type: "text", text: buildBinaryFileText(fileName, buffer, inboxDir, log) };
   }
 
   if (item.type === MessageItemType.VOICE && item.voice_item?.media) {
@@ -167,4 +170,62 @@ function guessMimeType(name: string): string {
     yaml: "text/yaml", yml: "text/yaml", csv: "text/csv",
   };
   return map[ext] ?? "text/plain";
+}
+
+/**
+ * Build the text block describing a received binary file.
+ *
+ * When `inboxDir` is set, the buffer is persisted to disk so the agent
+ * can read it by path. On any save failure we silently fall back to the
+ * legacy size-only notice (with a log line for diagnostics) — the agent
+ * still gets *something* and the message poll loop is not blocked.
+ */
+function buildBinaryFileText(
+  fileName: string,
+  buffer: Buffer,
+  inboxDir: string | null,
+  log: (msg: string) => void,
+): string {
+  if (!inboxDir) {
+    return `[Received file: ${fileName}, ${buffer.length} bytes]`;
+  }
+  try {
+    const savedPath = saveToInbox(buffer, fileName, inboxDir);
+    return `[Received file: ${fileName} (${buffer.length} bytes) \u2014 saved to: ${savedPath}]`;
+  } catch (err) {
+    log(`Failed to save received file "${fileName}" to inbox: ${String(err)}`);
+    return `[Received file: ${fileName}, ${buffer.length} bytes]`;
+  }
+}
+
+/**
+ * Write `buffer` into `inboxDir` and return the absolute path.
+ *
+ * Filename convention: `${ISO-timestamp}-${safeName}`, where
+ *   - the timestamp uses ISO 8601 with colons replaced by dashes so the
+ *     name is valid on Windows/macOS/Linux,
+ *   - `safeName` replaces filesystem-unsafe characters (`/`, `\`, ASCII
+ *     control chars, leading dots) with `_`, while preserving Unicode
+ *     (so Chinese filenames stay readable),
+ *   - if the sanitized name is empty, it falls back to `"file"`.
+ */
+export function saveToInbox(
+  buffer: Buffer,
+  fileName: string,
+  inboxDir: string,
+): string {
+  fs.mkdirSync(inboxDir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const safeBase = sanitizeFilename(fileName);
+  const target = path.resolve(inboxDir, `${stamp}-${safeBase}`);
+  fs.writeFileSync(target, buffer);
+  return target;
+}
+
+function sanitizeFilename(name: string): string {
+  // Drop any path separators a remote sender might have included.
+  const tail = name.split(/[\\/]/).pop() ?? "";
+  // Replace control chars and reserved chars; leave Unicode alone.
+  const cleaned = tail.replace(/[\x00-\x1f<>:"/\\|?*]/g, "_").replace(/^\.+/, "_");
+  return cleaned.length > 0 ? cleaned : "file";
 }

--- a/src/adapter/inbound.ts
+++ b/src/adapter/inbound.ts
@@ -2,7 +2,7 @@
  * Inbound adapter: convert WeChat messages to ACP ContentBlock[].
  */
 
-import fs from "node:fs";
+import fsp from "node:fs/promises";
 import path from "node:path";
 import type * as acp from "@agentclientprotocol/sdk";
 import type { WeixinMessage, MessageItem } from "../weixin/types.js";
@@ -136,7 +136,7 @@ async function convertMediaItem(
       } as acp.ContentBlock;
     }
 
-    return { type: "text", text: buildBinaryFileText(fileName, buffer, inboxDir, log) };
+    return { type: "text", text: await buildBinaryFileText(fileName, buffer, inboxDir, log) };
   }
 
   if (item.type === MessageItemType.VOICE && item.voice_item?.media) {
@@ -180,23 +180,34 @@ function guessMimeType(name: string): string {
  * legacy size-only notice (with a log line for diagnostics) — the agent
  * still gets *something* and the message poll loop is not blocked.
  */
-function buildBinaryFileText(
+async function buildBinaryFileText(
   fileName: string,
   buffer: Buffer,
   inboxDir: string | null,
   log: (msg: string) => void,
-): string {
+): Promise<string> {
   if (!inboxDir) {
     return `[Received file: ${fileName}, ${buffer.length} bytes]`;
   }
   try {
-    const savedPath = saveToInbox(buffer, fileName, inboxDir);
+    const savedPath = await saveToInbox(buffer, fileName, inboxDir);
     return `[Received file: ${fileName} (${buffer.length} bytes) \u2014 saved to: ${savedPath}]`;
   } catch (err) {
     log(`Failed to save received file "${fileName}" to inbox: ${String(err)}`);
     return `[Received file: ${fileName}, ${buffer.length} bytes]`;
   }
 }
+
+// Permissions: 0o600 on the file and 0o700 on the inbox dir so that on
+// multi-user POSIX systems received files (which often contain personal
+// info: IDs, contracts, photos…) aren't readable by other local users.
+// Ignored by Windows but harmless there.
+const INBOX_DIR_MODE = 0o700;
+const INBOX_FILE_MODE = 0o600;
+// Safety cap on the EEXIST retry loop. Each retry uses a new millisecond
+// timestamp, so colliding past this count is essentially impossible — the
+// cap is just a belt-and-braces guard against an unforeseen infinite loop.
+const INBOX_MAX_COLLISION_RETRIES = 100;
 
 /**
  * Write `buffer` into `inboxDir` and return the absolute path.
@@ -208,18 +219,43 @@ function buildBinaryFileText(
  *     control chars, leading dots) with `_`, while preserving Unicode
  *     (so Chinese filenames stay readable),
  *   - if the sanitized name is empty, it falls back to `"file"`.
+ *
+ * Writes use the `wx` flag (fail-if-exists) so a same-millisecond
+ * collision — e.g. two bridge instances writing into a shared inbox, or
+ * a user re-sending the same file twice in quick succession — never
+ * silently overwrites an existing file. On `EEXIST` we re-stamp and
+ * retry with a fresh timestamp.
  */
-export function saveToInbox(
+export async function saveToInbox(
   buffer: Buffer,
   fileName: string,
   inboxDir: string,
-): string {
-  fs.mkdirSync(inboxDir, { recursive: true });
-  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+): Promise<string> {
+  await fsp.mkdir(inboxDir, { recursive: true, mode: INBOX_DIR_MODE });
   const safeBase = sanitizeFilename(fileName);
-  const target = path.resolve(inboxDir, `${stamp}-${safeBase}`);
-  fs.writeFileSync(target, buffer);
-  return target;
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+
+  for (let attempt = 0; attempt < INBOX_MAX_COLLISION_RETRIES; attempt++) {
+    // attempt 0 → "stamp-name"; subsequent retries → "stamp-N-name".
+    // Putting the counter ahead of the user-supplied name keeps the file
+    // extension at the tail (so OS open-by-extension still works) and
+    // guarantees a fresh path even when the wall clock hasn't ticked
+    // between retries (super-fast disk, stubbed time, etc.).
+    const suffix = attempt === 0 ? "" : `-${attempt}`;
+    const target = path.resolve(inboxDir, `${stamp}${suffix}-${safeBase}`);
+    try {
+      await fsp.writeFile(target, buffer, { flag: "wx", mode: INBOX_FILE_MODE });
+      return target;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      // Yield to the event loop between retries so we don't starve the
+      // bridge's poll loop on a pathological hot loop.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+  }
+  throw new Error(
+    `saveToInbox: exhausted ${INBOX_MAX_COLLISION_RETRIES} collision retries for ${safeBase}`,
+  );
 }
 
 function sanitizeFilename(name: string): string {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -144,6 +144,7 @@ export class WeChatAcpBridge {
       msg,
       this.config.wechat.cdnBaseUrl,
       this.log,
+      this.config.storage.inboxDir,
     );
 
     await this.sessionManager!.enqueue(userId, { prompt, contextToken });

--- a/src/config.ts
+++ b/src/config.ts
@@ -88,6 +88,15 @@ export interface WeChatAcpConfig {
   storage: {
     dir: string;
     instance?: string;
+    /**
+     * Directory where incoming binary files received from WeChat are
+     * persisted so the agent can read them by path. Set to `null` to
+     * disable saving (matches pre-0.3 behavior, where the file buffer
+     * was dropped after download). Unset (`undefined`) is treated the
+     * same as `null` by the bridge so existing library users that
+     * construct `WeChatAcpConfig` without this field keep working.
+     */
+    inboxDir?: string | null;
   };
 }
 
@@ -145,6 +154,7 @@ export function defaultConfig(opts?: { instance?: string }): WeChatAcpConfig {
     storage: {
       dir: storageDir,
       instance,
+      inboxDir: path.join(storageDir, "inbox"),
     },
   };
 }


### PR DESCRIPTION
Closes part of #9 (binary file receiving).

## What's wrong today

When a WeChat user sends a binary file (PDF, ZIP, photo exported as a file, recording exported as a file…), [`src/adapter/inbound.ts`](https://github.com/formulahendry/wechat-acp/blob/main/src/adapter/inbound.ts#L136) downloads & decrypts it from the WeChat CDN — and then **drops the buffer on the floor**, sending only this to the agent:

```
[Received file: foo.pdf, 484067 bytes]
```

The agent has no path, no bytes, no handle. End-to-end, sending a file to the bot is a no-op for any non-text agent today.

(Text-typed files like `.md` / `.json` / source code, and images, are already inlined as `resource` / `image` blocks — they work. This PR only fixes the lossy binary path.)

## What this PR does

Adds a per-bridge **inbox directory**. By default `<storage.dir>/inbox`, so:

- `~/.wechat-acp/inbox/` for the normal case
- `~/.wechat-acp/instances/<name>/inbox/` automatically when `--instance` is used (free, since we derive from `storage.dir`)

Received binary files are written as `<ISO-timestamp>-<safe-filename>` and the prompt the agent receives becomes:

```
[Received file: foo.pdf (484067 bytes) — saved to: /Users/me/.wechat-acp/inbox/2026-05-21T09-29-12-492Z-foo.pdf]
```

so any ACP agent that can read local files (Copilot CLI, Claude Code, Codex, …) can just open the path with its normal `read_file` / `Read` tool.

## Why default-on

The current behavior is functionally broken for binary files — the data is dropped silently. Making the save default-on:

- closes the gap for new users without any flag-fiddling
- costs nothing extra (the buffer is already downloaded and decrypted)
- is easy to opt out of (`--no-inbox` or `storage.inboxDir: null`)
- lives under the same `storage.dir` the user already accepted when they installed, so there's no surprising new path

If you'd rather keep this opt-in, very happy to flip the default — see "open questions" below.

## API surface

- New CLI flags:
  - `--inbox-dir <path>` — relocate the inbox (resolved to absolute)
  - `--no-inbox` — disable saving; revert to legacy `[Received file: name, N bytes]` notice
- New optional config field: `storage.inboxDir?: string | null` (kept optional so existing programmatic `WeChatAcpConfig` constructors don't break their types)
- New helper exported from `src/adapter/inbound.ts`: `saveToInbox(buffer, fileName, inboxDir)` — also used as a testing seam

`--instance` precedence is preserved: when `--instance projA` is passed, the inbox defaults to `~/.wechat-acp/instances/projA/inbox`; a later `--inbox-dir` / `--no-inbox` still wins. `--no-inbox` wins over `--inbox-dir` if a user passes both (explicit-disable beats explicit-set).

## Filename safety

- Path separators in the sender-supplied filename are stripped (`name.split(/[\\/]/).pop()`), so a remote `../../etc/passwd` can't escape the inbox.
- Filesystem-reserved chars (`<>:"/\\|?*` + ASCII control chars) are replaced with `_` to stay Windows-safe.
- Leading dots are replaced with `_` (no accidental hidden files / no path-walk-via-dot).
- Unicode is **preserved** — Chinese filenames remain readable, which is the whole point in a WeChat tool.
- Empty after sanitization → falls back to `"file"`.

## Failure mode

If the disk write fails (full disk, perms, race), the bridge logs a single warning line and falls back to the legacy size-only notice. The poll loop is never blocked by a save error.

## What is NOT in scope

- Voice and video downloads — currently the bridge doesn't download these at all when there's no transcription. Saving them would be valuable but it's a separate change (would need to fetch the CDN media first). Happy to follow up.
- Image saving — images already round-trip fine via base64 inline. I considered also writing them to the inbox (handy if you want to grep your inbox folder later), but it doubles bandwidth for a marginal win. Left out to keep the diff focused.
- Cleanup policy — files in the inbox persist until the user deletes them. Agents may reference saved paths long after the WeChat message arrived, so auto-pruning would be risky. README documents a `find … -mtime` one-liner.

## Verification

- `npm run build` clean
- `node dist/bin/wechat-acp.js --help` shows the new flags
- Smoke test (see commit / can paste here):
  - `saveToInbox(..., "../../etc/passwd:bad*name?.pdf", tmp)` → result is inside `tmp`, name is `..._passwd_bad_name_.pdf`
  - `saveToInbox(..., "空调格栅现场平视图.pdf", tmp)` → Unicode preserved
  - `weixinMessageToPrompt` on a text-only message → identical output with or without `inboxDir` (backward compat)
- Real end-to-end on macOS with `--agent copilot`: sending a 484 KB PDF through WeChat now lands in `~/.wechat-acp/inbox/` and Copilot CLI is able to open + analyze it.

## Open questions for the maintainer

1. **Default-on or default-off?** I argued default-on above; happy to flip to opt-in if you'd rather treat this as a new capability rather than a bug-fix. Trivial change.
2. **`--no-inbox` vs `--inbox-dir ""`?** I went with the explicit `--no-inbox` flag because empty-string-means-disable is a footgun. Easy to drop one or rename.
3. **Filename prefix.** Currently `${new Date().toISOString().replace(/[:.]/g, "-")}-${name}` → `2026-05-21T09-29-12-492Z-foo.pdf`. Good for sortability and uniqueness within a millisecond; doesn't help against same-millisecond collisions (which would be exotic — single-threaded poll loop and only one media item per message). If you'd prefer a per-message hash or a sender-id prefix, let me know.
4. **`storage.inboxDir` typed as `string | null`** instead of `string | undefined`. I picked `null` so users can express "disable" in a JSON config file (`{ "storage": { "inboxDir": null } }`); `undefined` would require deleting the key. Both unset and `null` are treated as "off" by the bridge.

Drafting because items 1 and 4 are policy calls more than implementation calls.
