### PR TITLE
fix: deliver intermediate WeChat messages exactly once, in order, and without dropping the tail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "tsx": "^4.22.3",
         "typescript": "^5.5.0"
       },
       "engines": {
@@ -150,6 +151,448 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@microsoft/applicationinsights-web-snippet": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.0.1.tgz",
@@ -161,7 +604,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -372,7 +814,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -524,7 +965,6 @@
       "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
       "integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       }
@@ -545,6 +985,63 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "shimmer": "^1.2.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -647,6 +1144,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "build": "tsc",
     "prepack": "npm run build",
     "start": "node dist/bin/wechat-acp.js",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "node --import tsx/esm --test tests/**/*.ts"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.16.1",
@@ -32,6 +33,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "tsx": "^4.22.3",
     "typescript": "^5.5.0"
   },
   "engines": {

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -25,6 +25,9 @@ export class WeChatAcpClient implements acp.Client {
   private opts: WeChatAcpClientOpts;
   private lastTypingAt = 0;
   private producedMessageThisTurn = false;
+  // Promise chain serializing onMessageFlush calls so concurrent boundary events
+  // cannot interleave sends (e.g. chunk B reaching WeChat before chunk A).
+  private messageFlushChain: Promise<void> = Promise.resolve();
   private static readonly TYPING_INTERVAL_MS = 5_000;
   private static readonly SEND_MAX_ATTEMPTS = 3;
   private static readonly SEND_RETRY_BASE_MS = 300;
@@ -176,6 +179,9 @@ export class WeChatAcpClient implements acp.Client {
   /** Get accumulated text and reset the buffer. Also flushes any remaining thoughts. */
   async flush(): Promise<string> {
     await this.maybeFlushThoughts();
+    // Drain any in-flight sends (queued by maybeFlushMessage) before reading
+    // the buffer so a retried-and-restored flush cannot race with this read.
+    await this.messageFlushChain.catch(() => {});
     const text = this.chunks.join("");
     this.chunks = [];
     this.lastTypingAt = 0;
@@ -209,22 +215,39 @@ export class WeChatAcpClient implements acp.Client {
       this.chunks = [];
       return;
     }
-    // Clear the buffer synchronously BEFORE awaiting the send so that any
-    // concurrent sessionUpdate calls (the ACP SDK fires notifications without
-    // awaiting handlers) see an empty buffer and skip the flush instead of
-    // re-sending the same text. New chunks arriving during the send will be
-    // appended to the now-empty array and flushed at the next boundary.
+    // Clear the buffer synchronously BEFORE awaiting so that any concurrent
+    // sessionUpdate calls (the ACP SDK fires notifications without awaiting
+    // handlers) see an empty buffer and skip the flush instead of re-sending
+    // the same text. New chunks arriving during the send are appended to the
+    // now-empty array and flushed at the next boundary.
     this.chunks = [];
-    const ok = await this.sendWithRetry(() => this.opts.onMessageFlush(text), "message");
-    if (!ok) {
-      // Send failed after all retries. Prepend the unsent text back so the
-      // final flush() returns it and session.ts re-attempts via onReply (which
-      // surfaces failure to the user). Any new chunks appended during the
-      // failed send attempts are preserved after the restored text.
-      this.chunks = [text, ...this.chunks];
-      this.opts.log(
-        `[flush] message send failed after retries; retaining ${text.length} chars for final flush`,
-      );
+
+    // Acquire a send slot using a simple mutex chain: each caller saves the
+    // current tail of the chain, replaces it with a new unresolved promise,
+    // and awaits the old tail before sending. This guarantees strict FIFO
+    // ordering — chunk A always reaches WeChat before chunk B even when both
+    // boundary events fire nearly simultaneously.
+    const prev = this.messageFlushChain;
+    let resolve!: () => void;
+    this.messageFlushChain = new Promise<void>((r) => {
+      resolve = r;
+    });
+    await prev.catch(() => {});
+
+    try {
+      const ok = await this.sendWithRetry(() => this.opts.onMessageFlush(text), "message");
+      if (!ok) {
+        // Send failed after all retries. Prepend the unsent text back so the
+        // final flush() returns it and session.ts re-attempts via onReply (which
+        // surfaces failure to the user). Any new chunks appended during the
+        // failed send attempts are preserved after the restored text.
+        this.chunks = [text, ...this.chunks];
+        this.opts.log(
+          `[flush] message send failed after retries; retaining ${text.length} chars for final flush`,
+        );
+      }
+    } finally {
+      resolve();
     }
   }
 

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -209,14 +209,19 @@ export class WeChatAcpClient implements acp.Client {
       this.chunks = [];
       return;
     }
+    // Clear the buffer synchronously BEFORE awaiting the send so that any
+    // concurrent sessionUpdate calls (the ACP SDK fires notifications without
+    // awaiting handlers) see an empty buffer and skip the flush instead of
+    // re-sending the same text. New chunks arriving during the send will be
+    // appended to the now-empty array and flushed at the next boundary.
+    this.chunks = [];
     const ok = await this.sendWithRetry(() => this.opts.onMessageFlush(text), "message");
-    if (ok) {
-      this.chunks = [];
-    } else {
-      // Keep the buffer intact so the final flush() returns this text and the
-      // caller (session.ts) re-attempts delivery via onReply, which surfaces
-      // any failure to the user. This prevents the final answer from being
-      // silently dropped while intermediate thoughts were already delivered.
+    if (!ok) {
+      // Send failed after all retries. Prepend the unsent text back so the
+      // final flush() returns it and session.ts re-attempts via onReply (which
+      // surfaces failure to the user). Any new chunks appended during the
+      // failed send attempts are preserved after the restored text.
+      this.chunks = [text, ...this.chunks];
       this.opts.log(
         `[flush] message send failed after retries; retaining ${text.length} chars for final flush`,
       );

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -6,6 +6,7 @@
  */
 
 import type * as acp from "@agentclientprotocol/sdk";
+import crypto from "node:crypto";
 import { login, loadToken, type TokenData } from "./weixin/auth.js";
 import { startMonitor } from "./weixin/monitor.js";
 import { sendTextMessage, splitText } from "./weixin/send.js";
@@ -28,6 +29,8 @@ const BUFFER_DONE_COMMAND = BRIDGE_COMMANDS.promptDone;
 const TEXT_CHUNK_LIMIT = 4000;
 const BUFFER_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const BUFFER_MAX_BLOCKS = 50;
+const SEGMENT_SEND_MAX_ATTEMPTS = 3;
+const SEGMENT_SEND_RETRY_BASE_MS = 300;
 
 /**
  * Minimum spacing between two consecutive outbound text messages to the
@@ -609,30 +612,71 @@ export class WeChatAcpBridge {
   private async deliverReply(userId: string, contextToken: string, text: string): Promise<void> {
     const segments = splitText(text, TEXT_CHUNK_LIMIT);
     const startedAt = Date.now();
+    let segmentsSent = 0;
+    let anyFailed = false;
 
-    try {
-      for (const segment of segments) {
-        await this.paceConsecutiveSend(userId);
-        await sendTextMessage(userId, segment, {
-          baseUrl: this.tokenData!.baseUrl,
-          token: this.tokenData!.token,
-          contextToken,
-        });
+    for (const segment of segments) {
+      // Generate one stable idempotency key per segment *before* the retry
+      // loop so that all attempts for the same segment reuse the same
+      // client_id. The iLink gateway de-duplicates by client_id, so a retry
+      // after a transient hard error (connection reset, 5xx) will not produce
+      // a duplicate message even if the first attempt was already received.
+      const segmentClientId = `wechat-acp-${crypto.randomUUID()}`;
+      let sent = false;
+
+      for (let attempt = 1; attempt <= SEGMENT_SEND_MAX_ATTEMPTS; attempt++) {
+        try {
+          await this.paceConsecutiveSend(userId);
+          await sendTextMessage(
+            userId,
+            segment,
+            {
+              baseUrl: this.tokenData!.baseUrl,
+              token: this.tokenData!.token,
+              contextToken,
+            },
+            segmentClientId,
+          );
+          sent = true;
+          break;
+        } catch (err) {
+          trackException(err, "reply.segment", hashUserId(userId));
+          if (attempt < SEGMENT_SEND_MAX_ATTEMPTS) {
+            await new Promise((r) => setTimeout(r, SEGMENT_SEND_RETRY_BASE_MS * attempt));
+          }
+        }
       }
-      trackEvent(
-        "reply.sent",
-        {
-          userIdHash: hashUserId(userId),
-          segments: segments.length,
-          chars: text.length,
-          durationMs: Date.now() - startedAt,
-        },
+
+      if (sent) {
+        segmentsSent++;
+      } else {
+        // Log the drop but continue — a single failed segment must not
+        // prevent the remaining segments from being delivered.
+        anyFailed = true;
+      }
+    }
+
+    if (anyFailed) {
+      trackException(
+        new Error(
+          `deliverReply: ${segments.length - segmentsSent}/${segments.length} segment(s) failed to send after retries`,
+        ),
+        "reply",
         hashUserId(userId),
       );
-    } catch (err) {
-      trackException(err, "reply", hashUserId(userId));
-      throw err;
     }
+
+    trackEvent(
+      "reply.sent",
+      {
+        userIdHash: hashUserId(userId),
+        segments: segments.length,
+        segmentsSent,
+        chars: text.length,
+        durationMs: Date.now() - startedAt,
+      },
+      hashUserId(userId),
+    );
 
     // Cancel typing indicator after reply is sent
     this.cancelTypingIndicator(userId, contextToken).catch(() => {});

--- a/src/weixin/send.ts
+++ b/src/weixin/send.ts
@@ -16,20 +16,25 @@ export async function sendTextMessage(
   to: string,
   text: string,
   opts: WeixinSendOpts,
+  clientId?: string,
+  sendFn: typeof sendMessage = sendMessage,
 ): Promise<string> {
   if (!opts.contextToken) {
     throw new Error("contextToken is required to send a message");
   }
 
-  const clientId = `wechat-acp-${crypto.randomUUID()}`;
-  await sendMessage({
+  // Generate a stable idempotency key for this logical send. Callers that
+  // retry should pass the same clientId so the iLink gateway de-duplicates
+  // repeated deliveries of the same message segment.
+  const id = clientId ?? `wechat-acp-${crypto.randomUUID()}`;
+  await sendFn({
     baseUrl: opts.baseUrl,
     token: opts.token,
     body: {
       msg: {
         from_user_id: "",
         to_user_id: to,
-        client_id: clientId,
+        client_id: id,
         message_type: MessageType.BOT,
         message_state: MessageState.FINISH,
         context_token: opts.contextToken,
@@ -37,7 +42,7 @@ export async function sendTextMessage(
       },
     },
   });
-  return clientId;
+  return id;
 }
 
 /**

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for WeChatAcpClient message-flush behaviour.
+ *
+ * Verifies that intermediate status messages (flushed at tool_call /
+ * thought boundaries) are delivered exactly once even when multiple
+ * sessionUpdate notifications arrive concurrently – which happens because
+ * the ACP SDK fires notification handlers without awaiting them.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { WeChatAcpClient } from "../src/acp/client.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal WeChatAcpClient with controllable callbacks. */
+function makeClient(opts: {
+  onMessageFlush?: (text: string) => Promise<void>;
+  onThoughtFlush?: (text: string) => Promise<void>;
+  sendDelay?: number;
+}): WeChatAcpClient {
+  const { sendDelay = 0 } = opts;
+  const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+  return new WeChatAcpClient({
+    sendTyping: async () => {},
+    onThoughtFlush:
+      opts.onThoughtFlush ??
+      (async () => {
+        if (sendDelay) await delay(sendDelay);
+      }),
+    onMessageFlush:
+      opts.onMessageFlush ??
+      (async () => {
+        if (sendDelay) await delay(sendDelay);
+      }),
+    log: () => {},
+    showThoughts: false,
+  });
+}
+
+async function emitMessageChunk(client: WeChatAcpClient, text: string): Promise<void> {
+  await client.sessionUpdate({
+    update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text } },
+  } as never);
+}
+
+async function emitToolCall(client: WeChatAcpClient): Promise<void> {
+  await client.sessionUpdate({
+    update: { sessionUpdate: "tool_call", title: "test-tool", status: "started" },
+  } as never);
+}
+
+async function emitThoughtChunk(client: WeChatAcpClient, text = "thinking…"): Promise<void> {
+  await client.sessionUpdate({
+    update: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text } },
+  } as never);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("single intermediate message is flushed exactly once (sequential)", async () => {
+  const calls: string[] = [];
+  const client = makeClient({ onMessageFlush: async (t) => { calls.push(t); } });
+
+  await emitMessageChunk(client, "status update");
+  await emitToolCall(client);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0], "status update");
+});
+
+test("concurrent tool_call events send the buffered message exactly once", async () => {
+  /**
+   * The ACP SDK fires notification handlers without awaiting them, so two
+   * tool_call notifications can both reach maybeFlushMessage while the first
+   * send is still in-progress. Regression: before the fix, both would see
+   * non-empty chunks and each would trigger an independent send (triple-send).
+   */
+  const calls: string[] = [];
+  const client = makeClient({
+    onMessageFlush: async (text) => {
+      calls.push(text);
+      await new Promise<void>((r) => setTimeout(r, 20));
+    },
+  });
+
+  await emitMessageChunk(client, "intermediate status");
+
+  // Fire two concurrent boundary events without awaiting between them.
+  const flush1 = emitToolCall(client);
+  const flush2 = emitToolCall(client);
+  await Promise.all([flush1, flush2]);
+
+  assert.equal(calls.length, 1, `expected 1 send, got ${calls.length}: ${JSON.stringify(calls)}`);
+  assert.equal(calls[0], "intermediate status");
+});
+
+test("three concurrent boundary events send the message exactly once", async () => {
+  const calls: string[] = [];
+  const client = makeClient({
+    onMessageFlush: async (text) => {
+      calls.push(text);
+      await new Promise<void>((r) => setTimeout(r, 30));
+    },
+  });
+
+  await emitMessageChunk(client, "部分搜索结果像是媒体汇总和平台片单混在一起");
+
+  const p1 = emitToolCall(client);
+  const p2 = emitThoughtChunk(client, "thinking");
+  const p3 = emitToolCall(client);
+  await Promise.all([p1, p2, p3]);
+
+  assert.equal(
+    calls.length,
+    1,
+    `intermediate status message sent ${calls.length}x instead of once`,
+  );
+});
+
+test("final answer is delivered after intermediate flush clears the buffer", async () => {
+  const messageCalls: string[] = [];
+  const client = makeClient({
+    onMessageFlush: async (t) => { messageCalls.push(t); },
+  });
+  client.newTurn();
+
+  await emitMessageChunk(client, "searching…");
+  await emitToolCall(client); // flushes "searching…"
+
+  await emitMessageChunk(client, "here is the answer");
+  const replyText = await client.flush();
+
+  assert.equal(messageCalls.length, 1);
+  assert.equal(messageCalls[0], "searching…");
+  assert.equal(replyText, "here is the answer");
+});
+
+test("failed send retains buffer so final flush delivers the message", async () => {
+  const client = makeClient({
+    onMessageFlush: async () => { throw new Error("WeChat API error"); },
+  });
+
+  await emitMessageChunk(client, "status");
+  await emitToolCall(client); // will fail; buffer should be retained
+
+  const replyText = await client.flush();
+  assert.equal(replyText, "status");
+});

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -152,3 +152,38 @@ test("failed send retains buffer so final flush delivers the message", async () 
   const replyText = await client.flush();
   assert.equal(replyText, "status");
 });
+
+test("two sequential flushes are delivered in order (second waits for first)", async () => {
+  /**
+   * Scenario: chunk A is flushed at boundary-1, then chunk B is flushed at
+   * boundary-2 while A's send is still awaiting. The mutex chain must ensure
+   * A completes before B starts, so WeChat always receives A before B.
+   */
+  const order: string[] = [];
+  let releaseA!: () => void;
+  const client = makeClient({
+    onMessageFlush: async (text) => {
+      if (text === "chunk A") {
+        // Simulate a slow first send
+        await new Promise<void>((r) => {
+          releaseA = r;
+        });
+      }
+      order.push(text);
+    },
+  });
+
+  await emitMessageChunk(client, "chunk A");
+  // Fire boundary-1 without awaiting so it blocks on the slow send
+  const p1 = emitToolCall(client);
+
+  await emitMessageChunk(client, "chunk B");
+  // Fire boundary-2 — must queue behind A
+  const p2 = emitToolCall(client);
+
+  // Release A's send
+  releaseA();
+  await Promise.all([p1, p2]);
+
+  assert.deepEqual(order, ["chunk A", "chunk B"], "second message must arrive after first");
+});

--- a/tests/send.test.ts
+++ b/tests/send.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for sendTextMessage idempotency-key behaviour.
+ *
+ * Verifies that when a caller provides an explicit clientId, all retries for
+ * the same logical message reuse that id so the iLink gateway can de-duplicate
+ * repeated deliveries of the same message.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { sendTextMessage } from "../src/weixin/send.js";
+import type { sendMessage as SendMessageFn } from "../src/weixin/api.js";
+
+type SendMessageArgs = Parameters<typeof SendMessageFn>[0];
+
+/** Build a fake sendFn that records the client_ids it is called with. */
+function makeFakeSendFn(capturedIds: string[], throws?: () => Error): typeof SendMessageFn {
+  let callCount = 0;
+  return async (args: SendMessageArgs) => {
+    capturedIds.push(args.body.msg.client_id);
+    callCount++;
+    if (throws && callCount === 1) throw throws();
+  };
+}
+
+const baseOpts = { baseUrl: "http://fake", contextToken: "ctx" };
+
+test("sendTextMessage uses provided clientId instead of generating a new UUID", async () => {
+  const capturedIds: string[] = [];
+  const fakeSend = makeFakeSendFn(capturedIds);
+
+  const stableId = "wechat-acp-test-stable-id";
+  const returnedId = await sendTextMessage("user123", "hello", baseOpts, stableId, fakeSend);
+
+  assert.equal(capturedIds.length, 1);
+  assert.equal(capturedIds[0], stableId, "must use the provided clientId");
+  assert.equal(returnedId, stableId, "returned id must match the provided clientId");
+});
+
+test("sendTextMessage generates a fresh UUID when no clientId is provided", async () => {
+  const capturedIds: string[] = [];
+  const fakeSend = makeFakeSendFn(capturedIds);
+
+  const returnedId = await sendTextMessage("user123", "hello", baseOpts, undefined, fakeSend);
+
+  assert.equal(capturedIds.length, 1);
+  assert.equal(capturedIds[0], returnedId, "sent id must match the returned id");
+  assert.match(returnedId, /^wechat-acp-[0-9a-f-]{36}$/, "must be a UUID");
+});
+
+test("same clientId on retry means gateway receives identical client_id both times", async () => {
+  /**
+   * Simulates: first attempt throws (connection reset / 5xx); caller retries
+   * with the SAME clientId. The iLink gateway de-duplicates by client_id, so
+   * even if the first attempt was already received, the retry is a no-op.
+   */
+  const capturedIds: string[] = [];
+  let callCount = 0;
+  const fakeSend: typeof SendMessageFn = async (args: SendMessageArgs) => {
+    capturedIds.push(args.body.msg.client_id);
+    callCount++;
+    if (callCount === 1) {
+      throw new Error("connection reset");
+    }
+  };
+
+  const stableId = "wechat-acp-idempotent-key";
+
+  // First attempt throws
+  await assert.rejects(
+    () => sendTextMessage("user123", "hello", baseOpts, stableId, fakeSend),
+    /connection reset/,
+  );
+  // Retry — reuse same stableId
+  await sendTextMessage("user123", "hello", baseOpts, stableId, fakeSend);
+
+  assert.equal(callCount, 2, "two HTTP calls were made");
+  assert.deepEqual(
+    capturedIds,
+    [stableId, stableId],
+    "both calls must carry the same client_id so the gateway can de-duplicate",
+  );
+});


### PR DESCRIPTION
## Summary

Fixes three related delivery defects in the WeChat send path, all surfaced by the #37 / #39 changes. The first commit fixes the triple-send regression; the second adds idempotent retries, strict ordering, and dropped-tail handling (addressing the review feedback on this PR).

Tracked in yuwzho/agent-brain#16.

---

## 1. Triple-send of intermediate messages (regression from #37)

**Root cause.** The ACP SDK processes notifications fire-and-forget — `#processMessage(message)` is called **without `await`** in the read loop — so multiple `sessionUpdate` calls from back-to-back `tool_call` / `agent_thought_chunk` events run concurrently. PR #37 moved `this.chunks = []` to **after** the async `sendWithRetry` call, so every concurrent `maybeFlushMessage` invocation saw the same non-empty `chunks` and independently fired a full send → 3× duplicate. (`maybeFlushThoughts` was unaffected — it already cleared before its `await`.)

**Fix.** Clear `this.chunks` **synchronously before** the `await`, matching `maybeFlushThoughts`. On total retry failure the unsent text is prepended back into `chunks` (preserving chunks that arrived during the retries) so the final `flush()` still delivers via `onReply` — #37's at-least-once guarantee is preserved.

## 2. Out-of-order delivery

**Root cause.** Even with the buffer cleared, separate `maybeFlushMessage` calls could still run concurrently: if a later flush (chunk B) raced an earlier one (chunk A) still awaiting its send, B could reach WeChat first.

**Fix.** `maybeFlushMessage` now serializes sends through a `messageFlushChain` promise-mutex — each flush saves the chain tail, installs a new unresolved promise, and `await`s the prior tail before sending (strict FIFO). `flush()` drains the chain before reading the buffer so a retried-and-restored flush can't race the final read.

## 3. Idempotent retries (no duplicates) + dropped tail

**Where sends go.** Each send is one HTTPS POST to the Tencent **iLink cloud gateway** (`ilink/bot/sendmessage`); `client_id` is that gateway's idempotency key.

**Duplicate-on-retry root cause.** `sendTextMessage` generated a **new** `client_id = wechat-acp-${randomUUID()}` on every call, so a retry after a transient hard error (connection reset / 5xx) — where the first attempt was actually already received — looked like a brand-new message to the gateway → duplicate.

**Dropped-tail root cause.** `deliverReply` sent segments in a loop with **no per-segment retry** and `throw` on the first failure, aborting the loop; the outer per-user chain swallowed the error (`.catch(() => {})`) → the remaining segments (the ending of long replies) were silently lost.

**Fix.**
- `sendTextMessage` accepts an optional stable `clientId`; `deliverReply` generates **one `client_id` per segment before its retry loop** so all attempts for a segment reuse it → the gateway de-duplicates retries instead of duplicating.
- `deliverReply` now does **bounded per-segment retry**; a single failed segment no longer aborts the rest; a final per-segment failure is **surfaced via telemetry** (`trackException`) instead of being silently swallowed.

## Tests

`tests/client.test.ts` (Node `node:test` + `tsx`):
- concurrent `tool_call` events send the buffered message exactly once
- three concurrent boundary events (exact reproduction) send the message exactly once
- failed send retains buffer so the final flush delivers the message
- two sequential flushes are delivered in order (second waits for first)

`tests/send.test.ts`:
- `sendTextMessage` uses the provided `clientId` instead of generating a new UUID
- `sendTextMessage` generates a fresh UUID when no `clientId` is provided
- the same `clientId` on retry means the gateway receives an identical `client_id` both times

`npm run build` is clean; CI runs `npm test` via the committed `package-lock.json` (adds `tsx` as a dev-only test loader — not shipped in the published package, which is `dist/` only).

---

_This PR is on the yuwzho fork, targeting upstream `formulahendry/wechat-acp` for merge (the original auto-created PR pointed at the fork's own `main` by mistake and was closed)._
