### PR TITLE
feat: add outbound media send support

### DIFF
--- a/bin/wechat-acp.ts
+++ b/bin/wechat-acp.ts
@@ -77,6 +77,14 @@ Options:
   --max-sessions <n>  Max concurrent user sessions (default: 10)
   --hide-thoughts     Do not forward agent thinking to WeChat (default: forwarded)
   --show-diffs        Forward ACP file diffs to WeChat (default: hidden)
+  --auto-send-media <mode>
+                      Auto-send media mode: off, tagged, all (default: tagged)
+                        all    - send all file references in replies
+                        tagged - only send @send: tagged files
+                        off    - never auto-send media
+  --system-prompt <text>
+                      System prompt injected at the start of each new session
+                      (e.g. language preference, communication conventions)
   --text <text>       Message text for "inject"
   --file <path>       Read injected message text from a file
   --to <target>       Injection target (default: ${DEFAULT_INJECTION_TARGET})
@@ -136,6 +144,8 @@ function parseArgs(argv: string[]): {
   injectContextToken?: string;
   hideThoughts: boolean;
   showDiffs: boolean;
+  autoSendMedia?: string;
+  systemPrompt?: string;
   verbose: boolean;
   version: boolean;
   help: boolean;
@@ -210,6 +220,12 @@ function parseArgs(argv: string[]): {
         break;
       case "--show-diffs":
         result.showDiffs = true;
+        break;
+      case "--auto-send-media":
+        result.autoSendMedia = args[++i];
+        break;
+      case "--system-prompt":
+        result.systemPrompt = args[++i];
         break;
       case "-v":
       case "--verbose":
@@ -491,6 +507,17 @@ async function main(): Promise<void> {
   if (args.maxSessions) config.session.maxConcurrentUsers = args.maxSessions;
   if (args.hideThoughts) config.agent.showThoughts = false;
   if (args.showDiffs) config.agent.showDiffs = true;
+  if (args.autoSendMedia !== undefined) {
+    const mode = args.autoSendMedia.toLowerCase();
+    if (mode !== "off" && mode !== "tagged" && mode !== "all") {
+      console.error(`Error: invalid --auto-send-media value "${args.autoSendMedia}". Must be: off, tagged, or all.`);
+      process.exit(1);
+    }
+    config.agent.autoSendMedia = mode as "off" | "tagged" | "all";
+  }
+  if (args.systemPrompt !== undefined) {
+    config.agent.systemPrompt = args.systemPrompt;
+  }
   config.daemon.enabled = args.daemon;
 
   // Handle daemon mode

--- a/package-lock.json
+++ b/package-lock.json
@@ -604,7 +604,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -815,7 +814,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -967,7 +965,6 @@
       "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
       "integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechat-acp",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "Bridge WeChat to any ACP-compatible AI agent",
   "type": "module",
   "files": [

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -51,6 +51,7 @@ export interface UserSession {
   processing: boolean;
   lastActivity: number;
   createdAt: number;
+  systemPromptSent: boolean;
 }
 
 export interface SessionManagerOpts {
@@ -59,6 +60,8 @@ export interface SessionManagerOpts {
   agentCwd: string;
   agentEnv?: Record<string, string>;
   agentPreset?: string;
+  /** System prompt prepended to the first message of every new session. */
+  agentSystemPrompt?: string;
   idleTimeoutMs: number;
   maxConcurrentUsers: number;
   showThoughts: boolean;
@@ -114,6 +117,15 @@ export class SessionManager {
 
       session = await this.createSession(userId, message.contextToken);
       this.sessions.set(userId, session);
+
+      // Inject system prompt into the first message of a new session
+      if (this.opts.agentSystemPrompt && !session.systemPromptSent) {
+        message.prompt = [
+          { type: "text", text: this.opts.agentSystemPrompt },
+          ...message.prompt,
+        ];
+        session.systemPromptSent = true;
+      }
     }
 
     // Always update contextToken to the latest
@@ -275,6 +287,7 @@ export class SessionManager {
       processing: false,
       lastActivity: Date.now(),
       createdAt: Date.now(),
+      systemPromptSent: false,
     };
   }
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -7,9 +7,11 @@
 
 import type * as acp from "@agentclientprotocol/sdk";
 import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { login, loadToken, type TokenData } from "./weixin/auth.js";
 import { startMonitor } from "./weixin/monitor.js";
-import { sendTextMessage, splitText } from "./weixin/send.js";
+import { sendImageMessage, sendFileMessage, sendTextMessage, splitText } from "./weixin/send.js";
 import { sendTyping, getConfig } from "./weixin/api.js";
 import { TypingStatus, MessageType } from "./weixin/types.js";
 import type { WeixinMessage } from "./weixin/types.js";
@@ -128,6 +130,7 @@ export class WeChatAcpBridge {
       agentCwd: this.config.agent.cwd,
       agentEnv: this.config.agent.env,
       agentPreset: this.config.agent.preset ?? "raw",
+      agentSystemPrompt: this.config.agent.systemPrompt,
       idleTimeoutMs: this.config.session.idleTimeoutMs,
       maxConcurrentUsers: this.config.session.maxConcurrentUsers,
       showThoughts: this.config.agent.showThoughts,
@@ -666,6 +669,11 @@ export class WeChatAcpBridge {
       );
     }
 
+    // Auto-send media files referenced in reply text (e.g. markdown image links)
+    if (this.config.agent.cwd) {
+      await this.tryAutoSendMedia(userId, contextToken, text);
+    }
+
     trackEvent(
       "reply.sent",
       {
@@ -989,6 +997,186 @@ export class WeChatAcpBridge {
     const slashIndex = value.lastIndexOf("/");
     if (slashIndex >= 0 && slashIndex < value.length - 1) {
       return value.slice(slashIndex + 1);
+    }
+
+    return value;
+  }
+
+  // ── Auto-send media (images / files) referenced in agent reply ────────
+
+  /**
+   * Scan the reply text for file-path references (markdown links and
+   * backtick-enclosed paths), resolve them inside the agent workspace,
+   * and send the corresponding files as WeChat media messages.
+   *
+   * Modeled after codex-wechat's `sendAssistantAttachmentsForReply()` and
+   * `extractAutoSendFilePathsFromReply()`.
+   */
+  private async tryAutoSendMedia(
+    userId: string,
+    contextToken: string,
+    text: string,
+  ): Promise<void> {
+    const mode = this.config.agent.autoSendMedia ?? "all";
+    if (mode === "off") return;
+
+    const cwd = path.resolve(this.config.agent.cwd);
+    const candidates =
+      mode === "tagged"
+        ? this.extractTaggedFilePaths(text)
+        : this.extractFilePathsFromReply(text);
+
+    for (const relPath of candidates) {
+      const fullPath = path.resolve(cwd, relPath);
+
+      // Security: must stay within the agent workspace
+      if (!fullPath.startsWith(cwd + path.sep) && fullPath !== cwd) {
+        continue;
+      }
+
+      let buf: Buffer;
+      try {
+        buf = await fs.readFile(fullPath);
+      } catch {
+        continue;
+      }
+
+      const ext = path.extname(fullPath).toLowerCase();
+      const imageExts = new Set([
+        ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg",
+      ]);
+      const isImage = imageExts.has(ext);
+
+      const opts = {
+        baseUrl: this.tokenData!.baseUrl,
+        token: this.tokenData!.token,
+        contextToken,
+        cdnBaseUrl: this.config.wechat.cdnBaseUrl,
+      };
+
+      try {
+        if (isImage) {
+          await sendImageMessage(userId, buf, opts);
+        } else {
+          await sendFileMessage(userId, path.basename(fullPath), buf, opts);
+        }
+        this.log(
+          `Auto-sent media: ${path.relative(cwd, fullPath)} (${buf.length} bytes)`,
+        );
+      } catch (err) {
+        this.log(
+          `Failed to auto-send media ${path.relative(cwd, fullPath)}: ${String(err)}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Extract file-path candidates from reply text.
+   *
+   * Supports two patterns (matching codex-wechat):
+   *  - Markdown links: `![alt](path)` or `[text](path)`
+   *  - Backtick-enclosed paths: `` `path` ``
+   */
+  private extractFilePathsFromReply(text: string): string[] {
+    const candidates: string[] = [];
+    const seen = new Set<string>();
+
+    // Markdown image / link references
+    const mdLinkRe = /!?\[[^\]]*\]\(([^)\n]+)\)/g;
+    let m: RegExpExecArray | null;
+    while ((m = mdLinkRe.exec(text)) !== null) {
+      const raw = (m[1] ?? "").trim();
+      if (raw) {
+        const cleaned = this.stripPathDecorations(raw);
+        if (cleaned && !seen.has(cleaned)) {
+          seen.add(cleaned);
+          candidates.push(cleaned);
+        }
+      }
+    }
+
+    // Backtick-enclosed paths
+    const btRe = /`([^`\n]+)`/g;
+    while ((m = btRe.exec(text)) !== null) {
+      const raw = (m[1] ?? "").trim();
+      if (raw) {
+        const cleaned = this.stripPathDecorations(raw);
+        if (cleaned && !seen.has(cleaned)) {
+          seen.add(cleaned);
+          candidates.push(cleaned);
+        }
+      }
+    }
+
+    return candidates;
+  }
+
+  /**
+   * Extract file-path candidates tagged with `@send:` marker.
+   *
+   * Supports patterns:
+   *  - `@send:path/to/file` — explicit send marker
+   *  - `📎path/to/file` — emoji send marker
+   *
+   * Only these explicitly tagged paths are returned; regular file
+   * references in code discussions are ignored.
+   */
+  private extractTaggedFilePaths(text: string): string[] {
+    const candidates: string[] = [];
+    const seen = new Set<string>();
+
+    // @send: marker
+    const sendRe = /@send:(\S+)/g;
+    let m: RegExpExecArray | null;
+    while ((m = sendRe.exec(text)) !== null) {
+      const raw = (m[1] ?? "").trim();
+      if (raw && !seen.has(raw)) {
+        seen.add(raw);
+        candidates.push(raw);
+      }
+    }
+
+    // 📎 emoji marker
+    const emojiRe = /📎(\S+)/g;
+    while ((m = emojiRe.exec(text)) !== null) {
+      const raw = (m[1] ?? "").trim();
+      if (raw && !seen.has(raw)) {
+        seen.add(raw);
+        candidates.push(raw);
+      }
+    }
+
+    return candidates;
+  }
+
+  /**
+   * Strip decorations from a raw path candidate so it resolves cleanly:
+   *  - `< >` wrapping (auto-linked bare paths on some platforms)
+   *  - `#L…` line references from editor / code-review links
+   *  - `file.ext:line:col` suffixes
+   */
+  private stripPathDecorations(candidate: string): string {
+    let value = candidate.trim();
+    if (!value) return "";
+
+    // Strip <...> wrapping
+    if (value.startsWith("<") && value.endsWith(">")) {
+      value = value.slice(1, -1).trim();
+    }
+
+    // Strip #L... line anchor
+    const hashIdx = value.indexOf("#L");
+    if (hashIdx >= 0) {
+      value = value.slice(0, hashIdx).trim();
+    }
+
+    // Strip :line or :line:col suffix on filenames
+    const lineSuffixMatch = value.match(
+      /^(.*\.[A-Za-z0-9_-]+):\d+(?::\d+)?$/,
+    );
+    if (lineSuffixMatch) {
+      value = lineSuffixMatch[1]!;
     }
 
     return value;

--- a/src/config.ts
+++ b/src/config.ts
@@ -126,6 +126,28 @@ export interface WeChatAcpConfig {
     env?: Record<string, string>;
     showThoughts: boolean;
     showDiffs?: boolean;
+    /**
+     * System prompt injected at the start of each new agent session.
+     * When set, the text is prepended as the first content block in the
+     * first prompt of every session. Use this to set language preferences,
+     * communication conventions (e.g. file-sharing markers), and context
+     * about the WeChat bridge environment.
+     */
+    systemPrompt?: string;
+    /**
+     * Control auto-send of media files referenced in agent replies.
+     *
+     * - "all":    Current behavior — every markdown link and backtick path
+     *             that resolves to a file inside the agent workspace is
+     *             sent to the user.
+     * - "tagged": Only files explicitly marked with `@send:` (e.g.
+     *             `@send:path/to/file.png`) are sent. Regular file-path
+     *             references in code discussions are ignored.
+     * - "off":    Never auto-send media files.
+     *
+     * @default "all" (backward compatible)
+     */
+    autoSendMedia?: "off" | "tagged" | "all";
   };
   agents: Record<string, AgentPreset>;
   session: {
@@ -196,6 +218,12 @@ export function defaultConfig(opts?: { instance?: string }): WeChatAcpConfig {
       cwd: process.cwd(),
       showThoughts: true,
       showDiffs: false,
+      autoSendMedia: "tagged",
+      systemPrompt:
+        "你是通过 wechat-acp 桥接与用户微信交流的 AI 助手。" +
+        "请用中文回复，除非用户使用其他语言。" +
+        "如需发送文件或图片给用户，需要将文件或图片拷贝到当前目录，在回复中用 @send:相对路径 标记（例如 @send:test.png），bridge 会自动投递。" +
+        "引用代码时使用 文件:行号 格式，避免误触发文件发送。",
     },
     agents: { ...BUILT_IN_AGENTS },
     session: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,14 @@ export {
 	validateCommandAliases,
 	validateInstanceName,
 } from "./config.js";
+export {
+	sendFileMessage,
+	sendImageMessage,
+	sendTextMessage,
+	splitText,
+} from "./weixin/send.js";
+export type {
+	UploadedWeixinMedia,
+	WeixinMediaSendOpts,
+	WeixinSendOpts,
+} from "./weixin/send.js";

--- a/src/weixin/media.ts
+++ b/src/weixin/media.ts
@@ -51,13 +51,22 @@ export async function downloadAndDecrypt(
 
 export async function uploadToCdn(params: {
   buffer: Buffer;
-  uploadParam: string;
+  uploadParam?: string;
+  uploadFullUrl?: string;
   aesKey: Buffer;
   filekey: string;
   cdnBaseUrl: string;
 }): Promise<string> {
   const encrypted = encryptAesEcb(params.buffer, params.aesKey);
-  const url = `${params.cdnBaseUrl}/upload?encrypted_query_param=${encodeURIComponent(params.uploadParam)}&filekey=${encodeURIComponent(params.filekey)}`;
+  const url = params.uploadFullUrl
+    ?? (
+      params.uploadParam
+        ? `${params.cdnBaseUrl}/upload?encrypted_query_param=${encodeURIComponent(params.uploadParam)}&filekey=${encodeURIComponent(params.filekey)}`
+        : null
+    );
+  if (!url) {
+    throw new Error("CDN upload: uploadParam or uploadFullUrl is required");
+  }
 
   const res = await fetch(url, {
     method: "POST",

--- a/src/weixin/send.ts
+++ b/src/weixin/send.ts
@@ -3,13 +3,120 @@
  */
 
 import crypto from "node:crypto";
-import { sendMessage } from "./api.js";
-import { MessageType, MessageState } from "./types.js";
+import { getUploadUrl, sendMessage } from "./api.js";
+import { uploadToCdn } from "./media.js";
+import {
+  MessageItemType,
+  MessageState,
+  MessageType,
+  UploadMediaType,
+  type MessageItem,
+} from "./types.js";
 
 export interface WeixinSendOpts {
   baseUrl: string;
   token?: string;
   contextToken?: string;
+}
+
+export interface WeixinMediaSendOpts extends WeixinSendOpts {
+  cdnBaseUrl: string;
+}
+
+export interface UploadedWeixinMedia {
+  filekey: string;
+  downloadEncryptedQueryParam: string;
+  aesKeyHex: string;
+  md5: string;
+  rawSize: number;
+  ciphertextSize: number;
+}
+
+function aesEcbPaddedSize(size: number): number {
+  return Math.ceil((size + 1) / 16) * 16;
+}
+
+function createCdnMedia(uploaded: UploadedWeixinMedia) {
+  return {
+    encrypt_query_param: uploaded.downloadEncryptedQueryParam,
+    aes_key: Buffer.from(uploaded.aesKeyHex).toString("base64"),
+    encrypt_type: 1,
+  };
+}
+
+async function uploadMediaBuffer(params: {
+  to: string;
+  buffer: Buffer;
+  mediaType: (typeof UploadMediaType)[keyof typeof UploadMediaType];
+  opts: WeixinMediaSendOpts;
+}): Promise<UploadedWeixinMedia> {
+  const aesKey = crypto.randomBytes(16);
+  const filekey = crypto.randomBytes(16).toString("hex");
+  const md5 = crypto.createHash("md5").update(params.buffer).digest("hex");
+  const rawSize = params.buffer.length;
+  const ciphertextSize = aesEcbPaddedSize(rawSize);
+
+  const uploadUrl = await getUploadUrl({
+    baseUrl: params.opts.baseUrl,
+    token: params.opts.token,
+    body: {
+      filekey,
+      media_type: params.mediaType,
+      to_user_id: params.to,
+      rawsize: rawSize,
+      rawfilemd5: md5,
+      filesize: ciphertextSize,
+      no_need_thumb: true,
+      aeskey: aesKey.toString("hex"),
+    },
+  });
+
+  const downloadEncryptedQueryParam = await uploadToCdn({
+    buffer: params.buffer,
+    uploadParam: uploadUrl.upload_param,
+    uploadFullUrl: uploadUrl.upload_full_url,
+    aesKey,
+    filekey,
+    cdnBaseUrl: params.opts.cdnBaseUrl,
+  });
+
+  return {
+    filekey,
+    downloadEncryptedQueryParam,
+    aesKeyHex: aesKey.toString("hex"),
+    md5,
+    rawSize,
+    ciphertextSize,
+  };
+}
+
+async function sendMediaMessage(
+  to: string,
+  item: MessageItem,
+  opts: WeixinSendOpts,
+  clientId?: string,
+): Promise<string> {
+  if (!opts.contextToken) {
+    throw new Error("contextToken is required to send a message");
+  }
+
+  const id = clientId ?? `wechat-acp-${crypto.randomUUID()}`;
+  await sendMessage({
+    baseUrl: opts.baseUrl,
+    token: opts.token,
+    body: {
+      msg: {
+        from_user_id: "",
+        to_user_id: to,
+        client_id: id,
+        message_type: MessageType.BOT,
+        message_state: MessageState.FINISH,
+        context_token: opts.contextToken,
+        item_list: [item],
+      },
+    },
+  });
+  return id;
 }
 
 export async function sendTextMessage(
@@ -43,6 +150,71 @@ export async function sendTextMessage(
     },
   });
   return id;
+}
+
+export async function sendImageMessage(
+  to: string,
+  image: Buffer,
+  opts: WeixinMediaSendOpts,
+  clientId?: string,
+): Promise<string> {
+  if (!opts.contextToken) {
+    throw new Error("contextToken is required to send a message");
+  }
+
+  const uploaded = await uploadMediaBuffer({
+    to,
+    buffer: image,
+    mediaType: UploadMediaType.IMAGE,
+    opts,
+  });
+
+  return sendMediaMessage(
+    to,
+    {
+      type: MessageItemType.IMAGE,
+      image_item: {
+        media: createCdnMedia(uploaded),
+        mid_size: uploaded.ciphertextSize,
+      },
+    },
+    opts,
+    clientId,
+  );
+}
+
+export async function sendFileMessage(
+  to: string,
+  fileName: string,
+  file: Buffer,
+  opts: WeixinMediaSendOpts,
+  clientId?: string,
+): Promise<string> {
+  if (!opts.contextToken) {
+    throw new Error("contextToken is required to send a message");
+  }
+
+  const uploaded = await uploadMediaBuffer({
+    to,
+    buffer: file,
+    mediaType: UploadMediaType.FILE,
+    opts,
+  });
+
+  return sendMediaMessage(
+    to,
+    {
+      type: MessageItemType.FILE,
+      file_item: {
+        media: createCdnMedia(uploaded),
+        file_name: fileName,
+        md5: uploaded.md5,
+        len: String(uploaded.rawSize),
+      },
+    },
+    opts,
+    clientId,
+  );
 }
 
 /**

--- a/src/weixin/types.ts
+++ b/src/weixin/types.ts
@@ -155,6 +155,7 @@ export interface GetUploadUrlReq {
 export interface GetUploadUrlResp {
   upload_param?: string;
   thumb_upload_param?: string;
+  upload_full_url?: string;
 }
 
 export interface SendTypingReq {


### PR DESCRIPTION
- Add media file sending capability in bridge layer
- Update weixin send/media modules for outbound attachments
- Extend session and config to support media types
- Update bin entry for new functionality