### PR TITLE
Add local message injection queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,16 +303,17 @@ npm run dev
 WECHAT_ACP_TELEMETRY=0 npx wechat-acp --agent copilot
 ```
 
-**What is collected** (9 event types only):
+**What is collected** (10 event types only):
 
 - `app.start` / `app.stop` — process lifecycle, agent preset name, daemon flag, uptime
 - `login.success` / `login.failure` / `token.reused` — WeChat login outcomes (no token, no QR URL)
 - `message.received` — message arrived; only the categorical kind (`text` / `image` / `voice` / `file` / `video` / `empty`) and a hashed user id
+- `message.injected` — local injection queued for processing; only target kind (`last-active-user` / `explicit`) and a hashed user id
 - `session.created` — new ACP session opened
 - `prompt.completed` — ACP turn finished; agent preset, stop reason, duration, reply length
 - `reply.sent` — reply pushed back to WeChat; segment count, total length
 
-Plus exception reports for `monitor`, `prompt`, `reply`, `auth`, `agent_spawn`, and `enqueue` failures.
+Plus exception reports for `monitor`, `prompt`, `reply`, `auth`, `agent_spawn`, `enqueue`, and `state` failures.
 
 **What is never collected**: message bodies, filenames, voice transcripts, image URLs, login tokens, QR codes, raw agent command strings, environment variables, working directory paths, raw WeChat user IDs.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ These presets resolve to concrete `command + args` pairs internally, so users do
 ```text
 wechat-acp --agent <preset|command> [options]
 wechat-acp agents
+wechat-acp inject --text <text>
 wechat-acp stop
 wechat-acp status
 ```
@@ -87,6 +88,7 @@ Options:
 - `--no-inbox`: do not save received files; the agent only sees a size notice.
 - `--hide-thoughts`: do not forward agent thinking to WeChat (default: forwarded)
 - `--hide-diffs`: do not forward ACP file diffs to WeChat (default: forwarded)
+- `inject --text <text>`: enqueue a local text message for the running daemon
 - `-V, --version`: print version and exit
 - `-h, --help`: show help
 
@@ -170,6 +172,54 @@ You can also override or add agent presets:
 - Typing indicators are sent when supported by the WeChat API.
 - Sessions are cleaned up after inactivity (set `idleTimeoutMs` to `0` to disable idle cleanup).
 
+## Injecting messages locally
+
+`wechat-acp inject` lets local automation enqueue a text message for the running daemon. The daemon treats it like an incoming direct message from the target user, sends it to the configured ACP agent, and replies through WeChat.
+
+This is useful for cron or launchd jobs, for example a daily AI news prompt:
+
+```bash
+npx wechat-acp inject --instance main --text "今日 AI 资讯"
+```
+
+Targets:
+
+- Default target: `last-active-user`
+- Custom target: `--to <wechat-user-id>`
+
+The daemon learns `last-active-user` from real incoming WeChat messages and stores the latest `userId + contextToken` under the instance storage directory. If no user has messaged the bot yet, ask the target user to send any message once, then retry the injection.
+
+Injected messages are stored as JSON files under:
+
+```text
+~/.wechat-acp/inject/
+~/.wechat-acp/instances/<name>/inject/
+```
+
+The queue is file-based:
+
+```text
+inject/
+├── pending/
+├── processing/
+├── done/
+└── failed/
+```
+
+`inject` only writes to `pending/`; the daemon moves files through the other directories as it processes them. If the daemon is not running, the message remains queued and will be processed after the daemon starts.
+
+For longer prompts, use a file:
+
+```bash
+npx wechat-acp inject --instance main --file ./prompt.txt
+```
+
+Example Linux cron entry:
+
+```cron
+0 7 * * * /usr/local/bin/wechat-acp inject --instance main --text "今日 AI 资讯"
+```
+
 ## Receiving files
 
 When a WeChat user sends a binary file (PDF, image, audio recording exported as a file, ZIP, etc.), `wechat-acp` downloads and decrypts it from the WeChat CDN, then **saves it to disk** so the ACP agent can read it by absolute path. The agent receives a text block like:
@@ -209,6 +259,8 @@ This directory is used for:
 - sync state
 - anonymous telemetry install id (`telemetry-id`, see Telemetry section)
 - `inbox/` — binary files received from WeChat (see "Receiving files"); disable with `--no-inbox` or relocate with `--inbox-dir`
+- `state.json` — last active user and context token for local injection
+- `inject/` — local injected message queue
 
 When `--instance <name>` is used, the same files live under `~/.wechat-acp/instances/<name>/` instead, fully isolated from other instances.
 

--- a/bin/wechat-acp.ts
+++ b/bin/wechat-acp.ts
@@ -111,24 +111,10 @@ async function handleInject(
     contextToken: args.injectContextToken,
   });
 
-  const pidFile = config.daemon.pidFile;
-  let daemonRunning = false;
-  if (fs.existsSync(pidFile)) {
-    const pid = parseInt(fs.readFileSync(pidFile, "utf-8").trim(), 10);
-    try {
-      process.kill(pid, 0);
-      daemonRunning = true;
-    } catch {
-      daemonRunning = false;
-    }
-  }
-
   console.log(`Queued injection ${job.id}`);
   console.log(`Target: ${job.target}`);
   console.log(`File: ${filePath}`);
-  if (!daemonRunning) {
-    console.log("Daemon does not appear to be running; the message will be processed after it starts.");
-  }
+  console.log("It will be processed by any running wechat-acp instance using the same storage directory.");
 }
 
 function parseArgs(argv: string[]): {

--- a/bin/wechat-acp.ts
+++ b/bin/wechat-acp.ts
@@ -10,6 +10,7 @@
  *   wechat-acp --agent "claude code" --daemon
  *   wechat-acp stop
  *   wechat-acp status
+ *   wechat-acp inject --text "今日 AI 资讯"
  */
 
 import fs from "node:fs";
@@ -25,6 +26,8 @@ import {
   validateInstanceName,
 } from "../src/config.js";
 import type { WeChatAcpConfig } from "../src/config.js";
+import { queueInjectedMessage } from "../src/inject/queue.js";
+import { DEFAULT_INJECTION_TARGET } from "../src/inject/types.js";
 import {
   initTelemetry,
   trackEvent,
@@ -44,6 +47,7 @@ wechat-acp v${packageJson.version} — Bridge WeChat to any ACP-compatible AI ag
 Usage:
   wechat-acp --agent <preset|command>  [options]
   wechat-acp agents                        List built-in agent presets
+  wechat-acp inject --text <text>          Inject a local message into the daemon
   wechat-acp stop                          Stop a running daemon
   wechat-acp status                        Check daemon status
 
@@ -72,10 +76,59 @@ Options:
   --max-sessions <n>  Max concurrent user sessions (default: 10)
   --hide-thoughts     Do not forward agent thinking to WeChat (default: forwarded)
   --hide-diffs        Do not forward ACP file diffs to WeChat (default: forwarded)
+  --text <text>       Message text for "inject"
+  --file <path>       Read injected message text from a file
+  --to <target>       Injection target (default: ${DEFAULT_INJECTION_TARGET})
+  --context-token <t> Override stored context token for "inject"
   -v, --verbose       Verbose logging
   -V, --version       Print version and exit
   -h, --help          Show this help
 `);
+}
+
+async function handleInject(
+  config: WeChatAcpConfig,
+  args: ReturnType<typeof parseArgs>,
+): Promise<void> {
+  if (!config.storage.injectDir) {
+    throw new Error("storage.injectDir is not configured");
+  }
+  if (!args.injectText && !args.injectFile) {
+    throw new Error('inject requires --text <text> or --file <path>');
+  }
+  if (args.injectText && args.injectFile) {
+    throw new Error("inject accepts only one of --text or --file");
+  }
+
+  const text = args.injectFile
+    ? fs.readFileSync(path.resolve(args.injectFile), "utf-8")
+    : args.injectText!;
+
+  const { job, filePath } = await queueInjectedMessage({
+    injectDir: config.storage.injectDir,
+    text,
+    target: args.injectTo,
+    contextToken: args.injectContextToken,
+  });
+
+  const pidFile = config.daemon.pidFile;
+  let daemonRunning = false;
+  if (fs.existsSync(pidFile)) {
+    const pid = parseInt(fs.readFileSync(pidFile, "utf-8").trim(), 10);
+    try {
+      process.kill(pid, 0);
+      daemonRunning = true;
+    } catch {
+      daemonRunning = false;
+    }
+  }
+
+  console.log(`Queued injection ${job.id}`);
+  console.log(`Target: ${job.target}`);
+  console.log(`File: ${filePath}`);
+  if (!daemonRunning) {
+    console.log("Daemon does not appear to be running; the message will be processed after it starts.");
+  }
 }
 
 function parseArgs(argv: string[]): {
@@ -90,6 +143,10 @@ function parseArgs(argv: string[]): {
   disableInbox: boolean;
   idleTimeout?: number;
   maxSessions?: number;
+  injectText?: string;
+  injectFile?: string;
+  injectTo?: string;
+  injectContextToken?: string;
   hideThoughts: boolean;
   hideDiffs: boolean;
   verbose: boolean;
@@ -148,6 +205,18 @@ function parseArgs(argv: string[]): {
         break;
       case "--max-sessions":
         result.maxSessions = parseInt(args[++i], 10);
+        break;
+      case "--text":
+        result.injectText = args[++i];
+        break;
+      case "--file":
+        result.injectFile = args[++i];
+        break;
+      case "--to":
+        result.injectTo = args[++i];
+        break;
+      case "--context-token":
+        result.injectContextToken = args[++i];
         break;
       case "--hide-thoughts":
         result.hideThoughts = true;
@@ -293,6 +362,8 @@ async function main(): Promise<void> {
 
   // Load config file if specified
   let configFileSetInboxDir = false;
+  let configFileSetStateFile = false;
+  let configFileSetInjectDir = false;
   if (args.configFile) {
     const fileConfig = loadConfigFile(args.configFile);
     Object.assign(config.wechat, fileConfig.wechat ?? {});
@@ -309,6 +380,18 @@ async function main(): Promise<void> {
       Object.prototype.hasOwnProperty.call(fileConfig.storage, "inboxDir")
     ) {
       configFileSetInboxDir = true;
+    }
+    if (
+      fileConfig.storage &&
+      Object.prototype.hasOwnProperty.call(fileConfig.storage, "stateFile")
+    ) {
+      configFileSetStateFile = true;
+    }
+    if (
+      fileConfig.storage &&
+      Object.prototype.hasOwnProperty.call(fileConfig.storage, "injectDir")
+    ) {
+      configFileSetInjectDir = true;
     }
     Object.assign(config.storage, fileConfig.storage ?? {});
   }
@@ -344,9 +427,29 @@ async function main(): Promise<void> {
     config.storage.inboxDir = path.join(config.storage.dir, "inbox");
   }
 
+  if (configFileSetStateFile) {
+    if (config.storage.stateFile && !path.isAbsolute(config.storage.stateFile)) {
+      config.storage.stateFile = path.resolve(config.storage.stateFile);
+    }
+  } else {
+    config.storage.stateFile = path.join(config.storage.dir, "state.json");
+  }
+
+  if (configFileSetInjectDir) {
+    if (config.storage.injectDir && !path.isAbsolute(config.storage.injectDir)) {
+      config.storage.injectDir = path.resolve(config.storage.injectDir);
+    }
+  } else {
+    config.storage.injectDir = path.join(config.storage.dir, "inject");
+  }
+
   // Handle subcommands
   if (args.command === "agents") {
     handleAgents(config);
+    return;
+  }
+  if (args.command === "inject") {
+    await handleInject(config, args);
     return;
   }
   if (args.command === "stop") {

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -14,6 +14,10 @@ import { trackEvent, trackException, hashUserId } from "../telemetry/index.js";
 export interface PendingMessage {
   prompt: acp.ContentBlock[];
   contextToken: string;
+  completion?: {
+    resolve: () => void;
+    reject: (err: unknown) => void;
+  };
 }
 
 export interface UserSession {
@@ -99,6 +103,18 @@ export class SessionManager {
     }
   }
 
+  async enqueueAndWait(
+    userId: string,
+    message: Omit<PendingMessage, "completion">,
+  ): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.enqueue(userId, {
+        ...message,
+        completion: { resolve, reject },
+      }).catch(reject);
+    });
+  }
+
   getSession(userId: string): UserSession | undefined {
     return this.sessions.get(userId);
   }
@@ -159,6 +175,7 @@ export class SessionManager {
   }
 
   private async processQueue(session: UserSession): Promise<void> {
+    let completionError: unknown;
     try {
       while (session.queue.length > 0 && !this.aborted) {
         const pending = session.queue.shift()!;
@@ -213,6 +230,7 @@ export class SessionManager {
             await this.opts.onReply(session.userId, pending.contextToken, replyText);
           }
         } catch (err) {
+          completionError = err;
           this.opts.log(`[${session.userId}] Agent prompt error: ${String(err)}`);
 
           trackException(err, "prompt", hashUserId(session.userId));
@@ -233,6 +251,7 @@ export class SessionManager {
           if (session.agentInfo.process.killed || session.agentInfo.process.exitCode !== null) {
             this.opts.log(`[${session.userId}] Agent process died, removing session`);
             this.sessions.delete(session.userId);
+            pending.completion?.reject(err);
             return;
           }
 
@@ -245,6 +264,14 @@ export class SessionManager {
             );
           } catch {
             // best effort
+          }
+        } finally {
+          if (pending.completion) {
+            if (completionError) {
+              pending.completion.reject(completionError);
+            } else {
+              pending.completion.resolve();
+            }
           }
         }
       }

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -175,10 +175,10 @@ export class SessionManager {
   }
 
   private async processQueue(session: UserSession): Promise<void> {
-    let completionError: unknown;
     try {
       while (session.queue.length > 0 && !this.aborted) {
         const pending = session.queue.shift()!;
+        let completionError: unknown;
 
         // Keep the ACP client instance stable because the connection is bound to it.
         session.client.updateCallbacks({
@@ -251,7 +251,6 @@ export class SessionManager {
           if (session.agentInfo.process.killed || session.agentInfo.process.exitCode !== null) {
             this.opts.log(`[${session.userId}] Agent process died, removing session`);
             this.sessions.delete(session.userId);
-            pending.completion?.reject(err);
             return;
           }
 

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -78,6 +78,10 @@ export class SessionManager {
   }
 
   async enqueue(userId: string, message: PendingMessage): Promise<void> {
+    if (this.aborted) {
+      throw new Error("Session manager is stopped");
+    }
+
     let session = this.sessions.get(userId);
 
     if (!session) {

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -252,6 +252,7 @@ export class SessionManager {
           // Check if agent died
           if (session.agentInfo.process.killed || session.agentInfo.process.exitCode !== null) {
             this.opts.log(`[${session.userId}] Agent process died, removing session`);
+            this.rejectQueuedCompletions(session, err);
             this.sessions.delete(session.userId);
             return;
           }

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -71,6 +71,7 @@ export class SessionManager {
     // Kill all agent processes
     for (const [userId, session] of this.sessions) {
       this.opts.log(`Stopping session for ${userId}`);
+      this.rejectQueuedCompletions(session, new Error("Session stopped before queued message was processed"));
       killAgent(session.agentInfo.process);
     }
     this.sessions.clear();
@@ -158,6 +159,7 @@ export class SessionManager {
       const s = this.sessions.get(userId);
       if (s && s.agentInfo.process === agentInfo.process) {
         this.opts.log(`Agent process for ${userId} exited, removing session`);
+        this.rejectQueuedCompletions(s, new Error("Agent process exited before queued message was processed"));
         this.sessions.delete(userId);
       }
     });
@@ -304,8 +306,17 @@ export class SessionManager {
     if (oldest) {
       this.opts.log(`Evicting oldest idle session: ${oldest.userId}`);
       const session = this.sessions.get(oldest.userId);
-      if (session) killAgent(session.agentInfo.process);
-      this.sessions.delete(oldest.userId);
+      if (session) {
+        this.rejectQueuedCompletions(session, new Error("Session evicted before queued message was processed"));
+        killAgent(session.agentInfo.process);
+        this.sessions.delete(oldest.userId);
+      }
+    }
+  }
+
+  private rejectQueuedCompletions(session: UserSession, err: unknown): void {
+    for (const pending of session.queue.splice(0)) {
+      pending.completion?.reject(err);
     }
   }
 }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -5,6 +5,7 @@
  * One bridge = one WeChat bot account → many users → many agent sessions.
  */
 
+import type * as acp from "@agentclientprotocol/sdk";
 import { login, loadToken, type TokenData } from "./weixin/auth.js";
 import { startMonitor } from "./weixin/monitor.js";
 import { sendTextMessage, splitText } from "./weixin/send.js";
@@ -15,6 +16,9 @@ import { SessionManager } from "./acp/session.js";
 import { weixinMessageToPrompt } from "./adapter/inbound.js";
 import { formatForWeChat } from "./adapter/outbound.js";
 import type { WeChatAcpConfig } from "./config.js";
+import { InjectionMonitor } from "./inject/monitor.js";
+import type { InjectedMessage } from "./inject/types.js";
+import { resolveUserTarget, updateLastActiveUser } from "./storage/state.js";
 import { trackEvent, trackException, hashUserId } from "./telemetry/index.js";
 
 const TEXT_CHUNK_LIMIT = 4000;
@@ -23,7 +27,9 @@ export class WeChatAcpBridge {
   private config: WeChatAcpConfig;
   private abortController = new AbortController();
   private sessionManager: SessionManager | null = null;
+  private injectionMonitor: InjectionMonitor | null = null;
   private tokenData: TokenData | null = null;
+  private stateUpdate = Promise.resolve();
   // Per-user typing ticket cache
   private typingTickets = new Map<string, { ticket: string; expiresAt: number }>();
   private log: (msg: string) => void;
@@ -92,6 +98,16 @@ export class WeChatAcpBridge {
     });
     this.sessionManager.start();
 
+    if (this.config.storage.injectDir && this.config.storage.stateFile) {
+      this.injectionMonitor = new InjectionMonitor({
+        injectDir: this.config.storage.injectDir,
+        log: this.log,
+        onMessage: (job) => this.enqueueInjectedMessage(job),
+      });
+      await this.injectionMonitor.start();
+      this.log(`Injection queue: ${this.config.storage.injectDir}`);
+    }
+
     // 3. Start monitor loop
     this.log("Starting message polling...");
     await startMonitor({
@@ -107,6 +123,7 @@ export class WeChatAcpBridge {
   async stop(): Promise<void> {
     this.log("Stopping bridge...");
     this.abortController.abort();
+    this.injectionMonitor?.stop();
     await this.sessionManager?.stop();
     this.log("Bridge stopped");
   }
@@ -123,6 +140,7 @@ export class WeChatAcpBridge {
     if (!userId || !contextToken) return;
 
     this.log(`Message from ${userId}: ${this.previewMessage(msg)}`);
+    this.rememberActiveUser(userId, contextToken);
 
     trackEvent(
       "message.received",
@@ -153,6 +171,39 @@ export class WeChatAcpBridge {
     );
 
     await this.sessionManager!.enqueue(userId, { prompt, contextToken });
+  }
+
+  private async enqueueInjectedMessage(job: InjectedMessage): Promise<void> {
+    if (!this.sessionManager || !this.config.storage.stateFile) {
+      throw new Error("Bridge is not ready to process injected messages");
+    }
+
+    const target = await resolveUserTarget(this.config.storage.stateFile, job.target, job.contextToken);
+    const prompt: acp.ContentBlock[] = [{ type: "text", text: job.text }];
+    this.log(`[inject] enqueue ${job.id} for ${target.userId}`);
+    trackEvent(
+      "message.injected",
+      {
+        userIdHash: hashUserId(target.userId),
+        target: job.target,
+      },
+      hashUserId(target.userId),
+    );
+    await this.sessionManager.enqueueAndWait(target.userId, {
+      prompt,
+      contextToken: target.contextToken,
+    });
+  }
+
+  private rememberActiveUser(userId: string, contextToken: string): void {
+    if (!this.config.storage.stateFile) return;
+    this.stateUpdate = this.stateUpdate
+      .catch(() => {})
+      .then(() => updateLastActiveUser(this.config.storage.stateFile!, userId, contextToken));
+    this.stateUpdate.catch((err) => {
+      this.log(`Failed to persist last active user: ${String(err)}`);
+      trackException(err, "state", hashUserId(userId));
+    });
   }
 
   private async sendReply(userId: string, contextToken: string, text: string): Promise<void> {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -125,6 +125,10 @@ export class WeChatAcpBridge {
     this.abortController.abort();
     this.injectionMonitor?.stop();
     await this.sessionManager?.stop();
+    await this.stateUpdate.catch((err) => {
+      this.log(`Failed to flush state before stop: ${String(err)}`);
+      trackException(err, "state");
+    });
     this.log("Bridge stopped");
   }
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -185,7 +185,7 @@ export class WeChatAcpBridge {
       "message.injected",
       {
         userIdHash: hashUserId(target.userId),
-        target: job.target,
+        targetKind: job.target === "last-active-user" ? "last-active-user" : "explicit",
       },
       hashUserId(target.userId),
     );

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -123,11 +123,11 @@ export class WeChatAcpBridge {
   async stop(): Promise<void> {
     this.log("Stopping bridge...");
     this.abortController.abort();
-    this.injectionMonitor?.stop();
+    await this.injectionMonitor?.stop();
     await this.sessionManager?.stop();
     await this.stateUpdate.catch((err) => {
       this.log(`Failed to flush state before stop: ${String(err)}`);
-      trackException(err, "state");
+      trackException(sanitizeStateError(err), "state");
     });
     this.log("Bridge stopped");
   }
@@ -206,7 +206,7 @@ export class WeChatAcpBridge {
       .then(() => updateLastActiveUser(this.config.storage.stateFile!, userId, contextToken));
     this.stateUpdate.catch((err) => {
       this.log(`Failed to persist last active user: ${String(err)}`);
-      trackException(err, "state", hashUserId(userId));
+      trackException(sanitizeStateError(err), "state", hashUserId(userId));
     });
   }
 
@@ -327,4 +327,14 @@ export class WeChatAcpBridge {
     }
     return "empty";
   }
+}
+
+function sanitizeStateError(err: unknown): Error {
+  const code = typeof err === "object" && err !== null && "code" in err
+    ? String((err as { code?: unknown }).code)
+    : "";
+  const sanitized = new Error(code ? `State persistence failed (${code})` : "State persistence failed");
+  sanitized.name = err instanceof Error ? err.name : "Error";
+  sanitized.stack = undefined;
+  return sanitized;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,6 +89,8 @@ export interface WeChatAcpConfig {
   storage: {
     dir: string;
     instance?: string;
+    stateFile?: string;
+    injectDir?: string;
     /**
      * Directory where incoming binary files received from WeChat are
      * persisted so the agent can read them by path. Set to `null` to
@@ -156,6 +158,8 @@ export function defaultConfig(opts?: { instance?: string }): WeChatAcpConfig {
     storage: {
       dir: storageDir,
       instance,
+      stateFile: path.join(storageDir, "state.json"),
+      injectDir: path.join(storageDir, "inject"),
       inboxDir: path.join(storageDir, "inbox"),
     },
   };

--- a/src/inject/monitor.ts
+++ b/src/inject/monitor.ts
@@ -14,6 +14,7 @@ export interface InjectionMonitorOpts {
 export class InjectionMonitor {
   private timer: ReturnType<typeof setInterval> | null = null;
   private processing = false;
+  private currentProcessing: Promise<void> | null = null;
   private stopped = false;
 
   constructor(private readonly opts: InjectionMonitorOpts) {}
@@ -30,17 +31,32 @@ export class InjectionMonitor {
     this.timer.unref();
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     this.stopped = true;
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
     }
+    await this.currentProcessing;
   }
 
   private async processPending(): Promise<void> {
-    if (this.processing || this.stopped) return;
+    if (this.processing) {
+      await this.currentProcessing;
+      return;
+    }
+    if (this.stopped) return;
     this.processing = true;
+    this.currentProcessing = this.drainPending();
+    try {
+      await this.currentProcessing;
+    } finally {
+      this.processing = false;
+      this.currentProcessing = null;
+    }
+  }
+
+  private async drainPending(): Promise<void> {
     try {
       const pendingDir = this.dir("pending");
       const files = (await fs.readdir(pendingDir).catch((err) => {
@@ -54,8 +70,8 @@ export class InjectionMonitor {
         if (this.stopped) break;
         await this.processFile(file);
       }
-    } finally {
-      this.processing = false;
+    } catch (err) {
+      throw err;
     }
   }
 
@@ -95,7 +111,14 @@ export class InjectionMonitor {
 
   private async readJob(filePath: string): Promise<InjectedMessage> {
     const parsed = JSON.parse(await fs.readFile(filePath, "utf-8")) as Partial<InjectedMessage>;
-    if (!parsed.id || !parsed.createdAt || !parsed.target || !parsed.text || parsed.source !== "cli") {
+    if (
+      typeof parsed.id !== "string" ||
+      typeof parsed.createdAt !== "string" ||
+      typeof parsed.target !== "string" ||
+      typeof parsed.text !== "string" ||
+      parsed.source !== "cli" ||
+      (parsed.contextToken !== undefined && typeof parsed.contextToken !== "string")
+    ) {
       throw new Error(`Invalid injected message file: ${filePath}`);
     }
     return parsed as InjectedMessage;

--- a/src/inject/monitor.ts
+++ b/src/inject/monitor.ts
@@ -102,6 +102,9 @@ export class InjectionMonitor {
   }
 
   private async ensureDirs(): Promise<void> {
+    await fs.mkdir(this.opts.injectDir, { recursive: true, mode: INJECT_DIR_MODE });
+    await fs.chmod(this.opts.injectDir, INJECT_DIR_MODE).catch(() => {});
+
     const dirs = [
       this.dir("pending"),
       this.dir("processing"),

--- a/src/inject/monitor.ts
+++ b/src/inject/monitor.ts
@@ -1,0 +1,139 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { InjectedMessage } from "./types.js";
+
+const POLL_INTERVAL_MS = 2_000;
+const INJECT_DIR_MODE = 0o700;
+
+export interface InjectionMonitorOpts {
+  injectDir: string;
+  log: (msg: string) => void;
+  onMessage: (job: InjectedMessage) => Promise<void>;
+}
+
+export class InjectionMonitor {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private processing = false;
+  private stopped = false;
+
+  constructor(private readonly opts: InjectionMonitorOpts) {}
+
+  async start(): Promise<void> {
+    await this.ensureDirs();
+    await this.recoverProcessing();
+    await this.processPending();
+    this.timer = setInterval(() => {
+      this.processPending().catch((err) => {
+        this.opts.log(`[inject] monitor error: ${String(err)}`);
+      });
+    }, POLL_INTERVAL_MS);
+    this.timer.unref();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private async processPending(): Promise<void> {
+    if (this.processing || this.stopped) return;
+    this.processing = true;
+    try {
+      const pendingDir = this.dir("pending");
+      const files = (await fs.readdir(pendingDir).catch((err) => {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+        throw err;
+      }))
+        .filter((name) => name.endsWith(".json"))
+        .sort();
+
+      for (const file of files) {
+        if (this.stopped) break;
+        await this.processFile(file);
+      }
+    } finally {
+      this.processing = false;
+    }
+  }
+
+  private async processFile(file: string): Promise<void> {
+    const pendingPath = path.join(this.dir("pending"), file);
+    const processingPath = path.join(this.dir("processing"), file);
+
+    try {
+      await fs.rename(pendingPath, processingPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw err;
+    }
+
+    try {
+      const job = await this.readJob(processingPath);
+      await this.opts.onMessage(job);
+      await fs.rename(processingPath, path.join(this.dir("done"), file));
+      this.opts.log(`[inject] processed ${job.id} for ${job.target}`);
+    } catch (err) {
+      const failedPath = path.join(this.dir("failed"), file);
+      const raw = await fs.readFile(processingPath, "utf-8").catch(() => "");
+      const failure = {
+        failedAt: new Date().toISOString(),
+        error: String(err),
+        raw,
+      };
+      await fs.writeFile(
+        processingPath,
+        JSON.stringify(failure, null, 2) + "\n",
+        "utf-8",
+      ).catch(() => {});
+      await fs.rename(processingPath, failedPath).catch(() => {});
+      this.opts.log(`[inject] failed ${file}: ${String(err)}`);
+    }
+  }
+
+  private async readJob(filePath: string): Promise<InjectedMessage> {
+    const parsed = JSON.parse(await fs.readFile(filePath, "utf-8")) as Partial<InjectedMessage>;
+    if (!parsed.id || !parsed.createdAt || !parsed.target || !parsed.text || parsed.source !== "cli") {
+      throw new Error(`Invalid injected message file: ${filePath}`);
+    }
+    return parsed as InjectedMessage;
+  }
+
+  private async ensureDirs(): Promise<void> {
+    const dirs = [
+      this.dir("pending"),
+      this.dir("processing"),
+      this.dir("done"),
+      this.dir("failed"),
+    ];
+    await Promise.all(dirs.map(async (dir) => {
+      await fs.mkdir(dir, { recursive: true, mode: INJECT_DIR_MODE });
+      await fs.chmod(dir, INJECT_DIR_MODE).catch(() => {});
+    }));
+  }
+
+  private async recoverProcessing(): Promise<void> {
+    const processingDir = this.dir("processing");
+    const files = (await fs.readdir(processingDir).catch((err) => {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }))
+      .filter((name) => name.endsWith(".json"))
+      .sort();
+
+    for (const file of files) {
+      const from = path.join(processingDir, file);
+      const to = path.join(this.dir("pending"), file);
+      await fs.rename(from, to).catch((err) => {
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      });
+      this.opts.log(`[inject] recovered stale processing job ${file}`);
+    }
+  }
+
+  private dir(name: "pending" | "processing" | "done" | "failed"): string {
+    return path.join(this.opts.injectDir, name);
+  }
+}

--- a/src/inject/queue.ts
+++ b/src/inject/queue.ts
@@ -27,6 +27,8 @@ export async function queueInjectedMessage(
   }
 
   const pendingDir = path.join(params.injectDir, "pending");
+  await fs.mkdir(params.injectDir, { recursive: true, mode: INJECT_DIR_MODE });
+  await fs.chmod(params.injectDir, INJECT_DIR_MODE).catch(() => {});
   await fs.mkdir(pendingDir, { recursive: true, mode: INJECT_DIR_MODE });
   await fs.chmod(pendingDir, INJECT_DIR_MODE).catch(() => {});
 

--- a/src/inject/queue.ts
+++ b/src/inject/queue.ts
@@ -1,0 +1,52 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { DEFAULT_INJECTION_TARGET, type InjectedMessage } from "./types.js";
+
+const INJECT_DIR_MODE = 0o700;
+const INJECT_FILE_MODE = 0o600;
+
+export interface QueueInjectedMessageParams {
+  injectDir: string;
+  text: string;
+  target?: string;
+  contextToken?: string;
+}
+
+export interface QueuedInjectedMessage {
+  job: InjectedMessage;
+  filePath: string;
+}
+
+export async function queueInjectedMessage(
+  params: QueueInjectedMessageParams,
+): Promise<QueuedInjectedMessage> {
+  const text = params.text.trim();
+  if (!text) {
+    throw new Error("Injected message text cannot be empty");
+  }
+
+  const pendingDir = path.join(params.injectDir, "pending");
+  await fs.mkdir(pendingDir, { recursive: true, mode: INJECT_DIR_MODE });
+  await fs.chmod(pendingDir, INJECT_DIR_MODE).catch(() => {});
+
+  const job: InjectedMessage = {
+    id: `inj_${new Date().toISOString().replace(/[:.]/g, "-")}_${crypto.randomUUID()}`,
+    createdAt: new Date().toISOString(),
+    target: params.target ?? DEFAULT_INJECTION_TARGET,
+    text,
+    source: "cli",
+    ...(params.contextToken ? { contextToken: params.contextToken } : {}),
+  };
+
+  const tmpPath = path.join(pendingDir, `.${job.id}.tmp`);
+  const filePath = path.join(pendingDir, `${job.id}.json`);
+  await fs.writeFile(tmpPath, JSON.stringify(job, null, 2) + "\n", {
+    encoding: "utf-8",
+    mode: INJECT_FILE_MODE,
+  });
+  await fs.chmod(tmpPath, INJECT_FILE_MODE).catch(() => {});
+  await fs.rename(tmpPath, filePath);
+
+  return { job, filePath };
+}

--- a/src/inject/types.ts
+++ b/src/inject/types.ts
@@ -1,0 +1,10 @@
+export const DEFAULT_INJECTION_TARGET = "last-active-user";
+
+export interface InjectedMessage {
+  id: string;
+  createdAt: string;
+  target: string;
+  text: string;
+  source: "cli";
+  contextToken?: string;
+}

--- a/src/storage/state.ts
+++ b/src/storage/state.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 const STATE_DIR_MODE = 0o700;
 const STATE_FILE_MODE = 0o600;
+const MAX_STORED_USERS = 100;
 
 export interface UserState {
   contextToken: string;
@@ -38,7 +39,7 @@ export async function saveState(stateFile: string, state: BridgeState): Promise<
     mode: STATE_FILE_MODE,
   });
   await fs.chmod(tmp, STATE_FILE_MODE).catch(() => {});
-  await fs.rename(tmp, stateFile);
+  await replaceFile(tmp, stateFile);
 }
 
 export async function updateLastActiveUser(
@@ -55,6 +56,7 @@ export async function updateLastActiveUser(
       lastSeenAt: new Date().toISOString(),
     },
   };
+  state.users = pruneUsers(state.users);
   await saveState(stateFile, state);
 }
 
@@ -79,4 +81,28 @@ export async function resolveUserTarget(
     userId,
     contextToken: resolvedContextToken,
   };
+}
+
+async function replaceFile(tmp: string, target: string): Promise<void> {
+  try {
+    await fs.rename(tmp, target);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (process.platform !== "win32" || (code !== "EEXIST" && code !== "EPERM")) {
+      throw err;
+    }
+    await fs.rm(target, { force: true });
+    await fs.rename(tmp, target);
+  }
+}
+
+function pruneUsers(users: Record<string, UserState>): Record<string, UserState> {
+  const entries = Object.entries(users);
+  if (entries.length <= MAX_STORED_USERS) return users;
+
+  return Object.fromEntries(
+    entries
+      .sort(([, left], [, right]) => right.lastSeenAt.localeCompare(left.lastSeenAt))
+      .slice(0, MAX_STORED_USERS),
+  );
 }

--- a/src/storage/state.ts
+++ b/src/storage/state.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const STATE_DIR_MODE = 0o700;
+const STATE_FILE_MODE = 0o600;
+
+export interface UserState {
+  contextToken: string;
+  lastSeenAt: string;
+}
+
+export interface BridgeState {
+  lastActiveUserId?: string;
+  users?: Record<string, UserState>;
+}
+
+export interface ResolvedUserTarget {
+  userId: string;
+  contextToken: string;
+}
+
+export async function loadState(stateFile: string): Promise<BridgeState> {
+  try {
+    const content = await fs.readFile(stateFile, "utf-8");
+    return JSON.parse(content) as BridgeState;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw err;
+  }
+}
+
+export async function saveState(stateFile: string, state: BridgeState): Promise<void> {
+  await fs.mkdir(path.dirname(stateFile), { recursive: true, mode: STATE_DIR_MODE });
+  await fs.chmod(path.dirname(stateFile), STATE_DIR_MODE).catch(() => {});
+  const tmp = path.join(path.dirname(stateFile), `.state-${process.pid}-${Date.now()}.tmp`);
+  await fs.writeFile(tmp, JSON.stringify(state, null, 2) + "\n", {
+    encoding: "utf-8",
+    mode: STATE_FILE_MODE,
+  });
+  await fs.chmod(tmp, STATE_FILE_MODE).catch(() => {});
+  await fs.rename(tmp, stateFile);
+}
+
+export async function updateLastActiveUser(
+  stateFile: string,
+  userId: string,
+  contextToken: string,
+): Promise<void> {
+  const state = await loadState(stateFile);
+  state.lastActiveUserId = userId;
+  state.users = {
+    ...(state.users ?? {}),
+    [userId]: {
+      contextToken,
+      lastSeenAt: new Date().toISOString(),
+    },
+  };
+  await saveState(stateFile, state);
+}
+
+export async function resolveUserTarget(
+  stateFile: string,
+  target: string | undefined,
+  contextToken?: string,
+): Promise<ResolvedUserTarget> {
+  const state = await loadState(stateFile);
+  const userId = !target || target === "last-active-user" ? state.lastActiveUserId : target;
+  if (!userId) {
+    throw new Error("No last active user found. Send any message to this WeChat bot once, then retry.");
+  }
+
+  const stored = state.users?.[userId];
+  const resolvedContextToken = contextToken ?? stored?.contextToken;
+  if (!resolvedContextToken) {
+    throw new Error(`No context token found for target user ${userId}. Ask the user to send a new message first.`);
+  }
+
+  return {
+    userId,
+    contextToken: resolvedContextToken,
+  };
+}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -4,7 +4,7 @@
  * Privacy:
  *   - No message content, filenames, transcripts, URLs, tokens, or paths are collected.
  *   - WeChat user IDs are sha256-hashed with a per-install salt and truncated.
- *   - Only the 9 categorical events declared in `EventName` are emitted.
+ *   - Only the categorical events declared in `EventName` are emitted.
  *
  * Disable: set environment variable `WECHAT_ACP_TELEMETRY=0` (or `false` / `off`).
  */
@@ -28,6 +28,7 @@ export type EventName =
   | "login.failure"
   | "token.reused"
   | "message.received"
+  | "message.injected"
   | "session.created"
   | "prompt.completed"
   | "reply.sent";


### PR DESCRIPTION
## Summary

- add `wechat-acp inject` to enqueue local text messages into a file-backed queue
- persist the last active WeChat user/context token for `last-active-user` injection
- have the running bridge process injected jobs through the existing ACP session and WeChat reply path
- document cron usage for scheduled prompts such as daily AI news

## Validation

- `npm run build`
- local queue monitor smoke test for pending -> done and stale processing recovery
