### PR TITLE
feat: add /acp-prompt-start + /acp-prompt-done message buffering

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,29 @@ Behavior:
 - If no turn is in flight, the command replies with a notice and is a no-op.
 - This command is handled by `wechat-acp` itself and is **not** forwarded to the underlying agent.
 
+## Multi-part message buffering
+
+WeChat does not allow sending images, files, and text in a single message. To work around this, the bridge provides a buffering mode that collects multiple messages and sends them to the agent as one combined request:
+
+```text
+/acp-prompt-start
+/acp-prompt-done
+```
+
+Usage:
+
+1. Send `/acp-prompt-start` to enter buffering mode. The bridge replies with a confirmation.
+2. Send any number of messages (text, images, files) in any order. These are collected locally and **not** forwarded to the agent.
+3. Send `/acp-prompt-done` to flush the buffer. All collected content is combined into a single agent request.
+
+This avoids triggering multiple agent turns (and multiple replies) when a user needs to send mixed content.
+
+- If `/acp-prompt-done` is sent with nothing buffered, the bridge replies with a warning and no agent request is made.
+- If `/acp-prompt-start` is sent while already buffering, the bridge reminds the user and keeps the existing buffer.
+- Buffering is per-user and held in memory. It does not persist across bridge restarts.
+- Buffers expire after 10 minutes of inactivity. A maximum of 50 content blocks can be collected per buffer.
+- This command is handled by `wechat-acp` itself and is **not** forwarded to the underlying agent.
+
 ## Injecting messages locally
 
 `wechat-acp inject` lets local automation enqueue a text message for the running daemon. The daemon treats it like an incoming direct message from the target user, sends it to the configured ACP agent, and replies through WeChat.
@@ -348,7 +371,7 @@ npm run dev
 WECHAT_ACP_TELEMETRY=0 npx wechat-acp --agent copilot
 ```
 
-**What is collected** (13 event types only):
+**What is collected** (15 event types only):
 
 - `app.start` / `app.stop` — process lifecycle, agent preset name, daemon flag, uptime
 - `login.success` / `login.failure` / `token.reused` — WeChat login outcomes (no token, no QR URL)
@@ -357,11 +380,13 @@ WECHAT_ACP_TELEMETRY=0 npx wechat-acp --agent copilot
 - `command.acp_config.view` — `/acp-config` invoked to list options; whether a session exists and the option count
 - `command.acp_config.set` — `/acp-config set` succeeded; `configId`, option type (`select` / `boolean`), and the resolved option value (all from the agent's declared `configOptions`, never the user's raw input)
 - `command.acp_cancel` — `/acp-cancel` invoked; whether the queue was drained, whether an in-flight turn was actually cancelled, and how many queued messages were dropped
+- `command.buffer_start` — `/acp-prompt-start` invoked to enter buffering mode
+- `command.buffer_done` — `/acp-prompt-done` invoked to flush buffer; number of content blocks collected
 - `session.created` — new ACP session opened
 - `prompt.completed` — ACP turn finished; agent preset, stop reason, duration, reply length
 - `reply.sent` — reply pushed back to WeChat; segment count, total length
 
-Plus exception reports for `monitor`, `prompt`, `reply`, `auth`, `agent_spawn`, `enqueue`, `command`, and `state` failures.
+Plus exception reports for `monitor`, `prompt`, `reply`, `auth`, `agent_spawn`, `enqueue`, `buffer`, `command`, and `state` failures.
 
 **What is never collected**: message bodies, filenames, voice transcripts, image URLs, login tokens, QR codes, raw agent command strings, environment variables, working directory paths, raw WeChat user IDs.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,7 +161,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -372,7 +371,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -524,7 +522,6 @@
       "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
       "integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -22,7 +22,11 @@ import { trackEvent, trackException, hashUserId } from "./telemetry/index.js";
 
 const ACP_CONFIG_COMMAND = "/acp-config";
 const ACP_CANCEL_COMMAND = "/acp-cancel";
+const BUFFER_START_COMMAND = "/acp-prompt-start";
+const BUFFER_DONE_COMMAND = "/acp-prompt-done";
 const TEXT_CHUNK_LIMIT = 4000;
+const BUFFER_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const BUFFER_MAX_BLOCKS = 50;
 
 export class WeChatAcpBridge {
   private config: WeChatAcpConfig;
@@ -33,6 +37,20 @@ export class WeChatAcpBridge {
   private stateUpdate = Promise.resolve();
   // Per-user typing ticket cache
   private typingTickets = new Map<string, { ticket: string; expiresAt: number }>();
+  // Per-user message buffer for /acp-prompt-start.../acp-prompt-done multi-part compose
+  private messageBuffers = new Map<string, {
+    blocks: acp.ContentBlock[];
+    contextToken: string;
+    pending: Promise<void>;
+    lastUpdatedAt: number;
+  }>();
+  // Per-user expiry timers for buffer cleanup
+  private bufferTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  // Users currently flushing their buffer (between /done and enqueue).
+  // Maps userId to a promise that resolves when the flush completes, so
+  // messages arriving during the flush wait for the buffered prompt to
+  // enqueue first, preserving turn order.
+  private bufferFlushing = new Map<string, Promise<void>>();
   private log: (msg: string) => void;
 
   constructor(config: WeChatAcpConfig, log?: (msg: string) => void) {
@@ -174,8 +192,33 @@ export class WeChatAcpBridge {
       return;
     }
 
+    // /acp-prompt-start — enter buffering mode
+    if (this.isBufferStartCommand(msg)) {
+      this.handleBufferStart(userId, contextToken);
+      return;
+    }
+
+    // /acp-prompt-done — flush buffer and send to agent
+    if (this.isBufferDoneCommand(msg)) {
+      this.handleBufferDone(userId, contextToken).catch((err) => {
+        this.log(`Failed to flush message buffer for ${userId}: ${String(err)}`);
+        trackException(err, "buffer", hashUserId(userId));
+      });
+      return;
+    }
+
+    // If user is in buffering mode, append to buffer instead of enqueuing
+    if (this.messageBuffers.has(userId)) {
+      this.appendToBuffer(msg, userId, contextToken);
+      return;
+    }
+
     // Convert and enqueue — fire-and-forget (don't block the poll loop)
-    this.enqueueMessage(msg, userId, contextToken).catch((err) => {
+    const waitForFlush = this.bufferFlushing.get(userId);
+    const enqueue = waitForFlush
+      ? waitForFlush.then(() => this.enqueueMessage(msg, userId, contextToken))
+      : this.enqueueMessage(msg, userId, contextToken);
+    enqueue.catch((err) => {
       this.log(`Failed to enqueue message from ${userId}: ${String(err)}`);
       trackException(err, "enqueue", hashUserId(userId));
     });
@@ -350,6 +393,172 @@ export class WeChatAcpBridge {
     lines.push(`   • Cancel current turn:        ${ACP_CANCEL_COMMAND}`);
     lines.push(`   • Cancel + drop queued msgs:  ${ACP_CANCEL_COMMAND} all`);
     return lines.join("\n");
+  }
+
+  private isBufferStartCommand(msg: WeixinMessage): boolean {
+    return this.extractBridgeCommand(msg, BUFFER_START_COMMAND) !== null;
+  }
+
+  private isBufferDoneCommand(msg: WeixinMessage): boolean {
+    return this.extractBridgeCommand(msg, BUFFER_DONE_COMMAND) !== null;
+  }
+
+  private handleBufferStart(userId: string, contextToken: string): void {
+    if (this.messageBuffers.has(userId)) {
+      const buffer = this.messageBuffers.get(userId)!;
+      this.sendReply(userId, contextToken, `📝 Already in buffering mode (${buffer.blocks.length} block(s) collected). Keep sending, then /acp-prompt-done to submit.`).catch((err) => {
+        this.log(`Failed to send buffer active notice to ${userId}: ${String(err)}`);
+      });
+      return;
+    }
+
+    this.messageBuffers.set(userId, { blocks: [], contextToken, pending: Promise.resolve(), lastUpdatedAt: Date.now() });
+    this.resetBufferTimer(userId);
+    this.log(`Buffer started for ${userId}`);
+    trackEvent(
+      "command.buffer_start",
+      { userIdHash: hashUserId(userId) },
+      hashUserId(userId),
+    );
+    this.sendReply(userId, contextToken, "📝 Buffering mode started. Send your messages (text, images, files), then send /acp-prompt-done to submit them all at once.").catch((err) => {
+      this.log(`Failed to send buffer start confirmation to ${userId}: ${String(err)}`);
+    });
+  }
+
+  private handleBufferDone(userId: string, contextToken: string): Promise<void> {
+    const buffer = this.messageBuffers.get(userId);
+    if (!buffer) {
+      return this.sendReply(userId, contextToken, "⚠️ Nothing buffered. Send /acp-prompt-start first, then send messages before /acp-prompt-done.");
+    }
+
+    // Remove from map immediately so new messages during the await
+    // are not appended to a stale buffer.
+    const pending = buffer.pending;
+    this.messageBuffers.delete(userId);
+    this.clearBufferTimer(userId);
+
+    // Register a flushing promise so messages arriving during the await
+    // queue behind the buffered prompt, preserving turn order.
+    const flushPromise = this.doFlush(userId, contextToken, buffer, pending);
+    this.bufferFlushing.set(userId, flushPromise);
+    flushPromise.finally(() => {
+      // Only clear if this is still our flush (not a newer one)
+      if (this.bufferFlushing.get(userId) === flushPromise) {
+        this.bufferFlushing.delete(userId);
+      }
+    });
+    return flushPromise;
+  }
+
+  private async doFlush(
+    userId: string,
+    contextToken: string,
+    buffer: { blocks: acp.ContentBlock[]; contextToken: string; pending: Promise<void>; lastUpdatedAt: number },
+    pending: Promise<void>,
+  ): Promise<void> {
+    // Wait for any in-flight appends to finish before reading
+    try {
+      await pending;
+    } catch {
+      // A prior append failed (e.g. image download error). The chain
+      // already logged/tracked the error. Clear the buffer so the user
+      // can start fresh.
+      await this.sendReply(userId, contextToken, "⚠️ A buffered message failed to process. Buffer cleared. Please send /acp-prompt-start to try again.");
+      return;
+    }
+
+    // Check expiry
+    if (Date.now() - buffer.lastUpdatedAt > BUFFER_TTL_MS) {
+      await this.sendReply(userId, contextToken, "⚠️ Buffer expired (10 min without activity). Please send /acp-prompt-start to start over.");
+      return;
+    }
+
+    if (buffer.blocks.length === 0) {
+      await this.sendReply(userId, contextToken, "⚠️ Buffer is empty. Send some messages before /acp-prompt-done.");
+      return;
+    }
+
+    this.log(`Buffer flushed for ${userId}: ${buffer.blocks.length} block(s)`);
+    trackEvent(
+      "command.buffer_done",
+      {
+        userIdHash: hashUserId(userId),
+        blockCount: buffer.blocks.length,
+      },
+      hashUserId(userId),
+    );
+
+    await this.sessionManager!.enqueue(userId, {
+      prompt: buffer.blocks,
+      contextToken: buffer.contextToken,
+    });
+  }
+
+  private appendToBuffer(
+    msg: WeixinMessage,
+    userId: string,
+    contextToken: string,
+  ): void {
+    const buffer = this.messageBuffers.get(userId);
+    if (!buffer) return;
+
+    // Chain the async conversion so /acp-prompt-done waits for all in-flight appends
+    buffer.pending = buffer.pending
+      .then(async () => {
+        // Re-check buffer still exists (could have been flushed or expired)
+        if (!this.messageBuffers.has(userId)) return;
+
+        // Check TTL
+        if (Date.now() - buffer.lastUpdatedAt > BUFFER_TTL_MS) {
+          this.messageBuffers.delete(userId);
+          this.log(`Buffer expired for ${userId}`);
+          await this.sendReply(userId, contextToken, "⚠️ Buffering timed out (10 min without activity). Please send /acp-prompt-start again.");
+          return;
+        }
+
+        // Check block limit
+        if (buffer.blocks.length >= BUFFER_MAX_BLOCKS) {
+          await this.sendReply(userId, contextToken, `⚠️ Buffer is full (${BUFFER_MAX_BLOCKS} blocks max). Send /acp-prompt-done to submit what you have.`);
+          return;
+        }
+
+        const prompt = await weixinMessageToPrompt(
+          msg,
+          this.config.wechat.cdnBaseUrl,
+          this.log,
+          this.config.storage.inboxDir,
+        );
+        buffer.blocks.push(...prompt);
+        buffer.contextToken = contextToken;
+        buffer.lastUpdatedAt = Date.now();
+        this.resetBufferTimer(userId);
+
+        this.log(`Buffered message from ${userId}, now ${buffer.blocks.length} block(s)`);
+      });
+
+    buffer.pending.catch((err) => {
+      this.log(`Failed to buffer message from ${userId}: ${String(err)}`);
+      trackException(err, "buffer", hashUserId(userId));
+    });
+  }
+
+  private resetBufferTimer(userId: string): void {
+    this.clearBufferTimer(userId);
+    this.bufferTimers.set(userId, setTimeout(() => {
+      const buffer = this.messageBuffers.get(userId);
+      if (!buffer) return;
+      this.messageBuffers.delete(userId);
+      this.bufferTimers.delete(userId);
+      this.log(`Buffer expired (timer) for ${userId}`);
+    }, BUFFER_TTL_MS));
+  }
+
+  private clearBufferTimer(userId: string): void {
+    const timer = this.bufferTimers.get(userId);
+    if (timer) {
+      clearTimeout(timer);
+      this.bufferTimers.delete(userId);
+    }
   }
 
   private rememberActiveUser(userId: string, contextToken: string): void {

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -32,6 +32,8 @@ export type EventName =
   | "command.acp_config.view"
   | "command.acp_config.set"
   | "command.acp_cancel"
+  | "command.buffer_start"
+  | "command.buffer_done"
   | "session.created"
   | "prompt.completed"
   | "reply.sent";


### PR DESCRIPTION
## Problem

WeChat does not support sending images/files and text in one message. Users who want to include mixed content (e.g. a question + screenshots + a PDF) must send them separately, triggering multiple agent turns, multiple replies, and wasted compute.

Closes #32

## Solution

Add a pair of bridge commands for multi-part message buffering:

- `/acp-prompt-start`: enter buffering mode. The bridge replies with a confirmation and stops forwarding messages to the agent.
- `/acp-prompt-done`: flush the buffer. All collected content blocks (text, images, files) are concatenated into a single ACP prompt and enqueued as one agent request.

Example flow:
```
User: /acp-prompt-start
User: [text message]
User: [image]
User: [another image]
User: [file]
User: /acp-prompt-done
-> agent receives one request with all content
```

## Implementation details

- Buffer is per-user, in-memory (Map in `WeChatAcpBridge`). Does not persist across bridge restarts.
- While buffering, messages are converted to `ContentBlock[]` via the existing `weixinMessageToPrompt()` and appended to the buffer.
- Appends are serialized via a per-user promise chain so `/acp-prompt-done` awaits all in-flight conversions (e.g. image downloads) before flushing.
- Buffer is removed from the map immediately when `/acp-prompt-done` is received, so messages arriving during the flush are enqueued normally.
- Repeated `/acp-prompt-start` warns the user and keeps the existing buffer.
- 10-minute inactivity TTL (using `lastUpdatedAt`, refreshed on each append) with a proactive `setTimeout` timer for cleanup.
- 50-block cap with user-facing notification.
- Failed pending appends are caught gracefully in `/acp-prompt-done`.
- Two new telemetry events: `command.buffer_start` and `command.buffer_done`.
- README updated with usage docs and telemetry catalog.
