### PR TITLE
Hide ACP diffs by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Hide ACP file diffs by default. Use `--show-diffs` or `agent.showDiffs: true` to forward diffs to WeChat; `--hide-diffs` remains accepted as a deprecated no-op for compatibility.
+
 ## 0.7.1
 
 - Fix intermediate WeChat messages being delivered multiple times, out of order, or losing the trailing segments. Concurrent boundary flushes now go through a per-client mutex chain; each reply segment retries with a stable `client_id` so the iLink gateway de-duplicates; and a failed segment no longer aborts the remaining segments in the same reply (#41).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Hide ACP file diffs by default. Use `--show-diffs` or `agent.showDiffs: true` to forward diffs to WeChat; `--hide-diffs` remains accepted as a deprecated no-op for compatibility.
+- Hide ACP file diffs by default. Use `--show-diffs` or `agent.showDiffs: true` to forward diffs to WeChat.
 
 ## 0.7.1
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ Options:
 - `--inbox-dir <dir>`: directory where received binary files are saved (default: `<storage.dir>/inbox`). The agent sees the absolute saved path in the prompt and can read the file directly.
 - `--no-inbox`: do not save received files; the agent only sees a size notice.
 - `--hide-thoughts`: do not forward agent thinking to WeChat (default: forwarded)
-- `--hide-diffs`: do not forward ACP file diffs to WeChat (default: forwarded)
+- `--show-diffs`: forward ACP file diffs to WeChat (default: hidden)
+- `--hide-diffs`: deprecated no-op; diffs are hidden by default
 - `inject --text <text>`: enqueue a local text message for the running daemon
 - `-V, --version`: print version and exit
 - `-h, --help`: show help

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ Options:
 - `--no-inbox`: do not save received files; the agent only sees a size notice.
 - `--hide-thoughts`: do not forward agent thinking to WeChat (default: forwarded)
 - `--show-diffs`: forward ACP file diffs to WeChat (default: hidden)
-- `--hide-diffs`: deprecated no-op; diffs are hidden by default
 - `inject --text <text>`: enqueue a local text message for the running daemon
 - `-V, --version`: print version and exit
 - `-h, --help`: show help

--- a/bin/wechat-acp.ts
+++ b/bin/wechat-acp.ts
@@ -77,7 +77,6 @@ Options:
   --max-sessions <n>  Max concurrent user sessions (default: 10)
   --hide-thoughts     Do not forward agent thinking to WeChat (default: forwarded)
   --show-diffs        Forward ACP file diffs to WeChat (default: hidden)
-  --hide-diffs        Deprecated no-op; diffs are hidden by default
   --text <text>       Message text for "inject"
   --file <path>       Read injected message text from a file
   --to <target>       Injection target (default: ${DEFAULT_INJECTION_TARGET})
@@ -137,7 +136,6 @@ function parseArgs(argv: string[]): {
   injectContextToken?: string;
   hideThoughts: boolean;
   showDiffs: boolean;
-  hideDiffs: boolean;
   verbose: boolean;
   version: boolean;
   help: boolean;
@@ -148,7 +146,6 @@ function parseArgs(argv: string[]): {
     disableInbox: false,
     hideThoughts: false,
     showDiffs: false,
-    hideDiffs: false,
     verbose: false,
     version: false,
     help: false,
@@ -213,9 +210,6 @@ function parseArgs(argv: string[]): {
         break;
       case "--show-diffs":
         result.showDiffs = true;
-        break;
-      case "--hide-diffs":
-        result.hideDiffs = true;
         break;
       case "-v":
       case "--verbose":
@@ -497,7 +491,6 @@ async function main(): Promise<void> {
   if (args.maxSessions) config.session.maxConcurrentUsers = args.maxSessions;
   if (args.hideThoughts) config.agent.showThoughts = false;
   if (args.showDiffs) config.agent.showDiffs = true;
-  if (args.hideDiffs) config.agent.showDiffs = false;
   config.daemon.enabled = args.daemon;
 
   // Handle daemon mode

--- a/bin/wechat-acp.ts
+++ b/bin/wechat-acp.ts
@@ -76,7 +76,8 @@ Options:
                       Use 0 to disable idle cleanup
   --max-sessions <n>  Max concurrent user sessions (default: 10)
   --hide-thoughts     Do not forward agent thinking to WeChat (default: forwarded)
-  --hide-diffs        Do not forward ACP file diffs to WeChat (default: forwarded)
+  --show-diffs        Forward ACP file diffs to WeChat (default: hidden)
+  --hide-diffs        Deprecated no-op; diffs are hidden by default
   --text <text>       Message text for "inject"
   --file <path>       Read injected message text from a file
   --to <target>       Injection target (default: ${DEFAULT_INJECTION_TARGET})
@@ -135,6 +136,7 @@ function parseArgs(argv: string[]): {
   injectTo?: string;
   injectContextToken?: string;
   hideThoughts: boolean;
+  showDiffs: boolean;
   hideDiffs: boolean;
   verbose: boolean;
   version: boolean;
@@ -145,6 +147,7 @@ function parseArgs(argv: string[]): {
     daemon: false,
     disableInbox: false,
     hideThoughts: false,
+    showDiffs: false,
     hideDiffs: false,
     verbose: false,
     version: false,
@@ -207,6 +210,9 @@ function parseArgs(argv: string[]): {
         break;
       case "--hide-thoughts":
         result.hideThoughts = true;
+        break;
+      case "--show-diffs":
+        result.showDiffs = true;
         break;
       case "--hide-diffs":
         result.hideDiffs = true;
@@ -490,6 +496,7 @@ async function main(): Promise<void> {
   }
   if (args.maxSessions) config.session.maxConcurrentUsers = args.maxSessions;
   if (args.hideThoughts) config.agent.showThoughts = false;
+  if (args.showDiffs) config.agent.showDiffs = true;
   if (args.hideDiffs) config.agent.showDiffs = false;
   config.daemon.enabled = args.daemon;
 

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -233,7 +233,7 @@ export class SessionManager {
       },
       log: (msg) => this.opts.log(`[${userId}] ${msg}`),
       showThoughts: this.opts.showThoughts,
-      showDiffs: this.opts.showDiffs ?? true,
+      showDiffs: this.opts.showDiffs ?? false,
     });
 
     const agentInfo = await spawnAgent({

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -131,7 +131,7 @@ export class WeChatAcpBridge {
       idleTimeoutMs: this.config.session.idleTimeoutMs,
       maxConcurrentUsers: this.config.session.maxConcurrentUsers,
       showThoughts: this.config.agent.showThoughts,
-      showDiffs: this.config.agent.showDiffs ?? true,
+      showDiffs: this.config.agent.showDiffs ?? false,
       log: this.log,
       onReply: (userId, contextToken, text) => this.sendReply(userId, contextToken, text),
       sendTyping: (userId, contextToken) => this.sendTypingIndicator(userId, contextToken),

--- a/src/config.ts
+++ b/src/config.ts
@@ -195,7 +195,7 @@ export function defaultConfig(opts?: { instance?: string }): WeChatAcpConfig {
       args: [],
       cwd: process.cwd(),
       showThoughts: true,
-      showDiffs: true,
+      showDiffs: false,
     },
     agents: { ...BUILT_IN_AGENTS },
     session: {


### PR DESCRIPTION
## Summary
- hide ACP file diffs by default
- add `--show-diffs` to opt into forwarding diffs
- keep `--hide-diffs` as a deprecated no-op for compatibility

## Validation
- npm test
- npm run build