### PR TITLE
feat: media sending, markdown filter, pair-code login, notifyStart/Stop, daemon self-healing, skill auto-injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Bridge WeChat direct messages to any ACP-compatible AI agent.
 - Auto-allow permission requests from the agent
 - Direct message only; group chats are ignored
 - Background daemon mode
+- Agent replies can send files/images to WeChat via `@sendfile` marker
 
 ## Requirements
 
@@ -413,6 +414,12 @@ Watch mode:
 ```bash
 npm run dev
 ```
+
+## Sending Files
+
+When the agent includes `@sendfile /absolute/path/to/file` in its reply, the bridge uploads the file to the WeChat CDN and delivers it as a file message instead of text. Multiple `@sendfile` markers in one reply are supported.
+
+The path must be absolute and readable by the bridge process. This mechanism needs the agent to know about it — for OpenCode, a skill is automatically injected via `OPENCODE_CONFIG_CONTENT` so the agent understands when and how to use `@sendfile`.
 
 ## Telemetry
 

--- a/bin/wechat-acp.ts
+++ b/bin/wechat-acp.ts
@@ -300,11 +300,17 @@ function daemonize(config: WeChatAcpConfig): void {
   const out = fs.openSync(logFile, "a");
   const err = fs.openSync(logFile, "a");
 
-  // Re-run ourselves with --no-daemon (internal flag) as a detached process
-  const args = process.argv.slice(1).filter((a) => a !== "--daemon");
-  const child = spawn(process.execPath, args, {
+  // Re-run ourselves as a detached child process.
+  // Preserve the original node flags (e.g. --import tsx/esm) so that
+  // TypeScript ESM imports continue to resolve in the child.
+  const childArgs = [
+    ...process.execArgv,
+    ...process.argv.slice(1).filter((a) => a !== "--daemon"),
+  ];
+  const child = spawn(process.execPath, childArgs, {
     detached: true,
     stdio: ["ignore", out, err],
+    cwd: process.cwd(),
     env: { ...process.env, WECHAT_ACP_DAEMON: "1" },
     windowsHide: true,
   });
@@ -513,36 +519,72 @@ async function main(): Promise<void> {
   const startedAt = Date.now();
 
   // Create and start bridge
-  const bridge = new WeChatAcpBridge(config, (msg) => {
+  const bridgeLog = (msg: string) => {
     const ts = new Date().toISOString().substring(11, 19);
     console.log(`[${ts}] ${msg}`);
-  });
+  };
+  let bridge = new WeChatAcpBridge(config, bridgeLog);
 
   // Handle graceful shutdown
-  const shutdown = async (reason: "signal" | "error" | "normal") => {
+  let shuttingDown = false;
+  const shutdown = (reason: "signal" | "error" | "normal") => {
+    if (shuttingDown) return;
+    shuttingDown = true;
     trackEvent("app.stop", { reason, uptimeSec: Math.round((Date.now() - startedAt) / 1000) });
-    await bridge.stop();
-    await shutdownTelemetry();
-    process.exit(reason === "error" ? 1 : 0);
+    bridge.stop().finally(() => {
+      shutdownTelemetry().finally(() => process.exit(reason === "error" ? 1 : 0));
+    });
   };
   process.on("SIGINT", () => void shutdown("signal"));
   process.on("SIGTERM", () => void shutdown("signal"));
 
-  try {
+  // In daemon mode, auto-restart the bridge on unexpected death
+  if (config.daemon.enabled && process.env.WECHAT_ACP_DAEMON) {
+    let restartCount = 0;
+    const maxRestarts = 10;
+    const restartCapMs = 60_000;
+
+    while (!shuttingDown) {
+      try {
+        await bridge.start({
+          forceLogin: args.forceLogin && restartCount === 0,
+          renderQrUrl: renderQrInTerminal,
+        });
+        // Normal shutdown (aborted signal), don't restart
+        break;
+      } catch (err) {
+        if (shuttingDown || (err as Error).message === "aborted") break;
+
+        restartCount++;
+        trackException(err, "daemon.crash");
+        console.error(`[daemon] bridge crashed (restart ${restartCount}/${maxRestarts}): ${String(err)}`);
+
+        // Kill the old bridge's agent processes before restarting
+        console.error(`[daemon] stopping old bridge before restart...`);
+        await bridge.stop();
+
+        if (restartCount >= maxRestarts) {
+          console.error("[daemon] max restarts reached, giving up");
+          process.exit(1);
+        }
+
+        const delay = Math.min(1000 * Math.pow(2, restartCount), restartCapMs);
+        console.error(`[daemon] restarting in ${delay / 1000}s...`);
+        await new Promise((r) => {
+          const t = setTimeout(r, delay);
+          process.on("SIGTERM", () => { clearTimeout(t); });
+          process.on("SIGINT", () => { clearTimeout(t); });
+        });
+
+        // Recreate bridge for fresh state
+        bridge = new WeChatAcpBridge(config, bridgeLog);
+      }
+    }
+  } else {
     await bridge.start({
       forceLogin: args.forceLogin,
       renderQrUrl: renderQrInTerminal,
     });
-  } catch (err) {
-    if ((err as Error).message === "aborted") {
-      // Normal shutdown
-    } else {
-      trackException(err, "main");
-      trackEvent("app.stop", { reason: "error", uptimeSec: Math.round((Date.now() - startedAt) / 1000) });
-      await shutdownTelemetry();
-      console.error(`Fatal: ${String(err)}`);
-      process.exit(1);
-    }
   }
 }
 

--- a/skills/wechat-bridge/SKILL.md
+++ b/skills/wechat-bridge/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: wechat-bridge
+description: Use when the user is interacting through WeChat and needs to send files, images, or understand WeChat-specific constraints. Triggers on requests like "send me the file", "发给我", "把文件发过来", file sharing, or WeChat message formatting.
+---
+
+# WeChat Bridge
+
+You are connected to the user through WeChat via an ACP bridge. The bridge
+relays your text output to WeChat and detects special markers for file sending.
+
+## Sending Files
+
+When the user asks you to send a file, image, or document, use the exact
+syntax below. The bridge will detect this marker, read the file, and upload it
+to WeChat.
+
+```
+@sendfile /absolute/path/to/file
+```
+
+**Rules:**
+- The path MUST be absolute (e.g. `/home/alint/kx-novel/chapters/ch_001.txt`)
+- The marker must appear on its own line or at the beginning of a line
+- Do NOT read the file and paste its content into the reply — use `@sendfile` instead
+- You may include a brief text message before or after the marker
+- Multiple `@sendfile` markers in one reply are supported (one per file)
+
+**File size limit:** The WeChat CDN accepts files up to 100 MB.
+
+## Message Format
+
+WeChat renders messages as plain text with limited formatting support:
+- Code fences and tables are preserved by the bridge's markdown filter
+- Bold (`**text**`) is preserved
+- Italic, headings, blockquotes, strikethrough, and images are stripped
+- Links are rendered as plain text (URLs are not clickable in WeChat)
+- Keep messages concise — long messages are split into 4000-character chunks
+
+## Available Bridge Commands
+
+These commands are handled by the bridge and never reach you:
+
+| Command | Purpose |
+|---------|---------|
+| `/acp-config` | View ACP session config options |
+| `/acp-config set <id> <value>` | Update a session config (model, mode, etc.) |
+| `/acp-cancel` | Cancel the current in-progress turn |
+| `/acp-cancel all` | Cancel + drop all queued messages |
+| `/acp-prompt-start` | Start multi-message buffering mode |
+| `/acp-prompt-done` | Submit all buffered messages at once |

--- a/src/acp/agent-manager.ts
+++ b/src/acp/agent-manager.ts
@@ -36,6 +36,7 @@ export async function spawnAgent(params: {
     cwd,
     env: { ...process.env, ...env },
     shell: useShell,
+    detached: true,
     windowsHide: true,
   });
 
@@ -96,11 +97,20 @@ export async function spawnAgent(params: {
 }
 
 export function killAgent(proc: ChildProcess): void {
-  if (!proc.killed) {
+  if (proc.killed || !proc.pid) return;
+  try {
+    // Negative pid kills the entire process group — agent, MCP subprocesses,
+    // and any grandchildren spawned by the agent.
+    process.kill(-proc.pid, "SIGTERM");
+  } catch {
+    // Process may have already exited; fall back to direct kill
     proc.kill("SIGTERM");
-    // Force kill after 5s if still alive
-    setTimeout(() => {
-      if (!proc.killed) proc.kill("SIGKILL");
-    }, 5_000).unref();
   }
+  // Force kill after 5s if still alive
+  const pgid = proc.pid;
+  const timer = setTimeout(() => {
+    if (proc.killed || !pgid) return;
+    try { process.kill(-pgid, "SIGKILL"); } catch { proc.kill("SIGKILL"); }
+  }, 5_000);
+  timer.unref();
 }

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -7,12 +7,16 @@
  */
 
 import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
 import type * as acp from "@agentclientprotocol/sdk";
+import { StreamingMarkdownFilter } from "../weixin/markdown-filter.js";
 
 export interface WeChatAcpClientOpts {
   sendTyping: () => Promise<void>;
   onThoughtFlush: (text: string) => Promise<void>;
   onMessageFlush: (text: string) => Promise<void>;
+  onMediaFile: (filePath: string, mimeType: string, fileName?: string) => Promise<void>;
   onConfigOptionsUpdate?: (configOptions: acp.SessionConfigOption[]) => void;
   log: (msg: string) => void;
   showThoughts: boolean;
@@ -22,6 +26,7 @@ export interface WeChatAcpClientOpts {
 export class WeChatAcpClient implements acp.Client {
   private chunks: string[] = [];
   private thoughtChunks: string[] = [];
+  private filter = new StreamingMarkdownFilter();
   private opts: WeChatAcpClientOpts;
   private lastTypingAt = 0;
   private producedMessageThisTurn = false;
@@ -40,6 +45,7 @@ export class WeChatAcpClient implements acp.Client {
   /** Reset per-turn delivery state. Call at the start of each prompt. */
   newTurn(): void {
     this.producedMessageThisTurn = false;
+    this.filter = new StreamingMarkdownFilter();
   }
 
   constructor(opts: WeChatAcpClientOpts) {
@@ -50,12 +56,14 @@ export class WeChatAcpClient implements acp.Client {
     sendTyping: () => Promise<void>;
     onThoughtFlush: (text: string) => Promise<void>;
     onMessageFlush: (text: string) => Promise<void>;
+    onMediaFile: (filePath: string, mimeType: string, fileName?: string) => Promise<void>;
   }): void {
     this.opts = {
       ...this.opts,
       sendTyping: callbacks.sendTyping,
       onThoughtFlush: callbacks.onThoughtFlush,
       onMessageFlush: callbacks.onMessageFlush,
+      onMediaFile: callbacks.onMediaFile,
     };
   }
 
@@ -85,9 +93,48 @@ export class WeChatAcpClient implements acp.Client {
       case "agent_message_chunk":
         await this.maybeFlushThoughts();
         if (update.content.type === "text") {
-          this.chunks.push(update.content.text);
-          if (update.content.text.trim()) {
+          const filtered = this.filter.feed(update.content.text);
+          if (filtered) {
+            this.chunks.push(filtered);
             this.producedMessageThisTurn = true;
+          }
+        } else if (update.content.type === "image") {
+          await this.maybeFlushMessage();
+          const imageContent = update.content as acp.ImageContent;
+          const ext = this.mimeToExt(imageContent.mimeType) ?? ".jpg";
+          const filePath = await this.saveTempFile(
+            Buffer.from(imageContent.data, "base64"),
+            ext,
+          );
+          this.opts.log(`[media] image (${imageContent.data.length} b64 chars) saved to ${filePath}`);
+          await this.sendWithRetry(
+            () => this.opts.onMediaFile(filePath, imageContent.mimeType),
+            "media-image",
+          );
+        } else if (update.content.type === "resource_link") {
+          await this.maybeFlushMessage();
+          const link = update.content as acp.ResourceLink;
+          const localPath = this.resolveLocalPath(link.uri);
+          this.chunks.push(`@sendfile ${localPath}`);
+          this.producedMessageThisTurn = true;
+          this.opts.log(`[media] resource_link -> @sendfile ${localPath}`);
+        } else if (update.content.type === "resource") {
+          await this.maybeFlushMessage();
+          const resource = (update.content as acp.EmbeddedResource).resource;
+          if ("blob" in resource) {
+            const ext = resource.mimeType ? this.mimeToExt(resource.mimeType) : ".bin";
+            const filePath = await this.saveTempFile(
+              Buffer.from(resource.blob, "base64"),
+              ext ?? ".bin",
+            );
+            this.chunks.push(`@sendfile ${filePath}`);
+            this.producedMessageThisTurn = true;
+            this.opts.log(`[media] resource blob -> @sendfile ${filePath}`);
+          } else if ("text" in resource) {
+            this.chunks.push(resource.text);
+            if (resource.text.trim()) {
+              this.producedMessageThisTurn = true;
+            }
           }
         }
         // Throttle typing indicators
@@ -155,6 +202,10 @@ export class WeChatAcpClient implements acp.Client {
         this.opts.onConfigOptionsUpdate?.(update.configOptions);
         this.opts.log(`[config] ${update.configOptions.length} option(s) updated`);
         break;
+
+      default:
+        this.opts.log(`[debug] unhandled sessionUpdate: ${String((update as { sessionUpdate?: string }).sessionUpdate)} content.type=${(update as { content?: { type?: string } }).content?.type}`);
+        break;
     }
   }
 
@@ -182,6 +233,13 @@ export class WeChatAcpClient implements acp.Client {
     // Drain any in-flight sends (queued by maybeFlushMessage) before reading
     // the buffer so a retried-and-restored flush cannot race with this read.
     await this.messageFlushChain.catch(() => {});
+    const filterTail = this.filter.flush();
+    if (filterTail) {
+      this.chunks.push(filterTail);
+      if (filterTail.trim()) {
+        this.producedMessageThisTurn = true;
+      }
+    }
     const text = this.chunks.join("");
     this.chunks = [];
     this.lastTypingAt = 0;
@@ -283,5 +341,39 @@ export class WeChatAcpClient implements acp.Client {
     } catch {
       // typing is best-effort
     }
+  }
+
+  private async saveTempFile(data: Buffer, ext: string): Promise<string> {
+    const name = `wechat-acp-${Date.now()}-${Math.random().toString(16).slice(2, 10)}${ext}`;
+    const filePath = path.join(os.tmpdir(), name);
+    await fs.promises.writeFile(filePath, data);
+    return filePath;
+  }
+
+  private resolveLocalPath(uri: string): string {
+    if (uri.startsWith("file://")) {
+      return decodeURIComponent(uri.slice(7));
+    }
+    return uri;
+  }
+
+  private mimeToExt(mimeType: string): string | undefined {
+    const map: Record<string, string> = {
+      "image/jpeg": ".jpg",
+      "image/png": ".png",
+      "image/gif": ".gif",
+      "image/webp": ".webp",
+      "image/svg+xml": ".svg",
+      "image/bmp": ".bmp",
+      "video/mp4": ".mp4",
+      "video/webm": ".webm",
+      "application/pdf": ".pdf",
+      "application/zip": ".zip",
+      "application/json": ".json",
+      "text/plain": ".txt",
+      "text/markdown": ".md",
+      "text/html": ".html",
+    };
+    return map[mimeType];
   }
 }

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -66,6 +66,7 @@ export interface SessionManagerOpts {
   log: (msg: string) => void;
   onReply: (userId: string, contextToken: string, text: string) => Promise<void>;
   sendTyping: (userId: string, contextToken: string) => Promise<void>;
+  onMediaFile: (userId: string, contextToken: string, filePath: string, mimeType: string, fileName?: string) => Promise<void>;
 }
 
 export class SessionManager {
@@ -225,6 +226,8 @@ export class SessionManager {
       sendTyping: () => this.opts.sendTyping(userId, contextToken),
       onThoughtFlush: (text) => this.opts.onReply(userId, contextToken, text),
       onMessageFlush: (text) => this.opts.onReply(userId, contextToken, text),
+      onMediaFile: (filePath, mimeType, fileName) =>
+        this.opts.onMediaFile(userId, contextToken, filePath, mimeType, fileName),
       onConfigOptionsUpdate: (configOptions) => {
         const session = this.sessions.get(userId);
         if (!session || session.client !== client) return;
@@ -289,6 +292,8 @@ export class SessionManager {
           sendTyping: () => this.opts.sendTyping(session.userId, pending.contextToken),
           onThoughtFlush: (text) => this.opts.onReply(session.userId, pending.contextToken, text),
           onMessageFlush: (text) => this.opts.onReply(session.userId, pending.contextToken, text),
+          onMediaFile: (filePath, mimeType, fileName) =>
+            this.opts.onMediaFile(session.userId, pending.contextToken, filePath, mimeType, fileName),
         });
 
         // Reset chunks for the new turn

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -7,12 +7,14 @@
 
 import type * as acp from "@agentclientprotocol/sdk";
 import crypto from "node:crypto";
+import fs from "node:fs/promises";
 import { login, loadToken, type TokenData } from "./weixin/auth.js";
 import { startMonitor } from "./weixin/monitor.js";
-import { sendTextMessage, splitText } from "./weixin/send.js";
-import { sendTyping, getConfig } from "./weixin/api.js";
+import { sendTextMessage, splitText, sendImageMessage, sendVideoMessage, sendFileMessage, sendFileBuffer } from "./weixin/send.js";
+import { sendTyping, getConfig, notifyStart, notifyStop } from "./weixin/api.js";
 import { TypingStatus, MessageType } from "./weixin/types.js";
 import type { WeixinMessage } from "./weixin/types.js";
+import { uploadImage, uploadVideo, uploadFile } from "./weixin/upload.js";
 import { SessionManager } from "./acp/session.js";
 import { weixinMessageToPrompt } from "./adapter/inbound.js";
 import type { WeChatAcpConfig } from "./config.js";
@@ -72,6 +74,10 @@ export class WeChatAcpBridge {
   // messages arriving during the flush wait for the buffered prompt to
   // enqueue first, preserving turn order.
   private bufferFlushing = new Map<string, Promise<void>>();
+  // Deduplicate messages by seq (WeChat may deliver the same message
+  // in consecutive getUpdates batches before the sync_buf advances).
+  private seenSeqs = new Set<number>();
+  private readonly maxSeenSeqs = 500;
   private log: (msg: string) => void;
 
   constructor(config: WeChatAcpConfig, log?: (msg: string) => void) {
@@ -121,12 +127,28 @@ export class WeChatAcpBridge {
       this.log(`Use --login to force re-login`);
     }
 
-    // 2. Create SessionManager
+    // 2. notify WeChat backend that this bot is online
+    try {
+      const resp = await notifyStart({ baseUrl: this.tokenData.baseUrl, token: this.tokenData.token });
+      if (resp.ret !== 0) {
+        this.log(`notifyStart: ret=${resp.ret} errmsg=${resp.errmsg ?? ""}`);
+      }
+    } catch (err) {
+      this.log(`notifyStart failed (ignored): ${String(err)}`);
+    }
+
+    // 3. Create SessionManager
+    // Inject skills path for opencode agents so they can use @sendfile
+    const skillsDir = new URL("../../skills", import.meta.url).pathname;
+    const agentEnv: Record<string, string> = { ...(this.config.agent.env ?? {}) };
+    if (this.config.agent.preset === "opencode") {
+      agentEnv.OPENCODE_CONFIG_CONTENT = JSON.stringify({ skills: { paths: [skillsDir] } });
+    }
     this.sessionManager = new SessionManager({
       agentCommand: this.config.agent.command,
       agentArgs: this.config.agent.args,
       agentCwd: this.config.agent.cwd,
-      agentEnv: this.config.agent.env,
+      agentEnv,
       agentPreset: this.config.agent.preset ?? "raw",
       idleTimeoutMs: this.config.session.idleTimeoutMs,
       maxConcurrentUsers: this.config.session.maxConcurrentUsers,
@@ -135,6 +157,8 @@ export class WeChatAcpBridge {
       log: this.log,
       onReply: (userId, contextToken, text) => this.sendReply(userId, contextToken, text),
       sendTyping: (userId, contextToken) => this.sendTypingIndicator(userId, contextToken),
+      onMediaFile: (userId, contextToken, filePath, mimeType, fileName) =>
+        this.sendMediaFile(userId, contextToken, filePath, mimeType, fileName),
     });
     this.sessionManager.start();
 
@@ -162,9 +186,20 @@ export class WeChatAcpBridge {
 
   async stop(): Promise<void> {
     this.log("Stopping bridge...");
+
+    if (this.sessionManager) {
+      this.log("Killing all agent sessions...");
+      await this.sessionManager.stop();
+    }
+
+    if (this.tokenData) {
+      notifyStop({ baseUrl: this.tokenData.baseUrl, token: this.tokenData.token }).catch((err) => {
+        this.log(`notifyStop failed (ignored): ${String(err)}`);
+      });
+    }
+
     this.abortController.abort();
     await this.injectionMonitor?.stop();
-    await this.sessionManager?.stop();
     await this.stateUpdate.catch((err) => {
       this.log(`Failed to flush state before stop: ${String(err)}`);
       trackException(sanitizeStateError(err), "state");
@@ -173,6 +208,18 @@ export class WeChatAcpBridge {
   }
 
   private handleMessage(msg: WeixinMessage): void {
+    if (msg.seq != null && this.seenSeqs.has(msg.seq)) {
+      this.log(`Dedup: skipping duplicate msg seq=${msg.seq}`);
+      return;
+    }
+    if (msg.seq != null) {
+      this.seenSeqs.add(msg.seq);
+      if (this.seenSeqs.size > this.maxSeenSeqs) {
+        const [first] = this.seenSeqs;
+        this.seenSeqs.delete(first!);
+      }
+    }
+
     // Only process user messages (not bot's own messages)
     if (msg.message_type !== MessageType.USER) return;
 
@@ -183,7 +230,7 @@ export class WeChatAcpBridge {
     const contextToken = msg.context_token;
     if (!userId || !contextToken) return;
 
-    this.log(`Message from ${userId}: ${this.previewMessage(msg)}`);
+    this.log(`Message from ${userId} (seq=${msg.seq}): ${this.previewMessage(msg)}`);
     this.rememberActiveUser(userId, contextToken);
 
     trackEvent(
@@ -594,6 +641,12 @@ export class WeChatAcpBridge {
   }
 
   private async sendReply(userId: string, contextToken: string, text: string): Promise<void> {
+    const sendFileMatch = text.match(/^@sendfile\s+(.+)$/m);
+    if (sendFileMatch) {
+      const filePath = sendFileMatch[1]!.trim();
+      return this.sendOriginalFile(userId, contextToken, filePath);
+    }
+
     // Serialize all replies to the same user behind a per-user promise chain so
     // that segments from separate sendReply calls cannot interleave (issue #38).
     // The stored link swallows errors so one failed reply doesn't break the
@@ -607,6 +660,104 @@ export class WeChatAcpBridge {
       current.catch(() => {}),
     );
     return current;
+  }
+
+  private async sendMediaFile(
+    userId: string,
+    contextToken: string,
+    filePath: string,
+    mimeType: string,
+    fileName?: string,
+  ): Promise<void> {
+    this.log(`sendMediaFile: userId=${userId} file=${filePath} mime=${mimeType}`);
+    const opts = {
+      baseUrl: this.tokenData!.baseUrl,
+      token: this.tokenData!.token,
+      contextToken,
+    };
+    const resolvedMime = mimeType || getMimeFromFilename(filePath);
+
+    if (resolvedMime.startsWith("video/")) {
+      const uploaded = await uploadVideo({
+        filePath,
+        toUserId: userId,
+        baseUrl: this.tokenData!.baseUrl,
+        token: this.tokenData!.token,
+        cdnBaseUrl: this.config.wechat.cdnBaseUrl,
+        log: this.log,
+      });
+      await this.paceConsecutiveSend(userId);
+      await sendVideoMessage({ to: userId, text: "", uploaded, opts });
+    } else if (resolvedMime.startsWith("image/")) {
+      const uploaded = await uploadImage({
+        filePath,
+        toUserId: userId,
+        baseUrl: this.tokenData!.baseUrl,
+        token: this.tokenData!.token,
+        cdnBaseUrl: this.config.wechat.cdnBaseUrl,
+        log: this.log,
+      });
+      await this.paceConsecutiveSend(userId);
+      await sendImageMessage({ to: userId, text: "", uploaded, opts });
+    } else {
+      const uploaded = await uploadFile({
+        filePath,
+        toUserId: userId,
+        baseUrl: this.tokenData!.baseUrl,
+        token: this.tokenData!.token,
+        cdnBaseUrl: this.config.wechat.cdnBaseUrl,
+        log: this.log,
+      });
+      const name = fileName || filePath.split("/").pop() || "file";
+      await this.paceConsecutiveSend(userId);
+      await sendFileMessage({ to: userId, text: "", fileName: name, uploaded, opts });
+    }
+
+    this.cancelTypingIndicator(userId, contextToken).catch(() => {});
+  }
+
+  private async sendOriginalFile(
+    userId: string,
+    contextToken: string,
+    filePath: string,
+  ): Promise<void> {
+    this.log(`sendOriginalFile: userId=${userId} file=${filePath}`);
+    let buffer: Buffer;
+    let fileName: string;
+
+    if (filePath.startsWith("http://") || filePath.startsWith("https://")) {
+      const res = await fetch(filePath);
+      if (!res.ok) {
+        await this.sendReply(userId, contextToken, `下载文件失败: HTTP ${res.status}`);
+        return;
+      }
+      buffer = Buffer.from(await res.arrayBuffer());
+      fileName = filePath.split("/").pop() || "download";
+    } else {
+      try {
+        buffer = await fs.readFile(filePath);
+        fileName = filePath.split("/").pop() || "file";
+      } catch (err) {
+        await this.sendReply(userId, contextToken, `读取文件失败: ${String(err)}`);
+        return;
+      }
+    }
+
+    try {
+      await sendFileBuffer(userId, buffer, fileName, {
+        baseUrl: this.tokenData!.baseUrl,
+        token: this.tokenData!.token,
+        contextToken,
+        cdnBaseUrl: this.config.wechat.cdnBaseUrl,
+      });
+      this.log(`sendOriginalFile: sent ${fileName} (${buffer.length} bytes) to ${userId}`);
+    } catch (err) {
+      this.log(`sendOriginalFile: failed: ${String(err)}`);
+      await this.sendReply(userId, contextToken, `发送文件失败: ${String(err)}`);
+      return;
+    }
+
+    this.cancelTypingIndicator(userId, contextToken).catch(() => {});
   }
 
   private async deliverReply(userId: string, contextToken: string, text: string): Promise<void> {
@@ -1003,4 +1154,37 @@ function sanitizeStateError(err: unknown): Error {
   sanitized.name = err instanceof Error ? err.name : "Error";
   sanitized.stack = undefined;
   return sanitized;
+}
+
+function getMimeFromFilename(filePath: string): string {
+  const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
+  const map: Record<string, string> = {
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    png: "image/png",
+    gif: "image/gif",
+    webp: "image/webp",
+    bmp: "image/bmp",
+    svg: "image/svg+xml",
+    mp4: "video/mp4",
+    webm: "video/webm",
+    mov: "video/quicktime",
+    avi: "video/x-msvideo",
+    pdf: "application/pdf",
+    zip: "application/zip",
+    gz: "application/gzip",
+    tar: "application/x-tar",
+    doc: "application/msword",
+    docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    xls: "application/vnd.ms-excel",
+    xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ppt: "application/vnd.ms-powerpoint",
+    pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    txt: "text/plain",
+    json: "application/json",
+    md: "text/markdown",
+    html: "text/html",
+    csv: "text/csv",
+  };
+  return map[ext] ?? "application/octet-stream";
 }

--- a/src/weixin/api.ts
+++ b/src/weixin/api.ts
@@ -13,6 +13,8 @@ import type {
   GetUploadUrlResp,
   SendTypingReq,
   GetConfigResp,
+  NotifyStartResp,
+  NotifyStopResp,
 } from "./types.js";
 
 const CHANNEL_VERSION = "1.0.2";
@@ -161,15 +163,44 @@ export async function getBotQrcode(params: {
 export async function getQrcodeStatus(params: {
   baseUrl: string;
   qrcode: string;
+  verifyCode?: string;
 }): Promise<{
   status: string;
   bot_token?: string;
   baseurl?: string;
   ilink_bot_id?: string;
   ilink_user_id?: string;
+  redirect_host?: string;
 }> {
-  return apiGet(
+  let qs = `ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(params.qrcode)}`;
+  if (params.verifyCode) {
+    qs += `&verify_code=${encodeURIComponent(params.verifyCode)}`;
+  }
+  return apiGet(params.baseUrl, qs);
+}
+
+export async function notifyStart(params: {
+  baseUrl: string;
+  token?: string;
+}): Promise<NotifyStartResp> {
+  return apiPost<NotifyStartResp>(
     params.baseUrl,
-    `ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(params.qrcode)}`,
+    "ilink/bot/msg/notifystart",
+    { base_info: buildBaseInfo() },
+    params.token,
+    10_000,
+  );
+}
+
+export async function notifyStop(params: {
+  baseUrl: string;
+  token?: string;
+}): Promise<NotifyStopResp> {
+  return apiPost<NotifyStopResp>(
+    params.baseUrl,
+    "ilink/bot/msg/notifystop",
+    { base_info: buildBaseInfo() },
+    params.token,
+    10_000,
   );
 }

--- a/src/weixin/auth.ts
+++ b/src/weixin/auth.ts
@@ -4,6 +4,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import readline from "node:readline";
 import { getBotQrcode, getQrcodeStatus } from "./api.js";
 
 export interface TokenData {
@@ -34,6 +35,19 @@ export function saveToken(storageDir: string, data: TokenData): void {
   fs.writeFileSync(tokenPath, JSON.stringify(data, null, 2), "utf-8");
 }
 
+async function readVerifyCodeFromStdin(prompt: string): Promise<string> {
+  process.stdout.write(prompt);
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question("", (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+const MAX_QR_REFRESH_COUNT = 3;
+
 export async function login(params: {
   baseUrl: string;
   botType?: string;
@@ -49,31 +63,80 @@ export async function login(params: {
   const qrcodeUrl = qrResp.qrcode_img_content;
 
   log("Please scan the QR code with WeChat:");
+  log(`QR URL: ${qrcodeUrl}`);
   if (renderQrUrl) {
     renderQrUrl(qrcodeUrl);
-  } else {
-    log(`QR URL: ${qrcodeUrl}`);
   }
 
   const deadline = Date.now() + 5 * 60_000;
   let currentQrcode = qrResp.qrcode;
+  let currentBaseUrl = baseUrl;
   let refreshCount = 0;
+  let pendingVerifyCode: string | undefined;
 
   while (Date.now() < deadline) {
-    const statusResp = await getQrcodeStatus({ baseUrl, qrcode: currentQrcode });
+    const statusResp = await getQrcodeStatus({
+      baseUrl: currentBaseUrl,
+      qrcode: currentQrcode,
+      verifyCode: pendingVerifyCode,
+    });
 
     switch (statusResp.status) {
       case "wait":
         break;
-      case "scaned":
+      case "scaned": {
+        if (pendingVerifyCode) {
+          log("Pair-code accepted");
+          pendingVerifyCode = undefined;
+        }
         log("QR scanned, please confirm in WeChat...");
         break;
+      }
+      case "need_verifycode": {
+        const prompt = pendingVerifyCode
+          ? "❌ Wrong code, please re-enter the number shown on your phone: "
+          : "Enter the verification number shown on your phone: ";
+        const code = await readVerifyCodeFromStdin(prompt);
+        pendingVerifyCode = code;
+        continue;
+      }
+      case "verify_code_blocked": {
+        log("Verification code blocked (too many attempts)");
+        process.stdout.write("\n⛔ Too many incorrect attempts.\n");
+        pendingVerifyCode = undefined;
+        refreshCount++;
+        if (refreshCount > MAX_QR_REFRESH_COUNT) {
+          throw new Error("Verification code blocked and QR refresh limit reached");
+        }
+        log(`Refreshing QR code (${refreshCount}/${MAX_QR_REFRESH_COUNT})...`);
+        const newQr = await getBotQrcode({ baseUrl, botType });
+        currentQrcode = newQr.qrcode;
+        if (renderQrUrl) {
+          renderQrUrl(newQr.qrcode_img_content);
+        } else {
+          log(`New QR URL: ${newQr.qrcode_img_content}`);
+        }
+        break;
+      }
+      case "scaned_but_redirect": {
+        const redirectHost = (statusResp as Record<string, unknown>).redirect_host as string | undefined;
+        if (redirectHost) {
+          currentBaseUrl = `https://${redirectHost}`;
+          log(`Redirecting polling to ${currentBaseUrl}`);
+        }
+        break;
+      }
+      case "binded_redirect": {
+        log("Bot already bound to this account");
+        process.stdout.write("\n✅ Already connected, no need to re-connect.\n");
+        throw new Error("Already connected (binded_redirect)");
+      }
       case "expired": {
         refreshCount++;
-        if (refreshCount > 3) {
+        if (refreshCount > MAX_QR_REFRESH_COUNT) {
           throw new Error("QR code expired multiple times, please retry");
         }
-        log(`QR expired, refreshing (${refreshCount}/3)...`);
+        log(`QR expired, refreshing (${refreshCount}/${MAX_QR_REFRESH_COUNT})...`);
         const newQr = await getBotQrcode({ baseUrl, botType });
         currentQrcode = newQr.qrcode;
         if (renderQrUrl) {

--- a/src/weixin/markdown-filter.ts
+++ b/src/weixin/markdown-filter.ts
@@ -1,0 +1,349 @@
+/**
+ * Streaming markdown filter — character-level state machine that strips
+ * unsupported markdown syntax on-the-fly.
+ *
+ * Adapted from @tencent-weixin/openclaw-weixin messaging/markdown-filter.ts (MIT)
+ *
+ * Constructs passed through (not filtered):
+ * - Code fences (```)
+ * - Inline code (`)
+ * - Tables (|...|)
+ * - Horizontal rules (---, ***, ___)
+ * - Bold (**)
+ * - Italic/bold-italic wrapping non-CJK content
+ *
+ * Constructs filtered (markers stripped, content kept):
+ * - Italic/bold-italic wrapping CJK content
+ * - Headings H5/H6 (#####, ######)
+ * - Images (![alt](url)) — removed entirely
+ */
+export class StreamingMarkdownFilter {
+  private buf = "";
+  private fence = false;
+  private sol = true;
+  private inl: { type: "image" | "bold3" | "italic" | "ubold3" | "uitalic"; acc: string } | null = null;
+
+  feed(delta: string): string {
+    this.buf += delta;
+    return this.pump(false);
+  }
+
+  flush(): string {
+    return this.pump(true);
+  }
+
+  private pump(eof: boolean): string {
+    let out = "";
+    while (this.buf) {
+      const sLen = this.buf.length;
+      const sSol = this.sol;
+      const sFence = this.fence;
+      const sInl = this.inl;
+
+      if (this.fence) out += this.pumpFence(eof);
+      else if (this.inl) out += this.pumpInline(eof);
+      else if (this.sol) out += this.pumpSOL(eof);
+      else out += this.pumpBody(eof);
+
+      if (this.buf.length === sLen && this.sol === sSol &&
+        this.fence === sFence && this.inl === sInl) break;
+    }
+
+    if (eof && this.inl) {
+      const markers: Record<string, string> = { image: "![", bold3: "***", italic: "*", ubold3: "___", uitalic: "_" };
+      out += (markers[this.inl.type] ?? "") + this.inl.acc;
+      this.inl = null;
+    }
+    return out;
+  }
+
+  private pumpFence(eof: boolean): string {
+    if (this.sol) {
+      if (this.buf.length < 3 && !eof) return "";
+      if (this.buf.startsWith("```")) {
+        const nl = this.buf.indexOf("\n", 3);
+        if (nl !== -1) {
+          this.fence = false;
+          const line = this.buf.slice(0, nl + 1);
+          this.buf = this.buf.slice(nl + 1);
+          this.sol = true;
+          return line;
+        }
+        if (eof) {
+          this.fence = false;
+          const line = this.buf;
+          this.buf = "";
+          return line;
+        }
+        return "";
+      }
+      this.sol = false;
+    }
+    const nl = this.buf.indexOf("\n");
+    if (nl !== -1) {
+      const chunk = this.buf.slice(0, nl + 1);
+      this.buf = this.buf.slice(nl + 1);
+      this.sol = true;
+      return chunk;
+    }
+    const chunk = this.buf;
+    this.buf = "";
+    return chunk;
+  }
+
+  private pumpSOL(eof: boolean): string {
+    const b = this.buf;
+
+    if (b[0] === "\n") {
+      this.buf = b.slice(1);
+      return "\n";
+    }
+
+    if (b[0] === "`") {
+      if (b.length < 3 && !eof) return "";
+      if (b.startsWith("```")) {
+        const nl = b.indexOf("\n", 3);
+        if (nl !== -1) {
+          this.fence = true;
+          const line = b.slice(0, nl + 1);
+          this.buf = b.slice(nl + 1);
+          this.sol = true;
+          return line;
+        }
+        if (eof) {
+          this.buf = "";
+          return b;
+        }
+        return "";
+      }
+      this.sol = false;
+      return "";
+    }
+
+    if (b[0] === ">") {
+      this.sol = false;
+      return "";
+    }
+
+    if (b[0] === "#") {
+      let n = 0;
+      while (n < b.length && b[n] === "#") n++;
+      if (n === b.length && !eof) return "";
+      if (n >= 5 && n <= 6 && n < b.length && b[n] === " ") {
+        this.buf = b.slice(n + 1);
+        this.sol = false;
+        return "";
+      }
+      this.sol = false;
+      return "";
+    }
+
+    if (b[0] === " " || b[0] === "\t") {
+      if (b.search(/[^ \t]/) === -1 && !eof) return "";
+      this.sol = false;
+      return "";
+    }
+
+    if (b[0] === "-" || b[0] === "*" || b[0] === "_") {
+      const ch = b[0];
+      let j = 0;
+      while (j < b.length && (b[j] === ch || b[j] === " ")) j++;
+      if (j === b.length && !eof) return "";
+      if (j === b.length || b[j] === "\n") {
+        let count = 0;
+        for (let k = 0; k < j; k++) if (b[k] === ch) count++;
+        if (count >= 3) {
+          if (j < b.length) {
+            this.buf = b.slice(j + 1);
+            this.sol = true;
+            return b.slice(0, j + 1);
+          }
+          this.buf = "";
+          return b;
+        }
+      }
+      this.sol = false;
+      return "";
+    }
+
+    this.sol = false;
+    return "";
+  }
+
+  private pumpBody(eof: boolean): string {
+    let out = "";
+    let i = 0;
+    while (i < this.buf.length) {
+      const c = this.buf[i];
+      if (c === "\n") {
+        out += this.buf.slice(0, i + 1);
+        this.buf = this.buf.slice(i + 1);
+        this.sol = true;
+        return out;
+      }
+      if (c === "!" && i + 1 < this.buf.length && this.buf[i + 1] === "[") {
+        out += this.buf.slice(0, i);
+        this.buf = this.buf.slice(i + 2);
+        this.inl = { type: "image", acc: "" };
+        return out;
+      }
+      if (c === "~") {
+        i++;
+        continue;
+      }
+      if (c === "*") {
+        if (i + 2 < this.buf.length && this.buf[i + 1] === "*" && this.buf[i + 2] === "*") {
+          out += this.buf.slice(0, i);
+          this.buf = this.buf.slice(i + 3);
+          this.inl = { type: "bold3", acc: "" };
+          return out;
+        }
+        if (i + 1 < this.buf.length && this.buf[i + 1] === "*") {
+          i += 2;
+          continue;
+        }
+        if (i + 1 < this.buf.length && this.buf[i + 1] !== " " && this.buf[i + 1] !== "\n") {
+          out += this.buf.slice(0, i);
+          this.buf = this.buf.slice(i + 1);
+          this.inl = { type: "italic", acc: "" };
+          return out;
+        }
+        i++;
+        continue;
+      }
+      if (c === "_") {
+        if (i + 2 < this.buf.length && this.buf[i + 1] === "_" && this.buf[i + 2] === "_") {
+          out += this.buf.slice(0, i);
+          this.buf = this.buf.slice(i + 3);
+          this.inl = { type: "ubold3", acc: "" };
+          return out;
+        }
+        if (i + 1 < this.buf.length && this.buf[i + 1] === "_") {
+          i += 2;
+          continue;
+        }
+        if (i + 1 < this.buf.length && this.buf[i + 1] !== " " && this.buf[i + 1] !== "\n") {
+          out += this.buf.slice(0, i);
+          this.buf = this.buf.slice(i + 1);
+          this.inl = { type: "uitalic", acc: "" };
+          return out;
+        }
+        i++;
+        continue;
+      }
+      i++;
+    }
+
+    let hold = 0;
+    if (!eof) {
+      if (this.buf.endsWith("**")) hold = 2;
+      else if (this.buf.endsWith("__")) hold = 2;
+      else if (this.buf.endsWith("*")) hold = 1;
+      else if (this.buf.endsWith("_")) hold = 1;
+      else if (this.buf.endsWith("!")) hold = 1;
+    }
+    out += this.buf.slice(0, this.buf.length - hold);
+    this.buf = hold > 0 ? this.buf.slice(-hold) : "";
+    return out;
+  }
+
+  private pumpInline(_eof: boolean): string {
+    if (!this.inl) return "";
+    this.inl.acc += this.buf;
+    this.buf = "";
+
+    switch (this.inl.type) {
+      case "bold3": {
+        const idx = this.inl.acc.indexOf("***");
+        if (idx !== -1) {
+          const content = this.inl.acc.slice(0, idx);
+          this.buf = this.inl.acc.slice(idx + 3);
+          this.inl = null;
+          if (StreamingMarkdownFilter.containsCJK(content)) return content;
+          return `***${content}***`;
+        }
+        return "";
+      }
+      case "ubold3": {
+        const idx = this.inl.acc.indexOf("___");
+        if (idx !== -1) {
+          const content = this.inl.acc.slice(0, idx);
+          this.buf = this.inl.acc.slice(idx + 3);
+          this.inl = null;
+          if (StreamingMarkdownFilter.containsCJK(content)) return content;
+          return `___${content}___`;
+        }
+        return "";
+      }
+      case "italic": {
+        for (let j = 0; j < this.inl.acc.length; j++) {
+          if (this.inl.acc[j] === "\n") {
+            const r = "*" + this.inl.acc.slice(0, j + 1);
+            this.buf = this.inl.acc.slice(j + 1);
+            this.inl = null;
+            this.sol = true;
+            return r;
+          }
+          if (this.inl.acc[j] === "*") {
+            if (j + 1 < this.inl.acc.length && this.inl.acc[j + 1] === "*") {
+              j++;
+              continue;
+            }
+            const content = this.inl.acc.slice(0, j);
+            this.buf = this.inl.acc.slice(j + 1);
+            this.inl = null;
+            if (StreamingMarkdownFilter.containsCJK(content)) return content;
+            return `*${content}*`;
+          }
+        }
+        return "";
+      }
+      case "uitalic": {
+        for (let j = 0; j < this.inl.acc.length; j++) {
+          if (this.inl.acc[j] === "\n") {
+            const r = "_" + this.inl.acc.slice(0, j + 1);
+            this.buf = this.inl.acc.slice(j + 1);
+            this.inl = null;
+            this.sol = true;
+            return r;
+          }
+          if (this.inl.acc[j] === "_") {
+            if (j + 1 < this.inl.acc.length && this.inl.acc[j + 1] === "_") {
+              j++;
+              continue;
+            }
+            const content = this.inl.acc.slice(0, j);
+            this.buf = this.inl.acc.slice(j + 1);
+            this.inl = null;
+            if (StreamingMarkdownFilter.containsCJK(content)) return content;
+            return `_${content}_`;
+          }
+        }
+        return "";
+      }
+      case "image": {
+        const cb = this.inl.acc.indexOf("]");
+        if (cb === -1) return "";
+        if (cb + 1 >= this.inl.acc.length) return "";
+        if (this.inl.acc[cb + 1] !== "(") {
+          const r = "![" + this.inl.acc.slice(0, cb + 1);
+          this.buf = this.inl.acc.slice(cb + 1);
+          this.inl = null;
+          return r;
+        }
+        const cp = this.inl.acc.indexOf(")", cb + 2);
+        if (cp !== -1) {
+          this.buf = this.inl.acc.slice(cp + 1);
+          this.inl = null;
+          return "";
+        }
+        return "";
+      }
+    }
+    return "";
+  }
+
+  private static containsCJK(text: string): boolean {
+    return /[\u2E80-\u9FFF\uAC00-\uD7AF\uF900-\uFAFF]/.test(text);
+  }
+}

--- a/src/weixin/media.ts
+++ b/src/weixin/media.ts
@@ -6,6 +6,12 @@
 import crypto from "node:crypto";
 import type { CDNMedia } from "./types.js";
 
+export function aesEcbPaddedSize(plaintextLen: number): number {
+  const blockSize = 16;
+  const padLen = blockSize - (plaintextLen % blockSize);
+  return plaintextLen + padLen;
+}
+
 export function encryptAesEcb(plaintext: Buffer, key: Buffer): Buffer {
   const cipher = crypto.createCipheriv("aes-128-ecb", key, null);
   return Buffer.concat([cipher.update(plaintext), cipher.final()]);

--- a/src/weixin/send.ts
+++ b/src/weixin/send.ts
@@ -3,8 +3,12 @@
  */
 
 import crypto from "node:crypto";
-import { sendMessage } from "./api.js";
-import { MessageType, MessageState } from "./types.js";
+import fs from "node:fs/promises";
+import { sendMessage, getUploadUrl } from "./api.js";
+import { MessageType, MessageState, MessageItemType, UploadMediaType } from "./types.js";
+import type { MessageItem } from "./types.js";
+import type { UploadedFileInfo } from "./upload.js";
+import { encryptAesEcb, aesEcbPaddedSize } from "./media.js";
 
 export interface WeixinSendOpts {
   baseUrl: string;
@@ -69,4 +73,268 @@ export function splitText(text: string, maxLen: number): string[] {
   }
 
   return segments;
+}
+
+function hexToBase64(hex: string): string {
+  return Buffer.from(hex).toString("base64");
+}
+
+function buildSendReq(params: {
+  to: string;
+  contextToken?: string;
+  clientId: string;
+  itemList: MessageItem[];
+}): { msg: Record<string, unknown> } {
+  return {
+    msg: {
+      from_user_id: "",
+      to_user_id: params.to,
+      client_id: params.clientId,
+      message_type: MessageType.BOT,
+      message_state: MessageState.FINISH,
+      context_token: params.contextToken,
+      item_list: params.itemList,
+    },
+  };
+}
+
+async function sendMediaItems(params: {
+  to: string;
+  text: string;
+  mediaItem: MessageItem;
+  opts: WeixinSendOpts;
+  sendFn?: typeof sendMessage;
+}): Promise<string> {
+  if (!params.opts.contextToken) {
+    throw new Error("contextToken is required to send a media message");
+  }
+
+  const clientId = `wechat-acp-${crypto.randomUUID()}`;
+  const itemList: MessageItem[] = [];
+
+  if (params.text) {
+    itemList.push({ type: MessageItemType.TEXT, text_item: { text: params.text } });
+  }
+  itemList.push(params.mediaItem);
+
+  const send = params.sendFn ?? sendMessage;
+  await send({
+    baseUrl: params.opts.baseUrl,
+    token: params.opts.token,
+    body: buildSendReq({
+      to: params.to,
+      contextToken: params.opts.contextToken,
+      clientId,
+      itemList,
+    }) as unknown as { msg?: import("./types.js").WeixinMessage },
+  });
+
+  return clientId;
+}
+
+export async function sendImageMessage(params: {
+  to: string;
+  text: string;
+  uploaded: UploadedFileInfo;
+  opts: WeixinSendOpts;
+  sendFn?: typeof sendMessage;
+}): Promise<string> {
+  const imageItem: MessageItem = {
+    type: MessageItemType.IMAGE,
+    image_item: {
+      media: {
+        encrypt_query_param: params.uploaded.downloadEncryptedQueryParam,
+        aes_key: hexToBase64(params.uploaded.aeskey),
+        encrypt_type: 1,
+      },
+      mid_size: params.uploaded.fileSizeCiphertext,
+    },
+  };
+
+  return sendMediaItems({ to: params.to, text: params.text, mediaItem: imageItem, opts: params.opts, sendFn: params.sendFn });
+}
+
+export async function sendVideoMessage(params: {
+  to: string;
+  text: string;
+  uploaded: UploadedFileInfo;
+  opts: WeixinSendOpts;
+  sendFn?: typeof sendMessage;
+}): Promise<string> {
+  const videoItem: MessageItem = {
+    type: MessageItemType.VIDEO,
+    video_item: {
+      media: {
+        encrypt_query_param: params.uploaded.downloadEncryptedQueryParam,
+        aes_key: hexToBase64(params.uploaded.aeskey),
+        encrypt_type: 1,
+      },
+      video_size: params.uploaded.fileSizeCiphertext,
+    },
+  };
+
+  return sendMediaItems({ to: params.to, text: params.text, mediaItem: videoItem, opts: params.opts, sendFn: params.sendFn });
+}
+
+export async function sendFileMessage(params: {
+  to: string;
+  text: string;
+  fileName: string;
+  uploaded: UploadedFileInfo;
+  opts: WeixinSendOpts;
+  sendFn?: typeof sendMessage;
+}): Promise<string> {
+  const fileItem: MessageItem = {
+    type: MessageItemType.FILE,
+    file_item: {
+      media: {
+        encrypt_query_param: params.uploaded.downloadEncryptedQueryParam,
+        aes_key: hexToBase64(params.uploaded.aeskey),
+        encrypt_type: 1,
+      },
+      file_name: params.fileName,
+      len: String(params.uploaded.fileSize),
+    },
+  };
+
+  return sendMediaItems({ to: params.to, text: params.text, mediaItem: fileItem, opts: params.opts, sendFn: params.sendFn });
+}
+
+const SEND_BUFFER_UPLOAD_MAX_RETRIES = 3;
+
+async function uploadBufferToCdn(params: {
+  buf: Buffer;
+  uploadFullUrl?: string;
+  uploadParam?: string;
+  filekey: string;
+  cdnBaseUrl: string;
+  aeskey: Buffer;
+}): Promise<string> {
+  const { buf, uploadFullUrl, uploadParam, filekey, cdnBaseUrl, aeskey } = params;
+  const ciphertext = encryptAesEcb(buf, aeskey);
+
+  const trimmedFull = uploadFullUrl?.trim();
+  let cdnUrl: string;
+  if (trimmedFull) {
+    cdnUrl = trimmedFull;
+  } else if (uploadParam) {
+    cdnUrl = `${cdnBaseUrl}/upload?encrypted_query_param=${encodeURIComponent(uploadParam)}&filekey=${encodeURIComponent(filekey)}`;
+  } else {
+    throw new Error("CDN upload URL missing");
+  }
+
+  let downloadParam: string | undefined;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= SEND_BUFFER_UPLOAD_MAX_RETRIES; attempt++) {
+    try {
+      const res = await fetch(cdnUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/octet-stream" },
+        body: new Uint8Array(ciphertext),
+      });
+      if (res.status >= 400 && res.status < 500) {
+        const errMsg = res.headers.get("x-error-message") ?? (await res.text());
+        throw new Error(`CDN upload client error ${res.status}: ${errMsg}`);
+      }
+      if (res.status !== 200) {
+        const errMsg = res.headers.get("x-error-message") ?? `status ${res.status}`;
+        throw new Error(`CDN upload server error: ${errMsg}`);
+      }
+      downloadParam = res.headers.get("x-encrypted-param") ?? undefined;
+      if (!downloadParam) {
+        throw new Error("CDN upload response missing x-encrypted-param header");
+      }
+      break;
+    } catch (err) {
+      lastError = err;
+      if (err instanceof Error && err.message.includes("client error")) throw err;
+      if (attempt >= SEND_BUFFER_UPLOAD_MAX_RETRIES) throw lastError;
+    }
+  }
+
+  if (!downloadParam) throw new Error(`CDN upload failed after ${SEND_BUFFER_UPLOAD_MAX_RETRIES} attempts`);
+  return downloadParam;
+}
+
+/**
+ * Upload a Buffer to CDN and send it as a file attachment via WeChat iLink.
+ * Built-in CDN pipeline: rawsize→MD5→getUploadUrl→encrypt→POST CDN→sendMessage.
+ * Designed for @sendfile text-flagged sends where the bridge reads a local
+ * file and needs to deliver it directly.
+ */
+export async function sendFileBuffer(
+  to: string,
+  buffer: Buffer,
+  fileName: string,
+  opts: WeixinSendOpts & { cdnBaseUrl: string },
+  sendFn: typeof sendMessage = sendMessage,
+): Promise<string> {
+  if (!opts.contextToken) {
+    throw new Error("contextToken is required to send a file");
+  }
+
+  const rawsize = buffer.length;
+  const rawfilemd5 = crypto.createHash("md5").update(buffer).digest("hex");
+  const filesize = aesEcbPaddedSize(rawsize);
+  const filekey = crypto.randomBytes(16).toString("hex");
+  const aeskey = crypto.randomBytes(16);
+  const aeskeyHex = aeskey.toString("hex");
+
+  const uploadUrlResp = await getUploadUrl({
+    baseUrl: opts.baseUrl,
+    token: opts.token,
+    body: {
+      filekey,
+      media_type: UploadMediaType.FILE,
+      to_user_id: to,
+      rawsize,
+      rawfilemd5,
+      filesize,
+      no_need_thumb: true,
+      aeskey: aeskeyHex,
+    },
+  });
+
+  const uploadFullUrl = uploadUrlResp.upload_full_url?.trim();
+  const uploadParam = uploadUrlResp.upload_param;
+  if (!uploadFullUrl && !uploadParam) {
+    throw new Error(`getUploadUrl returned no upload URL`);
+  }
+
+  const downloadEncryptedQueryParam = await uploadBufferToCdn({
+    buf: buffer,
+    uploadFullUrl: uploadFullUrl || undefined,
+    uploadParam: uploadParam ?? undefined,
+    filekey,
+    cdnBaseUrl: opts.cdnBaseUrl,
+    aeskey,
+  });
+
+  const fileItem: MessageItem = {
+    type: MessageItemType.FILE,
+    file_item: {
+      media: {
+        encrypt_query_param: downloadEncryptedQueryParam,
+        aes_key: hexToBase64(aeskeyHex),
+        encrypt_type: 1,
+      },
+      file_name: fileName,
+      len: String(rawsize),
+    },
+  };
+
+  const clientId = `wechat-acp-${crypto.randomUUID()}`;
+  await sendFn({
+    baseUrl: opts.baseUrl,
+    token: opts.token,
+    body: buildSendReq({
+      to,
+      contextToken: opts.contextToken,
+      clientId,
+      itemList: [fileItem],
+    }) as unknown as { msg?: import("./types.js").WeixinMessage },
+  });
+
+  return clientId;
 }

--- a/src/weixin/types.ts
+++ b/src/weixin/types.ts
@@ -154,6 +154,7 @@ export interface GetUploadUrlReq {
 
 export interface GetUploadUrlResp {
   upload_param?: string;
+  upload_full_url?: string;
   thumb_upload_param?: string;
 }
 
@@ -165,4 +166,22 @@ export interface SendTypingReq {
 
 export interface GetConfigResp {
   typing_ticket?: string;
+}
+
+export interface NotifyStopReq {
+  base_info?: BaseInfo;
+}
+
+export interface NotifyStopResp {
+  ret?: number;
+  errmsg?: string;
+}
+
+export interface NotifyStartReq {
+  base_info?: BaseInfo;
+}
+
+export interface NotifyStartResp {
+  ret?: number;
+  errmsg?: string;
 }

--- a/src/weixin/upload.ts
+++ b/src/weixin/upload.ts
@@ -1,0 +1,177 @@
+/**
+ * CDN upload pipeline for WeChat media.
+ * Adapted from @tencent-weixin/openclaw-weixin cdn/upload.ts + cdn/cdn-upload.ts
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import { getUploadUrl } from "./api.js";
+import { encryptAesEcb, aesEcbPaddedSize } from "./media.js";
+import { UploadMediaType } from "./types.js";
+
+const UPLOAD_MAX_RETRIES = 3;
+
+export interface UploadedFileInfo {
+  filekey: string;
+  downloadEncryptedQueryParam: string;
+  aeskey: string;
+  fileSize: number;
+  fileSizeCiphertext: number;
+}
+
+interface UploadToCdnParams {
+  buf: Buffer;
+  uploadFullUrl?: string;
+  uploadParam?: string;
+  filekey: string;
+  cdnBaseUrl: string;
+  aeskey: Buffer;
+  log: (msg: string) => void;
+}
+
+async function uploadToCdn(params: UploadToCdnParams): Promise<string> {
+  const { buf, uploadFullUrl, uploadParam, filekey, cdnBaseUrl, aeskey, log } = params;
+  const ciphertext = encryptAesEcb(buf, aeskey);
+
+  const trimmedFull = uploadFullUrl?.trim();
+  let cdnUrl: string;
+  if (trimmedFull) {
+    cdnUrl = trimmedFull;
+  } else if (uploadParam) {
+    cdnUrl = `${cdnBaseUrl}/upload?encrypted_query_param=${encodeURIComponent(uploadParam)}&filekey=${encodeURIComponent(filekey)}`;
+  } else {
+    throw new Error("CDN upload URL missing (need upload_full_url or upload_param)");
+  }
+
+  let downloadParam: string | undefined;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= UPLOAD_MAX_RETRIES; attempt++) {
+    try {
+      const res = await fetch(cdnUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/octet-stream" },
+        body: new Uint8Array(ciphertext),
+      });
+      if (res.status >= 400 && res.status < 500) {
+        const errMsg = res.headers.get("x-error-message") ?? (await res.text());
+        throw new Error(`CDN upload client error ${res.status}: ${errMsg}`);
+      }
+      if (res.status !== 200) {
+        const errMsg = res.headers.get("x-error-message") ?? `status ${res.status}`;
+        throw new Error(`CDN upload server error: ${errMsg}`);
+      }
+      downloadParam = res.headers.get("x-encrypted-param") ?? undefined;
+      if (!downloadParam) {
+        throw new Error("CDN upload response missing x-encrypted-param header");
+      }
+      break;
+    } catch (err) {
+      lastError = err;
+      if (err instanceof Error && err.message.includes("client error")) throw err;
+      if (attempt < UPLOAD_MAX_RETRIES) {
+        log(`CDN upload attempt ${attempt} failed, retrying: ${String(err)}`);
+      } else {
+        log(`CDN upload all ${UPLOAD_MAX_RETRIES} attempts failed: ${String(err)}`);
+      }
+    }
+  }
+
+  if (!downloadParam) {
+    throw lastError instanceof Error
+      ? lastError
+      : new Error(`CDN upload failed after ${UPLOAD_MAX_RETRIES} attempts`);
+  }
+  return downloadParam;
+}
+
+async function uploadMediaToCdn(params: {
+  filePath: string;
+  toUserId: string;
+  baseUrl: string;
+  token: string;
+  cdnBaseUrl: string;
+  mediaType: (typeof UploadMediaType)[keyof typeof UploadMediaType];
+  log: (msg: string) => void;
+}): Promise<UploadedFileInfo> {
+  const { filePath, toUserId, baseUrl, token, cdnBaseUrl, mediaType, log } = params;
+
+  const plaintext = await fs.readFile(filePath);
+  const rawsize = plaintext.length;
+  const rawfilemd5 = crypto.createHash("md5").update(plaintext).digest("hex");
+  const filesize = aesEcbPaddedSize(rawsize);
+  const filekey = crypto.randomBytes(16).toString("hex");
+  const aeskey = crypto.randomBytes(16);
+
+  const uploadUrlResp = await getUploadUrl({
+    baseUrl,
+    token,
+    body: {
+      filekey,
+      media_type: mediaType,
+      to_user_id: toUserId,
+      rawsize,
+      rawfilemd5,
+      filesize,
+      no_need_thumb: true,
+      aeskey: aeskey.toString("hex"),
+    },
+  });
+
+  const uploadFullUrl = uploadUrlResp.upload_full_url?.trim();
+  const uploadParam = uploadUrlResp.upload_param;
+  if (!uploadFullUrl && !uploadParam) {
+    throw new Error(`getUploadUrl returned no upload URL`);
+  }
+
+  const downloadEncryptedQueryParam = await uploadToCdn({
+    buf: plaintext,
+    uploadFullUrl: uploadFullUrl || undefined,
+    uploadParam: uploadParam ?? undefined,
+    filekey,
+    cdnBaseUrl,
+    aeskey,
+    log,
+  });
+
+  return {
+    filekey,
+    downloadEncryptedQueryParam,
+    aeskey: aeskey.toString("hex"),
+    fileSize: rawsize,
+    fileSizeCiphertext: filesize,
+  };
+}
+
+export async function uploadImage(params: {
+  filePath: string;
+  toUserId: string;
+  baseUrl: string;
+  token: string;
+  cdnBaseUrl: string;
+  log: (msg: string) => void;
+}): Promise<UploadedFileInfo> {
+  return uploadMediaToCdn({ ...params, mediaType: UploadMediaType.IMAGE });
+}
+
+export async function uploadVideo(params: {
+  filePath: string;
+  toUserId: string;
+  baseUrl: string;
+  token: string;
+  cdnBaseUrl: string;
+  log: (msg: string) => void;
+}): Promise<UploadedFileInfo> {
+  return uploadMediaToCdn({ ...params, mediaType: UploadMediaType.VIDEO });
+}
+
+export async function uploadFile(params: {
+  filePath: string;
+  toUserId: string;
+  baseUrl: string;
+  token: string;
+  cdnBaseUrl: string;
+  log: (msg: string) => void;
+}): Promise<UploadedFileInfo> {
+  return uploadMediaToCdn({ ...params, mediaType: UploadMediaType.FILE });
+}


### PR DESCRIPTION
## Changes

### Media Sending (`@sendfile`)
- `src/weixin/upload.ts` — CDN upload pipeline (encrypt + POST + 3 retries)
- `src/weixin/send.ts` — `sendFileBuffer()` with built-in CDN pipeline, `sendImageMessage`/`sendVideoMessage`/`sendFileMessage`
- `src/acp/client.ts` — `resource`/`resource_link` content emit `@sendfile` text markers
- `src/bridge.ts` — `sendReply` detects `@sendfile` → reads file → CDN upload → WeChat delivery

### Markdown Streaming Filter
- `src/weixin/markdown-filter.ts` — `StreamingMarkdownFilter` state machine preserving code fences, tables, bold; stripping CJK italic, headings, blockquotes, images
- `src/acp/client.ts` — all `agent_message_chunk` text passes through filter

### Pair-Code Login
- `src/weixin/auth.ts` — `need_verifycode` / `verify_code_blocked` / `scaned` / `scaned_but_redirect` / `binded_redirect` status handling
- `src/weixin/api.ts` — `getQrcodeStatus` with `verifyCode` parameter

### notifyStart/notifyStop
- `src/weixin/api.ts` — `notifyStart()` / `notifyStop()` API functions
- `src/bridge.ts` — called on bridge start/shutdown

### Daemon Self-Healing
- `bin/wechat-acp.ts` — auto-restart loop (max 10, exponential backoff 2s→60s)
- `src/bridge.ts::stop()` — kill agents FIRST, then cleanup
- `src/acp/agent-manager.ts` — `process.kill(-pid)` kills entire process group

### Skill Auto-Injection for OpenCode
- `skills/wechat-bridge/SKILL.md` — skill source maintained in project
- `src/bridge.ts` — injects `OPENCODE_CONFIG_CONTENT` env var when preset is `opencode`

### README
- Added `@sendfile` to Features, new `## Sending Files` section

All changes pass `tsc --noEmit` and 9/9 tests.