### PR TITLE
fix: stop silently dropping final reply on transient WeChat send failure

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -24,7 +24,20 @@ export class WeChatAcpClient implements acp.Client {
   private thoughtChunks: string[] = [];
   private opts: WeChatAcpClientOpts;
   private lastTypingAt = 0;
+  private producedMessageThisTurn = false;
   private static readonly TYPING_INTERVAL_MS = 5_000;
+  private static readonly SEND_MAX_ATTEMPTS = 3;
+  private static readonly SEND_RETRY_BASE_MS = 300;
+
+  /** Whether the agent emitted any non-empty message content during the current turn. */
+  get hasProducedMessage(): boolean {
+    return this.producedMessageThisTurn;
+  }
+
+  /** Reset per-turn delivery state. Call at the start of each prompt. */
+  newTurn(): void {
+    this.producedMessageThisTurn = false;
+  }
 
   constructor(opts: WeChatAcpClientOpts) {
     this.opts = opts;
@@ -70,6 +83,9 @@ export class WeChatAcpClient implements acp.Client {
         await this.maybeFlushThoughts();
         if (update.content.type === "text") {
           this.chunks.push(update.content.text);
+          if (update.content.text.trim()) {
+            this.producedMessageThisTurn = true;
+          }
         }
         // Throttle typing indicators
         await this.maybeSendTyping();
@@ -111,6 +127,7 @@ export class WeChatAcpClient implements acp.Client {
                 for (const l of diff.newText.split("\n")) lines.push(`+ ${l}`);
               }
               this.chunks.push("\n```diff\n" + lines.join("\n") + "\n```\n");
+              this.producedMessageThisTurn = true;
             }
           }
         }
@@ -169,12 +186,13 @@ export class WeChatAcpClient implements acp.Client {
     if (this.thoughtChunks.length === 0) return;
     const thoughtText = this.thoughtChunks.join("");
     this.thoughtChunks = [];
-    if (thoughtText.trim()) {
-      try {
-        await this.opts.onThoughtFlush(`💭 [Thinking]\n${thoughtText}`);
-      } catch {
-        // best effort
-      }
+    if (!thoughtText.trim()) return;
+    const ok = await this.sendWithRetry(
+      () => this.opts.onThoughtFlush(`💭 [Thinking]\n${thoughtText}`),
+      "thought",
+    );
+    if (!ok) {
+      this.opts.log(`[flush] dropping ${thoughtText.length} chars of thought after retries`);
     }
   }
 
@@ -187,14 +205,44 @@ export class WeChatAcpClient implements acp.Client {
   private async maybeFlushMessage(): Promise<void> {
     if (this.chunks.length === 0) return;
     const text = this.chunks.join("");
-    this.chunks = [];
-    if (text.trim()) {
+    if (!text.trim()) {
+      this.chunks = [];
+      return;
+    }
+    const ok = await this.sendWithRetry(() => this.opts.onMessageFlush(text), "message");
+    if (ok) {
+      this.chunks = [];
+    } else {
+      // Keep the buffer intact so the final flush() returns this text and the
+      // caller (session.ts) re-attempts delivery via onReply, which surfaces
+      // any failure to the user. This prevents the final answer from being
+      // silently dropped while intermediate thoughts were already delivered.
+      this.opts.log(
+        `[flush] message send failed after retries; retaining ${text.length} chars for final flush`,
+      );
+    }
+  }
+
+  /**
+   * Send with bounded retries and exponential-ish backoff. Returns true on
+   * success, false if all attempts failed (logging each failure so transient
+   * WeChat send errors are surfaced instead of silently swallowed).
+   */
+  private async sendWithRetry(send: () => Promise<void>, label: string): Promise<boolean> {
+    for (let attempt = 1; attempt <= WeChatAcpClient.SEND_MAX_ATTEMPTS; attempt++) {
       try {
-        await this.opts.onMessageFlush(text);
-      } catch {
-        // best effort
+        await send();
+        return true;
+      } catch (err) {
+        this.opts.log(
+          `[flush] ${label} send failed (attempt ${attempt}/${WeChatAcpClient.SEND_MAX_ATTEMPTS}): ${String(err)}`,
+        );
+        if (attempt < WeChatAcpClient.SEND_MAX_ATTEMPTS) {
+          await new Promise((r) => setTimeout(r, WeChatAcpClient.SEND_RETRY_BASE_MS * attempt));
+        }
       }
     }
+    return false;
   }
 
   private async maybeSendTyping(): Promise<void> {

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -224,9 +224,10 @@ export class WeChatAcpClient implements acp.Client {
   }
 
   /**
-   * Send with bounded retries and exponential-ish backoff. Returns true on
-   * success, false if all attempts failed (logging each failure so transient
-   * WeChat send errors are surfaced instead of silently swallowed).
+   * Send with bounded retries and linear backoff (`SEND_RETRY_BASE_MS *
+   * attempt`). Returns true on success, false if all attempts failed
+   * (logging each failure so transient WeChat send errors are surfaced
+   * instead of silently swallowed).
    */
   private async sendWithRetry(send: () => Promise<void>, label: string): Promise<boolean> {
     for (let attempt = 1; attempt <= WeChatAcpClient.SEND_MAX_ATTEMPTS; attempt++) {

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -11,6 +11,27 @@ import { WeChatAcpClient } from "./client.js";
 import { spawnAgent, killAgent, type AgentProcessInfo } from "./agent-manager.js";
 import { trackEvent, trackException, hashUserId } from "../telemetry/index.js";
 
+/**
+ * Build a short, user-friendly notice for a turn that ended without the
+ * agent producing any textual reply. The raw `stopReason` enum is kept
+ * out of the user-facing text (it is still logged) so users see a
+ * meaningful message rather than an internal token like `max_tokens`.
+ */
+function emptyTurnNotice(stopReason: acp.StopReason | undefined): string {
+  switch (stopReason) {
+    case "max_tokens":
+      return "ℹ️ The agent stopped at its output length limit before sending a reply. Try a more specific or shorter request.";
+    case "max_turn_requests":
+      return "ℹ️ The agent reached its tool-call limit before sending a reply. Try again or narrow the task.";
+    case "refusal":
+      return "ℹ️ The agent declined to respond to this request.";
+    case "cancelled":
+      return "ℹ️ The request was cancelled before the agent sent a reply.";
+    default:
+      return "ℹ️ The agent finished without sending a reply. Try rephrasing your request.";
+  }
+}
+
 export interface PendingMessage {
   prompt: acp.ContentBlock[];
   contextToken: string;
@@ -323,7 +344,7 @@ export class SessionManager {
             await this.opts.onReply(
               session.userId,
               pending.contextToken,
-              `(no reply produced — agent stopped: ${String(result.stopReason)})`,
+              emptyTurnNotice(result.stopReason),
             );
           }
         } catch (err) {

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -272,6 +272,7 @@ export class SessionManager {
 
         // Reset chunks for the new turn
         await session.client.flush();
+        session.client.newTurn();
 
         const promptStartedAt = Date.now();
         try {
@@ -312,6 +313,18 @@ export class SessionManager {
           // Send reply back to WeChat
           if (replyText.trim()) {
             await this.opts.onReply(session.userId, pending.contextToken, replyText);
+          } else if (!session.client.hasProducedMessage) {
+            // The turn ended without the agent ever producing a textual reply
+            // (e.g. it stopped after thoughts or a tool call). Surface a minimal
+            // notice so a turn never ends with zero user-facing output.
+            this.opts.log(
+              `[${session.userId}] Empty reply with no message produced (${result.stopReason}); sending fallback notice`,
+            );
+            await this.opts.onReply(
+              session.userId,
+              pending.contextToken,
+              `(no reply produced — agent stopped: ${String(result.stopReason)})`,
+            );
           }
         } catch (err) {
           completionError = err;


### PR DESCRIPTION
## Summary
Fixes #36 — sometimes the user sees the agent's `💭 [Thinking]` message but never receives the final answer.

## Root cause
The agent streams `thoughts → message chunks → (trailing thought/tool_call)`. That trailing event triggers `maybeFlushMessage()`, which sends the **final** answer as an intermediate segment. In `src/acp/client.ts`, both flush helpers cleared the buffer and then wrapped the WeChat send in an empty `catch {}`. So a transient `onMessageFlush` failure was silently swallowed and the buffer was already gone — `flush()` returned empty and `session.ts` skipped the final `onReply`. The earlier-sent thoughts survived, producing "thinking shown, answer lost".

## Changes
**`src/acp/client.ts`**
- Add `sendWithRetry(send, label)`: bounded retries (3) with backoff, logging each failure instead of swallowing it.
- `maybeFlushThoughts` / `maybeFlushMessage` use it. On message-send failure the buffer is **retained** (not cleared), so the final `flush()` returns the text and `session.ts` re-attempts delivery via `onReply` (which surfaces failures to the user). This favors at-least-once delivery over silent loss.
- Track `producedMessageThisTurn` (exposed via `hasProducedMessage`, reset via `newTurn()`).

**`src/acp/session.ts`**
- Call `client.newTurn()` at prompt start.
- When `replyText` is empty **and** no message was produced this turn, send a small fallback notice so a turn never ends with zero user-facing output. A successful mid-stream flush leaves `replyText` legitimately empty and does **not** trigger a spurious notice.

## Tradeoffs
Retaining the buffer can, in the rare ambiguous case (WeChat accepted but the call threw), cause a duplicate message. This is an intentional choice: a duplicate is preferable to silently losing the final answer.

## Testing
- `npm run build` (tsc) passes with no errors.