### PR TITLE
feat: customizable aliases for bridge slash commands (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add customizable aliases for bridge slash commands via the `commandAliases` config map. Map any built-in command (`/acp-config`, `/acp-cancel`) to one or more custom aliases (e.g. `{"commandAliases": {"/acp-cancel": ["/cancel", "/取消"]}}`); the original built-in names keep working as a fallback. Aliases are validated at startup. See the README's "Customizing bridge command names (aliases)" section.
+- Add customizable aliases for bridge slash commands via the `commandAliases` config map. Map any built-in command (`/acp-config`, `/acp-cancel`, `/acp-prompt-start`, `/acp-prompt-done`) to one or more custom aliases (e.g. `{"commandAliases": {"/acp-cancel": ["/cancel", "/取消"]}}`); the original built-in names keep working as a fallback. Aliases are validated at startup. See the README's "Customizing bridge command names (aliases)" section.
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add customizable aliases for bridge slash commands via the `commandAliases` config map. Map any built-in command (`/acp-config`, `/acp-cancel`) to one or more custom aliases (e.g. `{"commandAliases": {"/acp-cancel": ["/cancel", "/取消"]}}`); the original built-in names keep working as a fallback. Aliases are validated at startup. See the README's "Customizing bridge command names (aliases)" section.
+
 ## 0.6.0
 
 - Add `/acp-cancel` WeChat chat command to stop the in-flight ACP prompt turn for the current user, since WeChat has no UI for it. `/acp-cancel` sends `session/cancel` (the agent's `prompt()` resolves with `stopReason: "cancelled"` and any partial output already streamed is delivered with a `[cancelled]` suffix); `/acp-cancel all` also drops any queued messages behind it. See the README's "WeChat ACP cancel command" section.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ command to one or more custom aliases via the `commandAliases` config map:
 ```json
 {
   "commandAliases": {
-    "/acp-cancel": ["/cancel", "/取消"],
+    "/acp-cancel": ["/cancel", "/取消", "取消"],
     "/acp-config": ["/config", "/设置"]
   }
 }
@@ -193,10 +193,20 @@ With this config:
   `/设置 set <configId> <value>` works like `/acp-config set ...`.
 - The original built-in names always keep working as a fallback.
 
+Two alias styles are supported:
+
+- **Slash aliases** (start with `/`, e.g. `/cancel`) behave like the
+  built-in commands: they match the command token and may be followed by
+  arguments (`/cancel all`). They must not contain whitespace.
+- **Bare-phrase aliases** (no leading `/`, e.g. `取消`) match only when
+  they equal the *entire* message. This is handy for WeChat voice input,
+  where saying `/取消` out loud feels unnatural — a transcribed `取消`
+  triggers the command. Because they require an exact full-message match,
+  they take no arguments.
+
 Notes:
 
 - Keys must be a known bridge command (`/acp-config` or `/acp-cancel`).
-- Each alias must start with `/` and contain no whitespace.
 - An alias may not collide with a built-in command name or be mapped to
   more than one command. Invalid configs are rejected at startup.
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Two alias styles are supported:
 
 Notes:
 
-- Keys must be a known bridge command (`/acp-config` or `/acp-cancel`).
+- Keys must be a known bridge command (`/acp-config`, `/acp-cancel`, `/acp-prompt-start`, or `/acp-prompt-done`).
 - An alias may not collide with a built-in command name or be mapped to
   more than one command. Invalid configs are rejected at startup.
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,37 @@ You can also override or add agent presets:
 }
 ```
 
+## Customizing bridge command names (aliases)
+
+Bridge slash commands like `/acp-config` and `/acp-cancel` have fixed
+built-in names that may not feel natural to everyone, and can clash with
+slash commands built into the underlying agent. You can map any bridge
+command to one or more custom aliases via the `commandAliases` config map:
+
+```json
+{
+  "commandAliases": {
+    "/acp-cancel": ["/cancel", "/取消"],
+    "/acp-config": ["/config", "/设置"]
+  }
+}
+```
+
+With this config:
+
+- Sending `/取消` cancels the current turn (same as `/acp-cancel`), and
+  `/取消 all` works like `/acp-cancel all`.
+- Sending `/设置` lists ACP session config (same as `/acp-config`), and
+  `/设置 set <configId> <value>` works like `/acp-config set ...`.
+- The original built-in names always keep working as a fallback.
+
+Notes:
+
+- Keys must be a known bridge command (`/acp-config` or `/acp-cancel`).
+- Each alias must start with `/` and contain no whitespace.
+- An alias may not collide with a built-in command name or be mapped to
+  more than one command. Invalid configs are rejected at startup.
+
 ## Runtime Behavior
 
 - Each WeChat user gets a dedicated ACP session and subprocess.
@@ -200,6 +231,7 @@ Notes:
 - The command only works after the WeChat user already has an active ACP session. If not, send a normal message first so the session is created.
 - Available `configId` values come directly from the ACP agent's `configOptions`, so the exact list depends on the configured agent.
 - This command is handled by `wechat-acp` itself and is **not** forwarded to the underlying agent.
+- You can give this command your own aliases via `commandAliases` (see [Customizing bridge command names](#customizing-bridge-command-names-aliases)).
 
 ## WeChat ACP cancel command
 
@@ -216,6 +248,7 @@ Behavior:
 - `/acp-cancel all` does the same and also drops every message that was queued behind the current turn. Local injections (`wechat-acp inject`) waiting on those queued messages are rejected.
 - If no turn is in flight, the command replies with a notice and is a no-op.
 - This command is handled by `wechat-acp` itself and is **not** forwarded to the underlying agent.
+- You can give this command your own aliases via `commandAliases` (see [Customizing bridge command names](#customizing-bridge-command-names-aliases)).
 
 ## Injecting messages locally
 

--- a/bin/wechat-acp.ts
+++ b/bin/wechat-acp.ts
@@ -23,6 +23,7 @@ import {
   defaultStorageDir,
   listBuiltInAgents,
   resolveAgentSelection,
+  validateCommandAliases,
   validateInstanceName,
 } from "../src/config.js";
 import type { WeChatAcpConfig } from "../src/config.js";
@@ -357,6 +358,11 @@ async function main(): Promise<void> {
     Object.assign(config.agents, fileConfig.agents ?? {});
     Object.assign(config.session, fileConfig.session ?? {});
     Object.assign(config.daemon, fileConfig.daemon ?? {});
+    if (Object.prototype.hasOwnProperty.call(fileConfig, "commandAliases")) {
+      // Assign the raw value (even if malformed) so the post-merge
+      // validateCommandAliases() below can reject it with a clean error.
+      config.commandAliases = fileConfig.commandAliases;
+    }
     // Track whether the user explicitly set inboxDir so we don't
     // overwrite their choice with a re-derived default below. We check
     // before Object.assign because checking after can't distinguish
@@ -427,6 +433,13 @@ async function main(): Promise<void> {
     }
   } else {
     config.storage.injectDir = path.join(config.storage.dir, "inject");
+  }
+
+  try {
+    validateCommandAliases(config.commandAliases);
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
+    process.exit(1);
   }
 
   // Handle subcommands

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -499,8 +499,16 @@ export class WeChatAcpBridge {
     const text = item.text_item.text.trim();
     const names = resolveCommandNames(canonical, this.config.commandAliases);
     for (const name of names) {
-      if (text === name || text.startsWith(`${name} `)) {
-        return text;
+      // Exact match → normalize to the canonical command with no arguments.
+      // This is the only matching mode for bare-phrase aliases (no leading
+      // "/"), e.g. a voice-transcribed "取消", which must match the whole
+      // message to avoid false positives.
+      if (text === name) return canonical;
+      // Slash-prefixed names (the canonical command and "/"-style aliases)
+      // also support trailing arguments. Replace the matched name with the
+      // canonical command so handlers always see a single, stable token.
+      if (name.startsWith("/") && text.startsWith(`${name} `)) {
+        return canonical + text.slice(name.length);
       }
     }
     return null;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -407,7 +407,7 @@ export class WeChatAcpBridge {
   private handleBufferStart(userId: string, contextToken: string): void {
     if (this.messageBuffers.has(userId)) {
       const buffer = this.messageBuffers.get(userId)!;
-      this.sendReply(userId, contextToken, `📝 Already in buffering mode (${buffer.blocks.length} block(s) collected). Keep sending, then /acp-prompt-done to submit.`).catch((err) => {
+      this.sendReply(userId, contextToken, `📝 Already in buffering mode (${buffer.blocks.length} block(s) collected). Keep sending, then ${BUFFER_DONE_COMMAND}${this.aliasHint(BUFFER_DONE_COMMAND)} to submit.`).catch((err) => {
         this.log(`Failed to send buffer active notice to ${userId}: ${String(err)}`);
       });
       return;
@@ -421,7 +421,7 @@ export class WeChatAcpBridge {
       { userIdHash: hashUserId(userId) },
       hashUserId(userId),
     );
-    this.sendReply(userId, contextToken, "📝 Buffering mode started. Send your messages (text, images, files), then send /acp-prompt-done to submit them all at once.").catch((err) => {
+    this.sendReply(userId, contextToken, `📝 Buffering mode started. Send your messages (text, images, files), then send ${BUFFER_DONE_COMMAND}${this.aliasHint(BUFFER_DONE_COMMAND)} to submit them all at once.`).catch((err) => {
       this.log(`Failed to send buffer start confirmation to ${userId}: ${String(err)}`);
     });
   }
@@ -429,7 +429,7 @@ export class WeChatAcpBridge {
   private handleBufferDone(userId: string, contextToken: string): Promise<void> {
     const buffer = this.messageBuffers.get(userId);
     if (!buffer) {
-      return this.sendReply(userId, contextToken, "⚠️ Nothing buffered. Send /acp-prompt-start first, then send messages before /acp-prompt-done.");
+      return this.sendReply(userId, contextToken, `⚠️ Nothing buffered. Send ${BUFFER_START_COMMAND}${this.aliasHint(BUFFER_START_COMMAND)} first, then send messages before ${BUFFER_DONE_COMMAND}${this.aliasHint(BUFFER_DONE_COMMAND)}.`);
     }
 
     // Remove from map immediately so new messages during the await
@@ -464,18 +464,18 @@ export class WeChatAcpBridge {
       // A prior append failed (e.g. image download error). The chain
       // already logged/tracked the error. Clear the buffer so the user
       // can start fresh.
-      await this.sendReply(userId, contextToken, "⚠️ A buffered message failed to process. Buffer cleared. Please send /acp-prompt-start to try again.");
+      await this.sendReply(userId, contextToken, `⚠️ A buffered message failed to process. Buffer cleared. Please send ${BUFFER_START_COMMAND}${this.aliasHint(BUFFER_START_COMMAND)} to try again.`);
       return;
     }
 
     // Check expiry
     if (Date.now() - buffer.lastUpdatedAt > BUFFER_TTL_MS) {
-      await this.sendReply(userId, contextToken, "⚠️ Buffer expired (10 min without activity). Please send /acp-prompt-start to start over.");
+      await this.sendReply(userId, contextToken, `⚠️ Buffer expired (10 min without activity). Please send ${BUFFER_START_COMMAND}${this.aliasHint(BUFFER_START_COMMAND)} to start over.`);
       return;
     }
 
     if (buffer.blocks.length === 0) {
-      await this.sendReply(userId, contextToken, "⚠️ Buffer is empty. Send some messages before /acp-prompt-done.");
+      await this.sendReply(userId, contextToken, `⚠️ Buffer is empty. Send some messages before ${BUFFER_DONE_COMMAND}${this.aliasHint(BUFFER_DONE_COMMAND)}.`);
       return;
     }
 
@@ -513,13 +513,13 @@ export class WeChatAcpBridge {
         if (Date.now() - buffer.lastUpdatedAt > BUFFER_TTL_MS) {
           this.messageBuffers.delete(userId);
           this.log(`Buffer expired for ${userId}`);
-          await this.sendReply(userId, contextToken, "⚠️ Buffering timed out (10 min without activity). Please send /acp-prompt-start again.");
+          await this.sendReply(userId, contextToken, `⚠️ Buffering timed out (10 min without activity). Please send ${BUFFER_START_COMMAND}${this.aliasHint(BUFFER_START_COMMAND)} again.`);
           return;
         }
 
         // Check block limit
         if (buffer.blocks.length >= BUFFER_MAX_BLOCKS) {
-          await this.sendReply(userId, contextToken, `⚠️ Buffer is full (${BUFFER_MAX_BLOCKS} blocks max). Send /acp-prompt-done to submit what you have.`);
+          await this.sendReply(userId, contextToken, `⚠️ Buffer is full (${BUFFER_MAX_BLOCKS} blocks max). Send ${BUFFER_DONE_COMMAND}${this.aliasHint(BUFFER_DONE_COMMAND)} to submit what you have.`);
           return;
         }
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -23,8 +23,8 @@ import { trackEvent, trackException, hashUserId } from "./telemetry/index.js";
 
 const ACP_CONFIG_COMMAND = BRIDGE_COMMANDS.acpConfig;
 const ACP_CANCEL_COMMAND = BRIDGE_COMMANDS.acpCancel;
-const BUFFER_START_COMMAND = "/acp-prompt-start";
-const BUFFER_DONE_COMMAND = "/acp-prompt-done";
+const BUFFER_START_COMMAND = BRIDGE_COMMANDS.promptStart;
+const BUFFER_DONE_COMMAND = BRIDGE_COMMANDS.promptDone;
 const TEXT_CHUNK_LIMIT = 4000;
 const BUFFER_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const BUFFER_MAX_BLOCKS = 50;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -15,13 +15,14 @@ import type { WeixinMessage } from "./weixin/types.js";
 import { SessionManager } from "./acp/session.js";
 import { weixinMessageToPrompt } from "./adapter/inbound.js";
 import type { WeChatAcpConfig } from "./config.js";
+import { BRIDGE_COMMANDS, resolveCommandAliases, resolveCommandNames } from "./config.js";
 import { InjectionMonitor } from "./inject/monitor.js";
 import type { InjectedMessage } from "./inject/types.js";
 import { resolveUserTarget, updateLastActiveUser } from "./storage/state.js";
 import { trackEvent, trackException, hashUserId } from "./telemetry/index.js";
 
-const ACP_CONFIG_COMMAND = "/acp-config";
-const ACP_CANCEL_COMMAND = "/acp-cancel";
+const ACP_CONFIG_COMMAND = BRIDGE_COMMANDS.acpConfig;
+const ACP_CANCEL_COMMAND = BRIDGE_COMMANDS.acpCancel;
 const TEXT_CHUNK_LIMIT = 4000;
 
 export class WeChatAcpBridge {
@@ -335,7 +336,7 @@ export class WeChatAcpBridge {
     }
     lines.push("");
     lines.push("💡 **Usage**");
-    lines.push(`   • Cancel current turn:        ${ACP_CANCEL_COMMAND}`);
+    lines.push(`   • Cancel current turn:        ${ACP_CANCEL_COMMAND}${this.aliasHint(ACP_CANCEL_COMMAND)}`);
     lines.push(`   • Cancel + drop queued msgs:  ${ACP_CANCEL_COMMAND} all`);
     return lines.join("\n");
   }
@@ -347,7 +348,7 @@ export class WeChatAcpBridge {
       lines.push("");
     }
     lines.push("💡 **Usage**");
-    lines.push(`   • Cancel current turn:        ${ACP_CANCEL_COMMAND}`);
+    lines.push(`   • Cancel current turn:        ${ACP_CANCEL_COMMAND}${this.aliasHint(ACP_CANCEL_COMMAND)}`);
     lines.push(`   • Cancel + drop queued msgs:  ${ACP_CANCEL_COMMAND} all`);
     return lines.join("\n");
   }
@@ -488,7 +489,7 @@ export class WeChatAcpBridge {
     return this.extractBridgeCommand(msg, ACP_CANCEL_COMMAND);
   }
 
-  private extractBridgeCommand(msg: WeixinMessage, command: string): string | null {
+  private extractBridgeCommand(msg: WeixinMessage, canonical: string): string | null {
     const items = msg.item_list ?? [];
     if (items.length !== 1) return null;
 
@@ -496,7 +497,23 @@ export class WeChatAcpBridge {
     if (item?.type !== 1 || !item.text_item?.text) return null;
 
     const text = item.text_item.text.trim();
-    return text === command || text.startsWith(`${command} `) ? text : null;
+    const names = resolveCommandNames(canonical, this.config.commandAliases);
+    for (const name of names) {
+      if (text === name || text.startsWith(`${name} `)) {
+        return text;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Render a usage hint suffix listing any configured aliases for a
+   * canonical command, e.g. " (aliases: /cancel, /取消)". Returns an
+   * empty string when no aliases are configured.
+   */
+  private aliasHint(canonical: string): string {
+    const aliases = resolveCommandAliases(canonical, this.config.commandAliases);
+    return aliases.length > 0 ? ` (aliases: ${aliases.join(", ")})` : "";
   }
 
   private formatAcpConfigList(userId: string): string {
@@ -530,7 +547,7 @@ export class WeChatAcpBridge {
     lines.push("");
     lines.push("━━━━━━━━━━━━━━━━");
     lines.push("💡 **Usage**");
-    lines.push(`   • View:   ${ACP_CONFIG_COMMAND}`);
+    lines.push(`   • View:   ${ACP_CONFIG_COMMAND}${this.aliasHint(ACP_CONFIG_COMMAND)}`);
     lines.push(`   • Update: ${ACP_CONFIG_COMMAND} set <configId> <value>`);
     return lines.join("\n");
   }
@@ -542,7 +559,7 @@ export class WeChatAcpBridge {
       lines.push("");
     }
     lines.push("💡 **Usage**");
-    lines.push(`   • View:   ${ACP_CONFIG_COMMAND}`);
+    lines.push(`   • View:   ${ACP_CONFIG_COMMAND}${this.aliasHint(ACP_CONFIG_COMMAND)}`);
     lines.push(`   • Update: ${ACP_CONFIG_COMMAND} set <configId> <value>`);
     return lines.join("\n");
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,7 +91,26 @@ export const BUILT_IN_AGENTS: Record<string, AgentPreset> = {
   },
 };
 
+/**
+ * Canonical bridge slash commands that `wechat-acp` handles itself
+ * (i.e. not forwarded to the underlying agent). Used as the keys of
+ * {@link WeChatAcpConfig.commandAliases} and as the fallback names that
+ * always work regardless of configured aliases.
+ */
+export const BRIDGE_COMMANDS = {
+  acpConfig: "/acp-config",
+  acpCancel: "/acp-cancel",
+} as const;
+
 export interface WeChatAcpConfig {
+  /**
+   * Optional user-defined aliases for bridge slash commands. Maps a
+   * canonical command (e.g. `"/acp-cancel"`) to one or more custom
+   * aliases (e.g. `["/cancel", "/取消"]`). The canonical command always
+   * keeps working as a fallback. See {@link BRIDGE_COMMANDS} for the set
+   * of commands that can be aliased.
+   */
+  commandAliases?: Record<string, string[]>;
   wechat: {
     baseUrl: string;
     cdnBaseUrl: string;
@@ -162,6 +181,7 @@ export function defaultConfig(opts?: { instance?: string }): WeChatAcpConfig {
   const instance = opts?.instance;
   const storageDir = defaultStorageDir(instance);
   return {
+    commandAliases: {},
     wechat: {
       baseUrl: "https://ilinkai.weixin.qq.com",
       cdnBaseUrl: "https://novac2c.cdn.weixin.qq.com/c2c",
@@ -240,4 +260,92 @@ export function listBuiltInAgents(
   return Object.entries(registry)
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([id, preset]) => ({ id, preset }));
+}
+
+/**
+ * Resolve the configured aliases for a canonical bridge command into a
+ * trimmed, de-duplicated list. The canonical command itself is not
+ * included — use {@link resolveCommandNames} when you need the full set
+ * of names that should trigger a command.
+ */
+export function resolveCommandAliases(
+  canonical: string,
+  aliases?: Record<string, string[]>,
+): string[] {
+  const configured = aliases?.[canonical];
+  if (!configured) return [];
+  const result: string[] = [];
+  for (const alias of configured) {
+    const trimmed = alias.trim();
+    if (trimmed && !result.includes(trimmed)) {
+      result.push(trimmed);
+    }
+  }
+  return result;
+}
+
+/**
+ * Return the full ordered list of names that should trigger a bridge
+ * command: the canonical name first, followed by any user-defined
+ * aliases. The canonical name is always present so built-in commands
+ * keep working as a fallback even when aliases are configured.
+ */
+export function resolveCommandNames(
+  canonical: string,
+  aliases?: Record<string, string[]>,
+): string[] {
+  return [canonical, ...resolveCommandAliases(canonical, aliases).filter((a) => a !== canonical)];
+}
+
+/**
+ * Validate a `commandAliases` map. Aliases must be non-empty strings that
+ * start with `/` and contain no whitespace (whitespace would break
+ * command/argument parsing). Throws an `Error` describing the first
+ * problem found.
+ */
+export function validateCommandAliases(aliases: Record<string, string[]> | undefined): void {
+  if (aliases === undefined) return;
+  if (typeof aliases !== "object" || aliases === null || Array.isArray(aliases)) {
+    throw new Error("commandAliases must be an object mapping a command to a list of aliases.");
+  }
+
+  const knownCommands = new Set<string>(Object.values(BRIDGE_COMMANDS));
+  const seen = new Map<string, string>();
+
+  for (const [canonical, list] of Object.entries(aliases)) {
+    if (!knownCommands.has(canonical)) {
+      throw new Error(
+        `commandAliases: unknown command ${JSON.stringify(canonical)}. ` +
+          `Known commands: ${[...knownCommands].join(", ")}.`,
+      );
+    }
+    if (!Array.isArray(list)) {
+      throw new Error(`commandAliases[${JSON.stringify(canonical)}] must be an array of strings.`);
+    }
+    for (const alias of list) {
+      if (typeof alias !== "string" || alias.trim() === "") {
+        throw new Error(`commandAliases[${JSON.stringify(canonical)}] contains an empty alias.`);
+      }
+      const trimmed = alias.trim();
+      if (!trimmed.startsWith("/")) {
+        throw new Error(`commandAliases: alias ${JSON.stringify(trimmed)} must start with "/".`);
+      }
+      if (/\s/.test(trimmed)) {
+        throw new Error(`commandAliases: alias ${JSON.stringify(trimmed)} must not contain whitespace.`);
+      }
+      if (knownCommands.has(trimmed) && trimmed !== canonical) {
+        throw new Error(
+          `commandAliases: alias ${JSON.stringify(trimmed)} collides with built-in command ${JSON.stringify(trimmed)}.`,
+        );
+      }
+      const owner = seen.get(trimmed);
+      if (owner && owner !== canonical) {
+        throw new Error(
+          `commandAliases: alias ${JSON.stringify(trimmed)} is mapped to both ` +
+            `${JSON.stringify(owner)} and ${JSON.stringify(canonical)}.`,
+        );
+      }
+      seen.set(trimmed, canonical);
+    }
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,6 +100,8 @@ export const BUILT_IN_AGENTS: Record<string, AgentPreset> = {
 export const BRIDGE_COMMANDS = {
   acpConfig: "/acp-config",
   acpCancel: "/acp-cancel",
+  promptStart: "/acp-prompt-start",
+  promptDone: "/acp-prompt-done",
 } as const;
 
 export interface WeChatAcpConfig {

--- a/src/config.ts
+++ b/src/config.ts
@@ -298,10 +298,18 @@ export function resolveCommandNames(
 }
 
 /**
- * Validate a `commandAliases` map. Aliases must be non-empty strings that
- * start with `/` and contain no whitespace (whitespace would break
- * command/argument parsing). Throws an `Error` describing the first
- * problem found.
+ * Validate a `commandAliases` map. Each key must be a known bridge
+ * command (see {@link BRIDGE_COMMANDS}). Aliases must be non-empty
+ * strings. Two alias styles are supported:
+ *
+ *  - Slash aliases (start with `/`) work like the built-in commands:
+ *    they match the command token and may be followed by arguments, so
+ *    they must not contain whitespace.
+ *  - Bare-phrase aliases (no leading `/`) match only when they equal the
+ *    entire message — useful for voice input (e.g. "取消"). They may
+ *    contain spaces.
+ *
+ * Throws an `Error` describing the first problem found.
  */
 export function validateCommandAliases(aliases: Record<string, string[]> | undefined): void {
   if (aliases === undefined) return;
@@ -327,11 +335,10 @@ export function validateCommandAliases(aliases: Record<string, string[]> | undef
         throw new Error(`commandAliases[${JSON.stringify(canonical)}] contains an empty alias.`);
       }
       const trimmed = alias.trim();
-      if (!trimmed.startsWith("/")) {
-        throw new Error(`commandAliases: alias ${JSON.stringify(trimmed)} must start with "/".`);
-      }
-      if (/\s/.test(trimmed)) {
-        throw new Error(`commandAliases: alias ${JSON.stringify(trimmed)} must not contain whitespace.`);
+      if (trimmed.startsWith("/") && /\s/.test(trimmed)) {
+        throw new Error(
+          `commandAliases: slash alias ${JSON.stringify(trimmed)} must not contain whitespace.`,
+        );
       }
       if (knownCommands.has(trimmed) && trimmed !== canonical) {
         throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,14 @@ export type {
 } from "./config.js";
 export {
 	BUILT_IN_AGENTS,
+	BRIDGE_COMMANDS,
 	defaultConfig,
 	defaultStorageDir,
 	listBuiltInAgents,
 	parseAgentCommand,
 	resolveAgentSelection,
+	resolveCommandAliases,
+	resolveCommandNames,
+	validateCommandAliases,
 	validateInstanceName,
 } from "./config.js";


### PR DESCRIPTION
Implements #34: customizable aliases for bridge slash commands.

## What

Adds a `commandAliases` config map (in the `--config` JSON file) that lets users map the bridge-level slash commands to one or more custom aliases of their choice. The original built-in names always keep working as a fallback.

```json
{
  "commandAliases": {
    "/acp-cancel": ["/cancel", "/取消"],
    "/acp-config": ["/config", "/设置"]
  }
}
```

With this config, sending `/取消` cancels the current turn (same as `/acp-cancel`), `/取消 all` works like `/acp-cancel all`, and `/设置 set <id> <value>` works like `/acp-config set ...`.

> Note: the bridge currently only ships the self-handled commands `/acp-config` and `/acp-cancel` (the `/start` / `/done` names in the issue are illustrative). The alias mechanism is generic, so any future bridge command can be aliased by adding it to `BRIDGE_COMMANDS`.

## Why

- Users pick aliases that feel natural to them.
- Avoids conflicts with agent-level slash commands.
- Chinese aliases make the experience friendlier for Chinese-speaking users.

## How

- `src/config.ts`: new `BRIDGE_COMMANDS` constant, optional `commandAliases` field on `WeChatAcpConfig` (defaults to `{}`), and helpers `resolveCommandAliases`, `resolveCommandNames`, and `validateCommandAliases`.
- `src/bridge.ts`: command extraction now matches the canonical name **plus** any configured aliases; in-chat usage hints list the configured aliases.
- `bin/wechat-acp.ts`: merges `commandAliases` from the config file and validates it at startup (clean error + exit on malformed config).
- README + CHANGELOG updated.

## Validation

Aliases are validated at startup and rejected if a key is not a known bridge command, or an alias is empty, doesn't start with `/`, contains whitespace, collides with a built-in command name, or maps to more than one command.

## Testing

- `npm run build` (tsc) passes.
- Manually verified `resolveCommandNames` / `validateCommandAliases` behavior and end-to-end CLI rejection of malformed configs and acceptance of valid configs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
