### PR TITLE
feat: render ACP image content blocks as WeChat image messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Render ACP `image` content blocks from the agent (in `agent_message_chunk` and completed `tool_call_update` content) as native WeChat image messages, instead of silently dropping them. Images are uploaded to the WeChat CDN (AES-128-ECB, `getuploadurl` + `sendmessage` with an `image_item`) and delivered in stream order relative to surrounding text via the existing per-client flush chain and per-user reply queue. Supported types: png, jpeg, gif, webp, bmp; images above 10 MiB or with other MIME types are skipped with a log line; a failed delivery surfaces as an `[image could not be delivered]` placeholder in the text reply. Enabled by default; disable with `--hide-images` or `agent.showImages: false`. Adds one telemetry event: `reply.image.sent`. Fixes #52.
+- Render ACP `image` content blocks from the agent (in `agent_message_chunk` and completed `tool_call_update` content) as native WeChat image messages, instead of silently dropping them. Images are uploaded to the WeChat CDN (AES-128-ECB, `getuploadurl` + `sendmessage` with an `image_item`) and delivered in stream order relative to surrounding text: all session notifications are handled on a serialized per-client task queue, and outbound sends ride the per-user reply queue. Supported types: png, jpeg, gif, webp, bmp. Unsupported MIME types are skipped with a log line; an image above 10 MiB surfaces as an `[image too large to deliver]` placeholder in the text reply, and a failed delivery as `[image could not be delivered]`. Enabled by default; disable with `--hide-images` or `agent.showImages: false`. Adds one telemetry event: `reply.image.sent`. Fixes #52.
 
 ## 0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Render ACP `image` content blocks from the agent (in `agent_message_chunk` and completed `tool_call_update` content) as native WeChat image messages, instead of silently dropping them. Images are uploaded to the WeChat CDN (AES-128-ECB, `getuploadurl` + `sendmessage` with an `image_item`) and delivered in stream order relative to surrounding text via the existing per-client flush chain and per-user reply queue. Supported types: png, jpeg, gif, webp, bmp; images above 10 MiB or with other MIME types are skipped with a log line; a failed delivery surfaces as an `[image could not be delivered]` placeholder in the text reply. Enabled by default; disable with `--hide-images` or `agent.showImages: false`. Adds one telemetry event: `reply.image.sent`. Fixes #52.
+
 ## 0.8.0
 
 - Hide ACP file diffs by default. Use `--show-diffs` or `agent.showDiffs: true` to forward diffs to WeChat.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Bridge WeChat direct messages to any ACP-compatible AI agent.
 - One ACP agent session per WeChat user
 - Built-in ACP agent presets for common CLIs
 - Custom raw agent command support
+- Agent image output delivered as native WeChat image messages
 - Auto-allow permission requests from the agent
 - Direct message only; group chats are ignored
 - Background daemon mode
@@ -103,6 +104,7 @@ Options:
 - `--no-inbox`: do not save received files; the agent only sees a size notice.
 - `--hide-thoughts`: do not forward agent thinking to WeChat (default: forwarded)
 - `--show-diffs`: forward ACP file diffs to WeChat (default: hidden)
+- `--hide-images`: do not forward agent image output to WeChat (default: forwarded)
 - `inject --text <text>`: enqueue a local text message for the running daemon
 - `-V, --version`: print version and exit
 - `-h, --help`: show help
@@ -438,8 +440,9 @@ WECHAT_ACP_TELEMETRY=0 npx wechat-acp --agent copilot
 - `session.created` — new ACP session opened
 - `prompt.completed` — ACP turn finished; agent preset, stop reason, duration, reply length
 - `reply.sent` — reply pushed back to WeChat; segment count, total length
+- `reply.image.sent`: image reply pushed back to WeChat; byte size, MIME type, duration
 
-Plus exception reports for `monitor`, `prompt`, `reply`, `auth`, `agent_spawn`, `enqueue`, `buffer`, `command`, and `state` failures.
+Plus exception reports for `monitor`, `prompt`, `reply`, `reply.image`, `auth`, `agent_spawn`, `enqueue`, `buffer`, `command`, and `state` failures.
 
 **What is never collected**: message bodies, filenames, voice transcripts, image URLs, login tokens, QR codes, raw agent command strings, environment variables, working directory paths, raw WeChat user IDs.
 

--- a/bin/wechat-acp.ts
+++ b/bin/wechat-acp.ts
@@ -77,6 +77,7 @@ Options:
   --max-sessions <n>  Max concurrent user sessions (default: 10)
   --hide-thoughts     Do not forward agent thinking to WeChat (default: forwarded)
   --show-diffs        Forward ACP file diffs to WeChat (default: hidden)
+  --hide-images       Do not forward agent image output to WeChat (default: forwarded)
   --text <text>       Message text for "inject"
   --file <path>       Read injected message text from a file
   --to <target>       Injection target (default: ${DEFAULT_INJECTION_TARGET})
@@ -136,6 +137,7 @@ function parseArgs(argv: string[]): {
   injectContextToken?: string;
   hideThoughts: boolean;
   showDiffs: boolean;
+  hideImages: boolean;
   verbose: boolean;
   version: boolean;
   help: boolean;
@@ -146,6 +148,7 @@ function parseArgs(argv: string[]): {
     disableInbox: false,
     hideThoughts: false,
     showDiffs: false,
+    hideImages: false,
     verbose: false,
     version: false,
     help: false,
@@ -210,6 +213,9 @@ function parseArgs(argv: string[]): {
         break;
       case "--show-diffs":
         result.showDiffs = true;
+        break;
+      case "--hide-images":
+        result.hideImages = true;
         break;
       case "-v":
       case "--verbose":
@@ -491,6 +497,7 @@ async function main(): Promise<void> {
   if (args.maxSessions) config.session.maxConcurrentUsers = args.maxSessions;
   if (args.hideThoughts) config.agent.showThoughts = false;
   if (args.showDiffs) config.agent.showDiffs = true;
+  if (args.hideImages) config.agent.showImages = false;
   config.daemon.enabled = args.daemon;
 
   // Handle daemon mode

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -249,6 +249,11 @@ export class WeChatAcpClient implements acp.Client {
     }
 
     // Flush any text buffered before this image so ordering is preserved.
+    // Degraded mode: if that flush fails after its retries, the text is
+    // re-buffered for the final flush() and the image is still delivered
+    // now. Strict ordering is knowingly traded for content preservation
+    // here; dropping or deferring a deliverable image because a text
+    // segment hit a transient send failure would lose more than it saves.
     await this.maybeFlushMessage();
 
     const onImageFlush = this.opts.onImageFlush;

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -244,9 +244,10 @@ export class WeChatAcpClient implements acp.Client {
    * message, preserving stream order: buffered text preceding the image is
    * flushed first, then the image is sent. Runs entirely within one task on
    * the notification queue, so no other notification or flush() can observe
-   * or mutate state mid-delivery. Unsupported or oversized payloads are
-   * logged and skipped; a delivery failure surfaces as a placeholder in the
-   * text stream so the turn never silently loses content.
+   * or mutate state mid-delivery. Unsupported MIME types are logged and
+   * skipped; an oversized payload is logged and replaced with a placeholder
+   * in the text stream, as is a failed delivery, so the turn never silently
+   * loses content.
    */
   private async maybeSendImage(image: { data: string; mimeType: string }): Promise<void> {
     if (this.opts.showImages === false) {

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -9,14 +9,36 @@
 import fs from "node:fs";
 import type * as acp from "@agentclientprotocol/sdk";
 
+/** An image content block produced by the agent, ready for outbound delivery. */
+export interface AgentImage {
+  /** Base64-encoded image bytes. */
+  data: string;
+  mimeType: string;
+}
+
+/** Raster formats WeChat can render as native image messages. */
+const SUPPORTED_IMAGE_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/gif",
+  "image/webp",
+  "image/bmp",
+]);
+
+/** Sanity cap on decoded image size (10 MiB). */
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+
 export interface WeChatAcpClientOpts {
   sendTyping: () => Promise<void>;
   onThoughtFlush: (text: string) => Promise<void>;
   onMessageFlush: (text: string) => Promise<void>;
+  onImageFlush?: (image: AgentImage) => Promise<void>;
   onConfigOptionsUpdate?: (configOptions: acp.SessionConfigOption[]) => void;
   log: (msg: string) => void;
   showThoughts: boolean;
   showDiffs?: boolean;
+  showImages?: boolean;
 }
 
 export class WeChatAcpClient implements acp.Client {
@@ -50,12 +72,14 @@ export class WeChatAcpClient implements acp.Client {
     sendTyping: () => Promise<void>;
     onThoughtFlush: (text: string) => Promise<void>;
     onMessageFlush: (text: string) => Promise<void>;
+    onImageFlush?: (image: AgentImage) => Promise<void>;
   }): void {
     this.opts = {
       ...this.opts,
       sendTyping: callbacks.sendTyping,
       onThoughtFlush: callbacks.onThoughtFlush,
       onMessageFlush: callbacks.onMessageFlush,
+      ...(callbacks.onImageFlush ? { onImageFlush: callbacks.onImageFlush } : {}),
     };
   }
 
@@ -89,6 +113,8 @@ export class WeChatAcpClient implements acp.Client {
           if (update.content.text.trim()) {
             this.producedMessageThisTurn = true;
           }
+        } else if (update.content.type === "image") {
+          await this.maybeSendImage(update.content);
         }
         // Throttle typing indicators
         await this.maybeSendTyping();
@@ -131,6 +157,8 @@ export class WeChatAcpClient implements acp.Client {
               }
               this.chunks.push("\n```diff\n" + lines.join("\n") + "\n```\n");
               this.producedMessageThisTurn = true;
+            } else if (c.type === "content" && c.content.type === "image") {
+              await this.maybeSendImage(c.content);
             }
           }
         }
@@ -186,6 +214,65 @@ export class WeChatAcpClient implements acp.Client {
     this.chunks = [];
     this.lastTypingAt = 0;
     return text;
+  }
+
+  /**
+   * Deliver an agent-produced image content block as a native WeChat image
+   * message, preserving stream order: buffered text preceding the image is
+   * flushed first, and the image send itself is serialized on the same
+   * mutex chain as message flushes so concurrent notifications cannot
+   * reorder it. Unsupported or oversized payloads are logged and skipped;
+   * a delivery failure surfaces as a placeholder in the text stream so the
+   * turn never silently loses content.
+   */
+  private async maybeSendImage(image: { data: string; mimeType: string }): Promise<void> {
+    if (this.opts.showImages === false) {
+      this.opts.log(`[image] skipped (showImages=false, ${image.mimeType})`);
+      return;
+    }
+    if (!this.opts.onImageFlush) {
+      this.opts.log(`[image] skipped (no image sink configured, ${image.mimeType})`);
+      return;
+    }
+    const mime = image.mimeType.toLowerCase();
+    if (!SUPPORTED_IMAGE_MIME_TYPES.has(mime)) {
+      this.opts.log(`[image] skipped unsupported type: ${image.mimeType}`);
+      return;
+    }
+    // ceil(base64Len / 4) * 3 over-estimates by at most 2 bytes; fine for a cap.
+    const approxBytes = Math.ceil(image.data.length / 4) * 3;
+    if (approxBytes > MAX_IMAGE_BYTES) {
+      this.opts.log(`[image] skipped oversized image (~${approxBytes} bytes > ${MAX_IMAGE_BYTES})`);
+      this.chunks.push("\n⚠️ [image too large to deliver]\n");
+      this.producedMessageThisTurn = true;
+      return;
+    }
+
+    // Flush any text buffered before this image so ordering is preserved.
+    await this.maybeFlushMessage();
+
+    const onImageFlush = this.opts.onImageFlush;
+    const prev = this.messageFlushChain;
+    let release!: () => void;
+    this.messageFlushChain = new Promise<void>((r) => {
+      release = r;
+    });
+    await prev.catch(() => {});
+
+    try {
+      // Single attempt here: the bridge-side sink owns retries (with a stable
+      // client_id for gateway de-duplication), so retrying again at this layer
+      // would multiply CDN uploads.
+      await onImageFlush(image);
+      this.opts.log(`[image] sent (${image.mimeType}, ~${approxBytes} bytes)`);
+      this.producedMessageThisTurn = true;
+    } catch (err) {
+      this.opts.log(`[image] delivery failed: ${String(err)}`);
+      this.chunks.push("\n⚠️ [image could not be delivered]\n");
+      this.producedMessageThisTurn = true;
+    } finally {
+      release();
+    }
   }
 
   private async maybeFlushThoughts(): Promise<void> {

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -47,9 +47,13 @@ export class WeChatAcpClient implements acp.Client {
   private opts: WeChatAcpClientOpts;
   private lastTypingAt = 0;
   private producedMessageThisTurn = false;
-  // Promise chain serializing onMessageFlush calls so concurrent boundary events
-  // cannot interleave sends (e.g. chunk B reaching WeChat before chunk A).
-  private messageFlushChain: Promise<void> = Promise.resolve();
+  // FIFO task queue serializing all session-notification handling and flush()
+  // reads. The ACP SDK dispatches notifications without awaiting handlers, so
+  // without this two sessionUpdate calls interleave at their first await:
+  // sends can reorder, and flush() can read the buffer while an image send is
+  // still in flight. Slots are reserved synchronously at call time, so queue
+  // order always matches stream order.
+  private taskChain: Promise<void> = Promise.resolve();
   private static readonly TYPING_INTERVAL_MS = 5_000;
   private static readonly SEND_MAX_ATTEMPTS = 3;
   private static readonly SEND_RETRY_BASE_MS = 300;
@@ -102,7 +106,23 @@ export class WeChatAcpClient implements acp.Client {
     };
   }
 
+  /** Run `task` after all previously enqueued tasks. The slot is reserved
+   * synchronously, before the first await, so callers racing into this method
+   * are ordered by call time and nothing can jump the queue. */
+  private enqueue<T>(task: () => Promise<T>): Promise<T> {
+    const run = this.taskChain.then(task);
+    this.taskChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
   async sessionUpdate(params: acp.SessionNotification): Promise<void> {
+    return this.enqueue(() => this.handleSessionUpdate(params));
+  }
+
+  private async handleSessionUpdate(params: acp.SessionNotification): Promise<void> {
     const update = params.update;
 
     switch (update.sessionUpdate) {
@@ -206,24 +226,27 @@ export class WeChatAcpClient implements acp.Client {
 
   /** Get accumulated text and reset the buffer. Also flushes any remaining thoughts. */
   async flush(): Promise<string> {
-    await this.maybeFlushThoughts();
-    // Drain any in-flight sends (queued by maybeFlushMessage) before reading
-    // the buffer so a retried-and-restored flush cannot race with this read.
-    await this.messageFlushChain.catch(() => {});
-    const text = this.chunks.join("");
-    this.chunks = [];
-    this.lastTypingAt = 0;
-    return text;
+    // Joins the task queue so any in-flight notification work (a pending text
+    // send, an image upload) completes before the buffer is read. This also
+    // guarantees hasProducedMessage is final when flush() resolves, so an
+    // image-only turn is never mistaken for an empty one.
+    return this.enqueue(async () => {
+      await this.maybeFlushThoughts();
+      const text = this.chunks.join("");
+      this.chunks = [];
+      this.lastTypingAt = 0;
+      return text;
+    });
   }
 
   /**
    * Deliver an agent-produced image content block as a native WeChat image
    * message, preserving stream order: buffered text preceding the image is
-   * flushed first, and the image send itself is serialized on the same
-   * mutex chain as message flushes so concurrent notifications cannot
-   * reorder it. Unsupported or oversized payloads are logged and skipped;
-   * a delivery failure surfaces as a placeholder in the text stream so the
-   * turn never silently loses content.
+   * flushed first, then the image is sent. Runs entirely within one task on
+   * the notification queue, so no other notification or flush() can observe
+   * or mutate state mid-delivery. Unsupported or oversized payloads are
+   * logged and skipped; a delivery failure surfaces as a placeholder in the
+   * text stream so the turn never silently loses content.
    */
   private async maybeSendImage(image: { data: string; mimeType: string }): Promise<void> {
     if (this.opts.showImages === false) {
@@ -256,27 +279,19 @@ export class WeChatAcpClient implements acp.Client {
     // segment hit a transient send failure would lose more than it saves.
     await this.maybeFlushMessage();
 
-    const onImageFlush = this.opts.onImageFlush;
-    const prev = this.messageFlushChain;
-    let release!: () => void;
-    this.messageFlushChain = new Promise<void>((r) => {
-      release = r;
-    });
-    await prev.catch(() => {});
-
     try {
       // Single attempt here: the bridge-side sink owns retries (with a stable
       // client_id for gateway de-duplication), so retrying again at this layer
       // would multiply CDN uploads.
-      await onImageFlush(image);
+      await this.opts.onImageFlush(image);
       this.opts.log(`[image] sent (${image.mimeType}, ~${approxBytes} bytes)`);
       this.producedMessageThisTurn = true;
     } catch (err) {
       this.opts.log(`[image] delivery failed: ${String(err)}`);
+      // Queue serialization means no later text has been buffered yet, so the
+      // placeholder lands exactly where the image belonged in the stream.
       this.chunks.push("\n⚠️ [image could not be delivered]\n");
       this.producedMessageThisTurn = true;
-    } finally {
-      release();
     }
   }
 
@@ -298,48 +313,27 @@ export class WeChatAcpClient implements acp.Client {
    * Stream the buffered agent message (and any embedded diffs) as its own
    * WeChat reply. Called at thought/tool_call boundaries so multi-step turns
    * surface narrative segments in order; the final segment is still returned
-   * by `flush()` so the caller can append stop-reason suffixes.
+   * by `flush()` so the caller can append stop-reason suffixes. Always runs
+   * within a task on the notification queue, which guarantees FIFO send
+   * order without needing its own mutex.
    */
   private async maybeFlushMessage(): Promise<void> {
     if (this.chunks.length === 0) return;
     const text = this.chunks.join("");
+    this.chunks = [];
     if (!text.trim()) {
-      this.chunks = [];
       return;
     }
-    // Clear the buffer synchronously BEFORE awaiting so that any concurrent
-    // sessionUpdate calls (the ACP SDK fires notifications without awaiting
-    // handlers) see an empty buffer and skip the flush instead of re-sending
-    // the same text. New chunks arriving during the send are appended to the
-    // now-empty array and flushed at the next boundary.
-    this.chunks = [];
 
-    // Acquire a send slot using a simple mutex chain: each caller saves the
-    // current tail of the chain, replaces it with a new unresolved promise,
-    // and awaits the old tail before sending. This guarantees strict FIFO
-    // ordering — chunk A always reaches WeChat before chunk B even when both
-    // boundary events fire nearly simultaneously.
-    const prev = this.messageFlushChain;
-    let resolve!: () => void;
-    this.messageFlushChain = new Promise<void>((r) => {
-      resolve = r;
-    });
-    await prev.catch(() => {});
-
-    try {
-      const ok = await this.sendWithRetry(() => this.opts.onMessageFlush(text), "message");
-      if (!ok) {
-        // Send failed after all retries. Prepend the unsent text back so the
-        // final flush() returns it and session.ts re-attempts via onReply (which
-        // surfaces failure to the user). Any new chunks appended during the
-        // failed send attempts are preserved after the restored text.
-        this.chunks = [text, ...this.chunks];
-        this.opts.log(
-          `[flush] message send failed after retries; retaining ${text.length} chars for final flush`,
-        );
-      }
-    } finally {
-      resolve();
+    const ok = await this.sendWithRetry(() => this.opts.onMessageFlush(text), "message");
+    if (!ok) {
+      // Send failed after all retries. Prepend the unsent text back so the
+      // final flush() returns it and session.ts re-attempts via onReply (which
+      // surfaces failure to the user).
+      this.chunks = [text, ...this.chunks];
+      this.opts.log(
+        `[flush] message send failed after retries; retaining ${text.length} chars for final flush`,
+      );
     }
   }
 

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -7,7 +7,7 @@
 
 import type { ChildProcess } from "node:child_process";
 import type * as acp from "@agentclientprotocol/sdk";
-import { WeChatAcpClient } from "./client.js";
+import { WeChatAcpClient, type AgentImage } from "./client.js";
 import { spawnAgent, killAgent, type AgentProcessInfo } from "./agent-manager.js";
 import { trackEvent, trackException, hashUserId } from "../telemetry/index.js";
 
@@ -63,8 +63,10 @@ export interface SessionManagerOpts {
   maxConcurrentUsers: number;
   showThoughts: boolean;
   showDiffs?: boolean;
+  showImages?: boolean;
   log: (msg: string) => void;
   onReply: (userId: string, contextToken: string, text: string) => Promise<void>;
+  onReplyImage?: (userId: string, contextToken: string, image: AgentImage) => Promise<void>;
   sendTyping: (userId: string, contextToken: string) => Promise<void>;
 }
 
@@ -225,6 +227,9 @@ export class SessionManager {
       sendTyping: () => this.opts.sendTyping(userId, contextToken),
       onThoughtFlush: (text) => this.opts.onReply(userId, contextToken, text),
       onMessageFlush: (text) => this.opts.onReply(userId, contextToken, text),
+      ...(this.opts.onReplyImage
+        ? { onImageFlush: (image: AgentImage) => this.opts.onReplyImage!(userId, contextToken, image) }
+        : {}),
       onConfigOptionsUpdate: (configOptions) => {
         const session = this.sessions.get(userId);
         if (!session || session.client !== client) return;
@@ -234,6 +239,7 @@ export class SessionManager {
       log: (msg) => this.opts.log(`[${userId}] ${msg}`),
       showThoughts: this.opts.showThoughts,
       showDiffs: this.opts.showDiffs ?? false,
+      showImages: this.opts.showImages ?? true,
     });
 
     const agentInfo = await spawnAgent({
@@ -289,6 +295,12 @@ export class SessionManager {
           sendTyping: () => this.opts.sendTyping(session.userId, pending.contextToken),
           onThoughtFlush: (text) => this.opts.onReply(session.userId, pending.contextToken, text),
           onMessageFlush: (text) => this.opts.onReply(session.userId, pending.contextToken, text),
+          ...(this.opts.onReplyImage
+            ? {
+                onImageFlush: (image: AgentImage) =>
+                  this.opts.onReplyImage!(session.userId, pending.contextToken, image),
+              }
+            : {}),
         });
 
         // Reset chunks for the new turn

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -9,7 +9,8 @@ import type * as acp from "@agentclientprotocol/sdk";
 import crypto from "node:crypto";
 import { login, loadToken, type TokenData } from "./weixin/auth.js";
 import { startMonitor } from "./weixin/monitor.js";
-import { sendTextMessage, sendImageMessage, splitText } from "./weixin/send.js";
+import { sendTextMessage, uploadImageMedia, sendImageItem, splitText } from "./weixin/send.js";
+import type { UploadedImageMedia } from "./weixin/send.js";
 import { sendTyping, getConfig } from "./weixin/api.js";
 import { TypingStatus, MessageType } from "./weixin/types.js";
 import type { WeixinMessage } from "./weixin/types.js";
@@ -702,26 +703,27 @@ export class WeChatAcpBridge {
   private async deliverImage(userId: string, contextToken: string, image: AgentImage): Promise<void> {
     const buffer = Buffer.from(image.data, "base64");
     const startedAt = Date.now();
-    // Stable idempotency key across attempts; the iLink gateway de-duplicates
-    // the send-message call by client_id (the CDN upload preceding it is
-    // harmless to repeat).
+    // Stable idempotency key across attempts. Together with reusing the
+    // uploaded media descriptor below, every send attempt carries a
+    // byte-identical payload, so the iLink gateway can de-duplicate by
+    // client_id without a retry ever referencing different media.
     const clientId = `wechat-acp-${crypto.randomUUID()}`;
+    const sendOpts = {
+      baseUrl: this.tokenData!.baseUrl,
+      token: this.tokenData!.token,
+      contextToken,
+      cdnBaseUrl: this.config.wechat.cdnBaseUrl,
+    };
+    let media: UploadedImageMedia | null = null;
     let lastError: unknown;
 
     for (let attempt = 1; attempt <= SEGMENT_SEND_MAX_ATTEMPTS; attempt++) {
       try {
+        // Upload once; only re-run if a previous attempt failed before the
+        // upload completed. A send-stage failure retries with the same media.
+        media ??= await uploadImageMedia(userId, buffer, sendOpts);
         await this.paceConsecutiveSend(userId);
-        await sendImageMessage(
-          userId,
-          buffer,
-          {
-            baseUrl: this.tokenData!.baseUrl,
-            token: this.tokenData!.token,
-            contextToken,
-            cdnBaseUrl: this.config.wechat.cdnBaseUrl,
-          },
-          clientId,
-        );
+        await sendImageItem(userId, media, sendOpts, clientId);
         trackEvent(
           "reply.image.sent",
           {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -9,11 +9,12 @@ import type * as acp from "@agentclientprotocol/sdk";
 import crypto from "node:crypto";
 import { login, loadToken, type TokenData } from "./weixin/auth.js";
 import { startMonitor } from "./weixin/monitor.js";
-import { sendTextMessage, splitText } from "./weixin/send.js";
+import { sendTextMessage, sendImageMessage, splitText } from "./weixin/send.js";
 import { sendTyping, getConfig } from "./weixin/api.js";
 import { TypingStatus, MessageType } from "./weixin/types.js";
 import type { WeixinMessage } from "./weixin/types.js";
 import { SessionManager } from "./acp/session.js";
+import type { AgentImage } from "./acp/client.js";
 import { weixinMessageToPrompt } from "./adapter/inbound.js";
 import type { WeChatAcpConfig } from "./config.js";
 import { BRIDGE_COMMANDS, resolveCommandAliases, resolveCommandNames } from "./config.js";
@@ -132,8 +133,10 @@ export class WeChatAcpBridge {
       maxConcurrentUsers: this.config.session.maxConcurrentUsers,
       showThoughts: this.config.agent.showThoughts,
       showDiffs: this.config.agent.showDiffs ?? false,
+      showImages: this.config.agent.showImages ?? true,
       log: this.log,
       onReply: (userId, contextToken, text) => this.sendReply(userId, contextToken, text),
+      onReplyImage: (userId, contextToken, image) => this.sendImageReply(userId, contextToken, image),
       sendTyping: (userId, contextToken) => this.sendTypingIndicator(userId, contextToken),
     });
     this.sessionManager.start();
@@ -680,6 +683,70 @@ export class WeChatAcpBridge {
 
     // Cancel typing indicator after reply is sent
     this.cancelTypingIndicator(userId, contextToken).catch(() => {});
+  }
+
+  private async sendImageReply(userId: string, contextToken: string, image: AgentImage): Promise<void> {
+    // Ride the same per-user chain as text replies so an image cannot
+    // interleave with the segments of a concurrent text reply.
+    const previous = this.sendChains.get(userId) ?? Promise.resolve();
+    const current = previous
+      .catch(() => {})
+      .then(() => this.deliverImage(userId, contextToken, image));
+    this.sendChains.set(
+      userId,
+      current.catch(() => {}),
+    );
+    return current;
+  }
+
+  private async deliverImage(userId: string, contextToken: string, image: AgentImage): Promise<void> {
+    const buffer = Buffer.from(image.data, "base64");
+    const startedAt = Date.now();
+    // Stable idempotency key across attempts; the iLink gateway de-duplicates
+    // the send-message call by client_id (the CDN upload preceding it is
+    // harmless to repeat).
+    const clientId = `wechat-acp-${crypto.randomUUID()}`;
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= SEGMENT_SEND_MAX_ATTEMPTS; attempt++) {
+      try {
+        await this.paceConsecutiveSend(userId);
+        await sendImageMessage(
+          userId,
+          buffer,
+          {
+            baseUrl: this.tokenData!.baseUrl,
+            token: this.tokenData!.token,
+            contextToken,
+            cdnBaseUrl: this.config.wechat.cdnBaseUrl,
+          },
+          clientId,
+        );
+        trackEvent(
+          "reply.image.sent",
+          {
+            userIdHash: hashUserId(userId),
+            bytes: buffer.length,
+            mimeType: image.mimeType,
+            durationMs: Date.now() - startedAt,
+          },
+          hashUserId(userId),
+        );
+        this.cancelTypingIndicator(userId, contextToken).catch(() => {});
+        return;
+      } catch (err) {
+        lastError = err;
+        trackException(err, "reply.image", hashUserId(userId));
+        if (attempt < SEGMENT_SEND_MAX_ATTEMPTS) {
+          await new Promise((r) => setTimeout(r, SEGMENT_SEND_RETRY_BASE_MS * attempt));
+        }
+      }
+    }
+
+    // Propagate so the ACP client appends its delivery-failure placeholder.
+    throw lastError instanceof Error
+      ? lastError
+      : new Error(`deliverImage: failed after ${SEGMENT_SEND_MAX_ATTEMPTS} attempts`);
   }
 
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -126,6 +126,12 @@ export interface WeChatAcpConfig {
     env?: Record<string, string>;
     showThoughts: boolean;
     showDiffs?: boolean;
+    /**
+     * Render agent-produced ACP `image` content blocks as native WeChat
+     * image messages. Defaults to `true`; set to `false` (or pass
+     * `--hide-images`) to drop them.
+     */
+    showImages?: boolean;
   };
   agents: Record<string, AgentPreset>;
   session: {
@@ -196,6 +202,7 @@ export function defaultConfig(opts?: { instance?: string }): WeChatAcpConfig {
       cwd: process.cwd(),
       showThoughts: true,
       showDiffs: false,
+      showImages: true,
     },
     agents: { ...BUILT_IN_AGENTS },
     session: {

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -36,7 +36,8 @@ export type EventName =
   | "command.buffer_done"
   | "session.created"
   | "prompt.completed"
-  | "reply.sent";
+  | "reply.sent"
+  | "reply.image.sent";
 
 type PropValue = string | number | boolean;
 

--- a/src/weixin/media.ts
+++ b/src/weixin/media.ts
@@ -16,6 +16,11 @@ export function decryptAesEcb(ciphertext: Buffer, key: Buffer): Buffer {
   return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
 }
 
+/** Compute AES-128-ECB ciphertext size (PKCS7 padding to a 16-byte boundary). */
+export function aesEcbPaddedSize(plaintextSize: number): number {
+  return Math.ceil((plaintextSize + 1) / 16) * 16;
+}
+
 /**
  * Parse the AES key from CDN media reference.
  * The key can be either:
@@ -51,13 +56,23 @@ export async function downloadAndDecrypt(
 
 export async function uploadToCdn(params: {
   buffer: Buffer;
-  uploadParam: string;
+  uploadParam?: string;
+  /** Full upload URL from getUploadUrl; takes precedence over uploadParam when set. */
+  uploadFullUrl?: string;
   aesKey: Buffer;
   filekey: string;
   cdnBaseUrl: string;
 }): Promise<string> {
   const encrypted = encryptAesEcb(params.buffer, params.aesKey);
-  const url = `${params.cdnBaseUrl}/upload?encrypted_query_param=${encodeURIComponent(params.uploadParam)}&filekey=${encodeURIComponent(params.filekey)}`;
+  const fullUrl = params.uploadFullUrl?.trim();
+  let url: string;
+  if (fullUrl) {
+    url = fullUrl;
+  } else if (params.uploadParam) {
+    url = `${params.cdnBaseUrl}/upload?encrypted_query_param=${encodeURIComponent(params.uploadParam)}&filekey=${encodeURIComponent(params.filekey)}`;
+  } else {
+    throw new Error("CDN upload: need uploadFullUrl or uploadParam");
+  }
 
   const res = await fetch(url, {
     method: "POST",

--- a/src/weixin/media.ts
+++ b/src/weixin/media.ts
@@ -42,15 +42,47 @@ export function parseAesKey(media: CDNMedia): Buffer | null {
   return decoded.subarray(0, 16);
 }
 
+/** Default bound on a single CDN request (upload or download). Generous for
+ * multi-MiB image bodies, but finite so a hung request rejects and the
+ * caller's retry logic regains control (image sends run on the serialized
+ * per-client task queue; an unsettled request there would stall every later
+ * notification and the final flush). */
+const CDN_TIMEOUT_MS = 60_000;
+
+/** Run a CDN request under a bounded timeout, mirroring apiPost. The signal
+ * stays armed across body consumption, and a timeout rejects with a
+ * descriptive error instead of hanging or being swallowed. */
+async function withCdnTimeout<T>(
+  timeoutMs: number,
+  label: string,
+  run: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await run(controller.signal);
+  } catch (err) {
+    if ((err as Error).name === "AbortError") {
+      throw new Error(`${label} timed out after ${timeoutMs}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export async function downloadAndDecrypt(
   encryptQueryParam: string,
   aesKey: Buffer,
   cdnBaseUrl: string,
+  timeoutMs = CDN_TIMEOUT_MS,
 ): Promise<Buffer> {
   const url = `${cdnBaseUrl}/download?encrypted_query_param=${encodeURIComponent(encryptQueryParam)}`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`CDN download failed: HTTP ${res.status}`);
-  const ciphertext = Buffer.from(await res.arrayBuffer());
+  const ciphertext = await withCdnTimeout(timeoutMs, "CDN download", async (signal) => {
+    const res = await fetch(url, { signal });
+    if (!res.ok) throw new Error(`CDN download failed: HTTP ${res.status}`);
+    return Buffer.from(await res.arrayBuffer());
+  });
   return decryptAesEcb(ciphertext, aesKey);
 }
 
@@ -62,6 +94,7 @@ export async function uploadToCdn(params: {
   aesKey: Buffer;
   filekey: string;
   cdnBaseUrl: string;
+  timeoutMs?: number;
 }): Promise<string> {
   const encrypted = encryptAesEcb(params.buffer, params.aesKey);
   const fullUrl = params.uploadFullUrl?.trim();
@@ -74,11 +107,14 @@ export async function uploadToCdn(params: {
     throw new Error("CDN upload: need uploadFullUrl or uploadParam");
   }
 
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/octet-stream" },
-    body: encrypted,
-  });
+  const res = await withCdnTimeout(params.timeoutMs ?? CDN_TIMEOUT_MS, "CDN upload", (signal) =>
+    fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: encrypted,
+      signal,
+    }),
+  );
 
   if (!res.ok) throw new Error(`CDN upload failed: HTTP ${res.status}`);
   const downloadParam = res.headers.get("x-encrypted-param");

--- a/src/weixin/send.ts
+++ b/src/weixin/send.ts
@@ -60,33 +60,36 @@ export interface WeixinImageSendOpts extends WeixinSendOpts {
 }
 
 /**
- * Upload an image to the WeChat CDN and send it as a native image message.
- *
- * Protocol (mirrors @tencent-weixin/openclaw-weixin):
- *   - random 16-byte AES key + 32-hex-char filekey
- *   - getuploadurl with media_type=IMAGE, plaintext md5/size, padded ciphertext size
- *   - AES-128-ECB encrypt + CDN POST; download param comes back via x-encrypted-param
- *   - sendmessage with image_item.media { encrypt_query_param, aes_key, encrypt_type: 1 }
- *     where aes_key is the base64 of the hex-encoded key string (the same convention
- *     parseAesKey() decodes on the inbound path) and mid_size is the ciphertext size.
- *
- * Returns the client_id used, so callers can retry with the same id for
- * gateway de-duplication.
+ * CDN media descriptor for an uploaded image, ready to be attached to an
+ * `image_item`. Stable across send retries: callers that retry a failed
+ * send reuse the same descriptor (and the same `client_id`) so every
+ * attempt carries a byte-identical payload and the iLink gateway can
+ * safely de-duplicate.
  */
-export async function sendImageMessage(
+export interface UploadedImageMedia {
+  encrypt_query_param: string;
+  /** Base64 of the hex-encoded AES key, the convention parseAesKey() decodes. */
+  aes_key: string;
+  /** Ciphertext size (PKCS7-padded), reported as mid_size. */
+  mid_size: number;
+}
+
+/**
+ * Upload an image to the WeChat CDN: random 16-byte AES key + 32-hex-char
+ * filekey, getuploadurl with media_type=IMAGE, plaintext md5/size, padded
+ * ciphertext size, then AES-128-ECB encrypt + CDN POST. The download param
+ * comes back via the x-encrypted-param response header.
+ *
+ * Protocol mirrors @tencent-weixin/openclaw-weixin.
+ */
+export async function uploadImageMedia(
   to: string,
   image: Buffer,
   opts: WeixinImageSendOpts,
-  clientId?: string,
   deps?: ImageSendDeps,
-): Promise<string> {
-  if (!opts.contextToken) {
-    throw new Error("contextToken is required to send a message");
-  }
-
+): Promise<UploadedImageMedia> {
   const getUploadUrlFn = deps?.getUploadUrlFn ?? getUploadUrl;
   const uploadFn = deps?.uploadFn ?? uploadToCdn;
-  const sendFn = deps?.sendFn ?? sendMessage;
 
   const rawsize = image.length;
   const rawfilemd5 = crypto.createHash("md5").update(image).digest("hex");
@@ -122,6 +125,34 @@ export async function sendImageMessage(
     cdnBaseUrl: opts.cdnBaseUrl,
   });
 
+  return {
+    encrypt_query_param: downloadParam,
+    // aes_key is the base64 of the ASCII hex string, the same convention
+    // parseAesKey() decodes on the inbound path.
+    aes_key: Buffer.from(aesKey.toString("hex")).toString("base64"),
+    mid_size: filesize,
+  };
+}
+
+/**
+ * Send an already-uploaded image as a native image message. Retry-safe:
+ * with the same `media` and `clientId`, every attempt sends a byte-identical
+ * message, so the iLink gateway de-duplicates by client_id without any risk
+ * of the retry carrying different media metadata.
+ *
+ * Returns the client_id used.
+ */
+export async function sendImageItem(
+  to: string,
+  media: UploadedImageMedia,
+  opts: WeixinSendOpts,
+  clientId?: string,
+  sendFn: typeof sendMessage = sendMessage,
+): Promise<string> {
+  if (!opts.contextToken) {
+    throw new Error("contextToken is required to send a message");
+  }
+
   const id = clientId ?? `wechat-acp-${crypto.randomUUID()}`;
   await sendFn({
     baseUrl: opts.baseUrl,
@@ -139,11 +170,11 @@ export async function sendImageMessage(
             type: MessageItemType.IMAGE,
             image_item: {
               media: {
-                encrypt_query_param: downloadParam,
-                aes_key: Buffer.from(aesKey.toString("hex")).toString("base64"),
+                encrypt_query_param: media.encrypt_query_param,
+                aes_key: media.aes_key,
                 encrypt_type: 1,
               },
-              mid_size: filesize,
+              mid_size: media.mid_size,
             },
           },
         ],
@@ -151,6 +182,29 @@ export async function sendImageMessage(
     },
   });
   return id;
+}
+
+/**
+ * Upload an image to the WeChat CDN and send it as a native image message
+ * in one shot. Convenience composition of {@link uploadImageMedia} +
+ * {@link sendImageItem}; callers that retry should use the two steps
+ * separately so a send retry reuses the uploaded media instead of
+ * re-running the whole pipeline (see deliverImage in bridge.ts).
+ *
+ * Returns the client_id used.
+ */
+export async function sendImageMessage(
+  to: string,
+  image: Buffer,
+  opts: WeixinImageSendOpts,
+  clientId?: string,
+  deps?: ImageSendDeps,
+): Promise<string> {
+  if (!opts.contextToken) {
+    throw new Error("contextToken is required to send a message");
+  }
+  const media = await uploadImageMedia(to, image, opts, deps);
+  return sendImageItem(to, media, opts, clientId, deps?.sendFn);
 }
 
 /**

--- a/src/weixin/send.ts
+++ b/src/weixin/send.ts
@@ -3,8 +3,9 @@
  */
 
 import crypto from "node:crypto";
-import { sendMessage } from "./api.js";
-import { MessageType, MessageState } from "./types.js";
+import { sendMessage, getUploadUrl } from "./api.js";
+import { aesEcbPaddedSize, uploadToCdn } from "./media.js";
+import { MessageType, MessageState, MessageItemType, UploadMediaType } from "./types.js";
 
 export interface WeixinSendOpts {
   baseUrl: string;
@@ -39,6 +40,113 @@ export async function sendTextMessage(
         message_state: MessageState.FINISH,
         context_token: opts.contextToken,
         item_list: [{ type: 1, text_item: { text } }],
+      },
+    },
+  });
+  return id;
+}
+
+/**
+ * Image upload/send dependencies, injectable for tests.
+ */
+export interface ImageSendDeps {
+  getUploadUrlFn?: typeof getUploadUrl;
+  uploadFn?: typeof uploadToCdn;
+  sendFn?: typeof sendMessage;
+}
+
+export interface WeixinImageSendOpts extends WeixinSendOpts {
+  cdnBaseUrl: string;
+}
+
+/**
+ * Upload an image to the WeChat CDN and send it as a native image message.
+ *
+ * Protocol (mirrors @tencent-weixin/openclaw-weixin):
+ *   - random 16-byte AES key + 32-hex-char filekey
+ *   - getuploadurl with media_type=IMAGE, plaintext md5/size, padded ciphertext size
+ *   - AES-128-ECB encrypt + CDN POST; download param comes back via x-encrypted-param
+ *   - sendmessage with image_item.media { encrypt_query_param, aes_key, encrypt_type: 1 }
+ *     where aes_key is the base64 of the hex-encoded key string (the same convention
+ *     parseAesKey() decodes on the inbound path) and mid_size is the ciphertext size.
+ *
+ * Returns the client_id used, so callers can retry with the same id for
+ * gateway de-duplication.
+ */
+export async function sendImageMessage(
+  to: string,
+  image: Buffer,
+  opts: WeixinImageSendOpts,
+  clientId?: string,
+  deps?: ImageSendDeps,
+): Promise<string> {
+  if (!opts.contextToken) {
+    throw new Error("contextToken is required to send a message");
+  }
+
+  const getUploadUrlFn = deps?.getUploadUrlFn ?? getUploadUrl;
+  const uploadFn = deps?.uploadFn ?? uploadToCdn;
+  const sendFn = deps?.sendFn ?? sendMessage;
+
+  const rawsize = image.length;
+  const rawfilemd5 = crypto.createHash("md5").update(image).digest("hex");
+  const filesize = aesEcbPaddedSize(rawsize);
+  const filekey = crypto.randomBytes(16).toString("hex");
+  const aesKey = crypto.randomBytes(16);
+
+  const uploadUrlResp = await getUploadUrlFn({
+    baseUrl: opts.baseUrl,
+    token: opts.token,
+    body: {
+      filekey,
+      media_type: UploadMediaType.IMAGE,
+      to_user_id: to,
+      rawsize,
+      rawfilemd5,
+      filesize,
+      no_need_thumb: true,
+      aeskey: aesKey.toString("hex"),
+    },
+  });
+
+  if (!uploadUrlResp.upload_full_url?.trim() && !uploadUrlResp.upload_param) {
+    throw new Error("getUploadUrl returned no upload URL (need upload_full_url or upload_param)");
+  }
+
+  const downloadParam = await uploadFn({
+    buffer: image,
+    uploadParam: uploadUrlResp.upload_param,
+    uploadFullUrl: uploadUrlResp.upload_full_url,
+    aesKey,
+    filekey,
+    cdnBaseUrl: opts.cdnBaseUrl,
+  });
+
+  const id = clientId ?? `wechat-acp-${crypto.randomUUID()}`;
+  await sendFn({
+    baseUrl: opts.baseUrl,
+    token: opts.token,
+    body: {
+      msg: {
+        from_user_id: "",
+        to_user_id: to,
+        client_id: id,
+        message_type: MessageType.BOT,
+        message_state: MessageState.FINISH,
+        context_token: opts.contextToken,
+        item_list: [
+          {
+            type: MessageItemType.IMAGE,
+            image_item: {
+              media: {
+                encrypt_query_param: downloadParam,
+                aes_key: Buffer.from(aesKey.toString("hex")).toString("base64"),
+                encrypt_type: 1,
+              },
+              mid_size: filesize,
+            },
+          },
+        ],
       },
     },
   });

--- a/src/weixin/types.ts
+++ b/src/weixin/types.ts
@@ -155,6 +155,8 @@ export interface GetUploadUrlReq {
 export interface GetUploadUrlResp {
   upload_param?: string;
   thumb_upload_param?: string;
+  /** Full upload URL returned by the server; preferred over client-side URL construction. */
+  upload_full_url?: string;
 }
 
 export interface SendTypingReq {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -184,9 +184,11 @@ test("failed send retains buffer so final flush delivers the message", async () 
 
 test("two sequential flushes are delivered in order (second waits for first)", async () => {
   /**
-   * Scenario: chunk A is flushed at boundary-1, then chunk B is flushed at
-   * boundary-2 while A's send is still awaiting. The mutex chain must ensure
-   * A completes before B starts, so WeChat always receives A before B.
+   * Scenario: chunk A is flushed at boundary-1, then chunk B arrives and is
+   * flushed at boundary-2 while A's send is still awaiting. The notification
+   * queue must ensure A completes before B starts, so WeChat always receives
+   * A before B. Notifications are deliberately not awaited between emits,
+   * mirroring the ACP SDK's fire-and-forget dispatch.
    */
   const order: string[] = [];
   let releaseA!: () => void;
@@ -205,14 +207,14 @@ test("two sequential flushes are delivered in order (second waits for first)", a
   await emitMessageChunk(client, "chunk A");
   // Fire boundary-1 without awaiting so it blocks on the slow send
   const p1 = emitToolCall(client);
+  // chunk B and boundary-2 queue up behind A's in-flight send
+  const p2 = emitMessageChunk(client, "chunk B");
+  const p3 = emitToolCall(client);
 
-  await emitMessageChunk(client, "chunk B");
-  // Fire boundary-2 — must queue behind A
-  const p2 = emitToolCall(client);
-
-  // Release A's send
+  // Let A's send start, then release it
+  await new Promise((r) => setTimeout(r, 10));
   releaseA();
-  await Promise.all([p1, p2]);
+  await Promise.all([p1, p2, p3]);
 
   assert.deepEqual(order, ["chunk A", "chunk B"], "second message must arrive after first");
 });
@@ -315,4 +317,98 @@ test("image without a configured sink is skipped without throwing", async () => 
   const client = makeClient({});
   await emitToolCallImage(client, { data: PNG_BASE64, mimeType: "image/png" });
   assert.equal(await client.flush(), "");
+});
+
+test("flush() waits for an unawaited in-flight image before reading the buffer", async () => {
+  /**
+   * The ACP SDK dispatches notifications without awaiting handlers, so the
+   * final flush() can race an image that is still uploading. Regression:
+   * before serialization, flush() resolved while the image was in flight,
+   * hasProducedMessage was still false, and session.ts sent the empty-turn
+   * fallback notice on an image-only turn.
+   */
+  let releaseImage!: () => void;
+  const images: AgentImage[] = [];
+  const client = makeClient({
+    onImageFlush: async (img) => {
+      await new Promise<void>((r) => {
+        releaseImage = r;
+      });
+      images.push(img);
+    },
+  });
+  client.newTurn();
+
+  // Fire-and-forget the image notification, then immediately flush.
+  const notification = emitToolCallImage(client, { data: PNG_BASE64, mimeType: "image/png" });
+  const flushed = client.flush();
+
+  // Let the image send start, then complete it.
+  await new Promise((r) => setTimeout(r, 10));
+  releaseImage();
+
+  const text = await flushed;
+  await notification;
+
+  assert.equal(images.length, 1, "image must be delivered before flush() resolves");
+  assert.equal(text, "");
+  assert.equal(client.hasProducedMessage, true, "image-only turn must count as produced output");
+});
+
+test("text arriving during an image send cannot overtake it", async () => {
+  let releaseImage!: () => void;
+  const order: string[] = [];
+  const client = makeClient({
+    onMessageFlush: async (t) => {
+      order.push(`text:${t}`);
+    },
+    onImageFlush: async () => {
+      await new Promise<void>((r) => {
+        releaseImage = r;
+      });
+      order.push("image");
+    },
+  });
+
+  const p1 = emitToolCallImage(client, { data: PNG_BASE64, mimeType: "image/png" });
+  const p2 = emitMessageChunk(client, "after-image");
+  const p3 = emitToolCall(client); // boundary flushes the buffered text
+
+  await new Promise((r) => setTimeout(r, 10));
+  releaseImage();
+  await Promise.all([p1, p2, p3]);
+
+  assert.deepEqual(order, ["image", "text:after-image"]);
+});
+
+test("failure placeholder keeps stream position when text arrives during the image send", async () => {
+  /**
+   * Regression: the failure placeholder used to be appended after any text
+   * that arrived while onImageFlush was pending, reversing the original
+   * image -> text order. Serialized handling buffers later text only after
+   * the image task settles, so the placeholder lands in the image's slot.
+   */
+  let failImage!: (err: Error) => void;
+  const client = makeClient({
+    onImageFlush: async () => {
+      await new Promise<void>((_, reject) => {
+        failImage = reject;
+      });
+    },
+  });
+  client.newTurn();
+
+  const p1 = emitToolCallImage(client, { data: PNG_BASE64, mimeType: "image/png" });
+  const p2 = emitMessageChunk(client, "after-image");
+
+  await new Promise((r) => setTimeout(r, 10));
+  failImage(new Error("CDN upload failed"));
+  await Promise.all([p1, p2]);
+
+  const text = await client.flush();
+  const placeholderAt = text.indexOf("[image could not be delivered]");
+  const textAt = text.indexOf("after-image");
+  assert.ok(placeholderAt >= 0, "placeholder must be present");
+  assert.ok(textAt >= 0, "later text must be preserved");
+  assert.ok(placeholderAt < textAt, `placeholder must precede later text, got: ${JSON.stringify(text)}`);
 });

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -9,7 +9,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { WeChatAcpClient } from "../src/acp/client.js";
+import { WeChatAcpClient, type AgentImage } from "../src/acp/client.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -19,6 +19,8 @@ import { WeChatAcpClient } from "../src/acp/client.js";
 function makeClient(opts: {
   onMessageFlush?: (text: string) => Promise<void>;
   onThoughtFlush?: (text: string) => Promise<void>;
+  onImageFlush?: (image: AgentImage) => Promise<void>;
+  showImages?: boolean;
   sendDelay?: number;
 }): WeChatAcpClient {
   const { sendDelay = 0 } = opts;
@@ -36,8 +38,10 @@ function makeClient(opts: {
       (async () => {
         if (sendDelay) await delay(sendDelay);
       }),
+    onImageFlush: opts.onImageFlush,
     log: () => {},
     showThoughts: false,
+    showImages: opts.showImages,
   });
 }
 
@@ -56,6 +60,31 @@ async function emitToolCall(client: WeChatAcpClient): Promise<void> {
 async function emitThoughtChunk(client: WeChatAcpClient, text = "thinking…"): Promise<void> {
   await client.sessionUpdate({
     update: { sessionUpdate: "agent_thought_chunk", content: { type: "text", text } },
+  } as never);
+}
+
+const PNG_BASE64 = Buffer.from("fake-png-bytes").toString("base64");
+
+async function emitToolCallImage(
+  client: WeChatAcpClient,
+  image: { data: string; mimeType: string },
+): Promise<void> {
+  await client.sessionUpdate({
+    update: {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "tc-1",
+      status: "completed",
+      content: [{ type: "content", content: { type: "image", ...image } }],
+    },
+  } as never);
+}
+
+async function emitMessageChunkImage(
+  client: WeChatAcpClient,
+  image: { data: string; mimeType: string },
+): Promise<void> {
+  await client.sessionUpdate({
+    update: { sessionUpdate: "agent_message_chunk", content: { type: "image", ...image } },
   } as never);
 }
 
@@ -186,4 +215,104 @@ test("two sequential flushes are delivered in order (second waits for first)", a
   await Promise.all([p1, p2]);
 
   assert.deepEqual(order, ["chunk A", "chunk B"], "second message must arrive after first");
+});
+
+// ---------------------------------------------------------------------------
+// Image content blocks
+// ---------------------------------------------------------------------------
+
+test("image in completed tool_call_update is delivered exactly once with data intact", async () => {
+  const images: AgentImage[] = [];
+  const client = makeClient({ onImageFlush: async (img) => { images.push(img); } });
+  client.newTurn();
+
+  await emitToolCallImage(client, { data: PNG_BASE64, mimeType: "image/png" });
+
+  assert.equal(images.length, 1);
+  assert.equal(images[0].data, PNG_BASE64);
+  assert.equal(images[0].mimeType, "image/png");
+  assert.equal(client.hasProducedMessage, true, "image counts as produced output");
+});
+
+test("image in agent_message_chunk is delivered", async () => {
+  const images: AgentImage[] = [];
+  const client = makeClient({ onImageFlush: async (img) => { images.push(img); } });
+
+  await emitMessageChunkImage(client, { data: PNG_BASE64, mimeType: "image/jpeg" });
+
+  assert.equal(images.length, 1);
+  assert.equal(images[0].mimeType, "image/jpeg");
+});
+
+test("text before an image is flushed first so ordering is preserved", async () => {
+  const order: string[] = [];
+  const client = makeClient({
+    onMessageFlush: async (t) => { order.push(`text:${t}`); },
+    onImageFlush: async () => { order.push("image"); },
+  });
+
+  await emitMessageChunk(client, "here is your chart:");
+  await emitToolCallImage(client, { data: PNG_BASE64, mimeType: "image/png" });
+  await emitMessageChunk(client, "anything else?");
+  const tail = await client.flush();
+
+  assert.deepEqual(order, ["text:here is your chart:", "image"]);
+  assert.equal(tail, "anything else?");
+});
+
+test("showImages=false drops images without calling the sink", async () => {
+  const images: AgentImage[] = [];
+  const client = makeClient({
+    onImageFlush: async (img) => { images.push(img); },
+    showImages: false,
+  });
+  client.newTurn();
+
+  await emitToolCallImage(client, { data: PNG_BASE64, mimeType: "image/png" });
+
+  assert.equal(images.length, 0);
+  assert.equal(client.hasProducedMessage, false);
+  assert.equal(await client.flush(), "", "no placeholder for intentionally hidden images");
+});
+
+test("unsupported mime type is skipped silently", async () => {
+  const images: AgentImage[] = [];
+  const client = makeClient({ onImageFlush: async (img) => { images.push(img); } });
+
+  await emitToolCallImage(client, { data: PNG_BASE64, mimeType: "image/svg+xml" });
+
+  assert.equal(images.length, 0);
+  assert.equal(await client.flush(), "");
+});
+
+test("oversized image is skipped with a placeholder instead of uploading", async () => {
+  const images: AgentImage[] = [];
+  const client = makeClient({ onImageFlush: async (img) => { images.push(img); } });
+
+  // ~12 MiB decoded > 10 MiB cap
+  const oversized = "A".repeat(16 * 1024 * 1024);
+  await emitToolCallImage(client, { data: oversized, mimeType: "image/png" });
+
+  assert.equal(images.length, 0);
+  const text = await client.flush();
+  assert.match(text, /image too large/);
+});
+
+test("failed image delivery appends a placeholder to the text stream", async () => {
+  const client = makeClient({
+    onImageFlush: async () => { throw new Error("CDN upload failed"); },
+  });
+  client.newTurn();
+
+  await emitToolCallImage(client, { data: PNG_BASE64, mimeType: "image/png" });
+
+  const text = await client.flush();
+  assert.match(text, /image could not be delivered/);
+  assert.equal(client.hasProducedMessage, true);
+});
+
+test("image without a configured sink is skipped without throwing", async () => {
+  const client = makeClient({});
+  await emitToolCallImage(client, { data: PNG_BASE64, mimeType: "image/png" });
+  assert.equal(await client.flush(), "");
 });

--- a/tests/send-image.test.ts
+++ b/tests/send-image.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for sendImageMessage protocol shape.
+ *
+ * Verifies the outbound image pipeline against the iLink conventions
+ * mirrored from @tencent-weixin/openclaw-weixin: getuploadurl request
+ * fields, ciphertext sizing, image_item structure (including the
+ * aes_key encoding that the inbound parseAesKey() expects), and
+ * client_id idempotency.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { sendImageMessage, type ImageSendDeps } from "../src/weixin/send.js";
+import { parseAesKey, aesEcbPaddedSize } from "../src/weixin/media.js";
+import { MessageItemType, UploadMediaType } from "../src/weixin/types.js";
+import type { getUploadUrl as GetUploadUrlFn, sendMessage as SendMessageFn } from "../src/weixin/api.js";
+import type { uploadToCdn as UploadToCdnFn } from "../src/weixin/media.js";
+
+type GetUploadUrlArgs = Parameters<typeof GetUploadUrlFn>[0];
+type UploadArgs = Parameters<typeof UploadToCdnFn>[0];
+type SendMessageArgs = Parameters<typeof SendMessageFn>[0];
+
+const IMAGE = Buffer.from("not-really-a-png-but-fine-for-tests");
+const OPTS = {
+  baseUrl: "http://fake",
+  contextToken: "ctx",
+  cdnBaseUrl: "http://fake-cdn/c2c",
+};
+
+function makeDeps(capture: {
+  uploadUrlReqs: GetUploadUrlArgs[];
+  uploads: UploadArgs[];
+  sends: SendMessageArgs[];
+}, uploadFullUrl?: string): ImageSendDeps {
+  return {
+    getUploadUrlFn: async (args) => {
+      capture.uploadUrlReqs.push(args);
+      return { upload_param: "up-param", upload_full_url: uploadFullUrl };
+    },
+    uploadFn: async (args) => {
+      capture.uploads.push(args);
+      return "download-param";
+    },
+    sendFn: async (args) => {
+      capture.sends.push(args);
+    },
+  };
+}
+
+test("sendImageMessage requests an upload slot with correct metadata", async () => {
+  const capture = { uploadUrlReqs: [], uploads: [], sends: [] } as Parameters<typeof makeDeps>[0];
+
+  await sendImageMessage("user123", IMAGE, OPTS, undefined, makeDeps(capture));
+
+  assert.equal(capture.uploadUrlReqs.length, 1);
+  const body = capture.uploadUrlReqs[0].body;
+  assert.equal(body.media_type, UploadMediaType.IMAGE);
+  assert.equal(body.to_user_id, "user123");
+  assert.equal(body.rawsize, IMAGE.length);
+  assert.equal(body.rawfilemd5, crypto.createHash("md5").update(IMAGE).digest("hex"));
+  assert.equal(body.filesize, aesEcbPaddedSize(IMAGE.length));
+  assert.equal(body.no_need_thumb, true);
+  assert.match(body.filekey, /^[0-9a-f]{32}$/, "filekey is 32 hex chars");
+  assert.match(body.aeskey!, /^[0-9a-f]{32}$/, "aeskey is hex-encoded 16 bytes");
+});
+
+test("sendImageMessage sends a well-formed image item", async () => {
+  const capture = { uploadUrlReqs: [], uploads: [], sends: [] } as Parameters<typeof makeDeps>[0];
+
+  await sendImageMessage("user123", IMAGE, OPTS, undefined, makeDeps(capture));
+
+  assert.equal(capture.uploads.length, 1);
+  const upload = capture.uploads[0];
+  assert.equal(upload.buffer, IMAGE);
+  assert.equal(upload.uploadParam, "up-param");
+  assert.equal(upload.cdnBaseUrl, OPTS.cdnBaseUrl);
+
+  assert.equal(capture.sends.length, 1);
+  const msg = capture.sends[0].body.msg;
+  assert.equal(msg.to_user_id, "user123");
+  assert.equal(msg.context_token, "ctx");
+  assert.equal(msg.item_list.length, 1);
+
+  const item = msg.item_list[0];
+  assert.equal(item.type, MessageItemType.IMAGE);
+  assert.ok(item.image_item, "image_item present");
+  assert.equal(item.image_item!.media.encrypt_query_param, "download-param");
+  assert.equal(item.image_item!.media.encrypt_type, 1);
+  assert.equal(item.image_item!.mid_size, aesEcbPaddedSize(IMAGE.length));
+
+  // The aes_key must round-trip through the same convention the inbound
+  // path decodes: base64 of the hex string, which parseAesKey() converts
+  // back to the raw 16-byte key that was announced to getuploadurl.
+  const announcedKey = Buffer.from(capture.uploadUrlReqs[0].body.aeskey!, "hex");
+  const parsed = parseAesKey({ encrypt_query_param: "x", aes_key: item.image_item!.media.aes_key });
+  assert.ok(parsed && parsed.equals(announcedKey), "aes_key decodes back to the announced key");
+});
+
+test("sendImageMessage prefers upload_full_url when present", async () => {
+  const capture = { uploadUrlReqs: [], uploads: [], sends: [] } as Parameters<typeof makeDeps>[0];
+
+  await sendImageMessage("user123", IMAGE, OPTS, undefined, makeDeps(capture, "http://cdn/full-upload-url"));
+
+  assert.equal(capture.uploads[0].uploadFullUrl, "http://cdn/full-upload-url");
+});
+
+test("sendImageMessage reuses a provided clientId for gateway de-duplication", async () => {
+  const capture = { uploadUrlReqs: [], uploads: [], sends: [] } as Parameters<typeof makeDeps>[0];
+  const deps = makeDeps(capture);
+
+  const stableId = "wechat-acp-image-stable-id";
+  const returnedId = await sendImageMessage("user123", IMAGE, OPTS, stableId, deps);
+  await sendImageMessage("user123", IMAGE, OPTS, stableId, deps);
+
+  assert.equal(returnedId, stableId);
+  assert.deepEqual(
+    capture.sends.map((s) => s.body.msg.client_id),
+    [stableId, stableId],
+    "retries carry the same client_id",
+  );
+});
+
+test("sendImageMessage fails fast when no upload URL is returned", async () => {
+  const deps: ImageSendDeps = {
+    getUploadUrlFn: async () => ({}),
+    uploadFn: async () => {
+      throw new Error("should not be called");
+    },
+    sendFn: async () => {
+      throw new Error("should not be called");
+    },
+  };
+
+  await assert.rejects(
+    () => sendImageMessage("user123", IMAGE, OPTS, undefined, deps),
+    /no upload URL/,
+  );
+});

--- a/tests/send-image.test.ts
+++ b/tests/send-image.test.ts
@@ -17,13 +17,12 @@ import {
   sendImageItem,
   type ImageSendDeps,
 } from "../src/weixin/send.js";
-import { parseAesKey, aesEcbPaddedSize } from "../src/weixin/media.js";
+import { parseAesKey, aesEcbPaddedSize, uploadToCdn } from "../src/weixin/media.js";
 import { MessageItemType, UploadMediaType } from "../src/weixin/types.js";
 import type { getUploadUrl as GetUploadUrlFn, sendMessage as SendMessageFn } from "../src/weixin/api.js";
-import type { uploadToCdn as UploadToCdnFn } from "../src/weixin/media.js";
 
 type GetUploadUrlArgs = Parameters<typeof GetUploadUrlFn>[0];
-type UploadArgs = Parameters<typeof UploadToCdnFn>[0];
+type UploadArgs = Parameters<typeof uploadToCdn>[0];
 type SendMessageArgs = Parameters<typeof SendMessageFn>[0];
 
 const IMAGE = Buffer.from("not-really-a-png-but-fine-for-tests");
@@ -178,4 +177,31 @@ test("send retry with reused media is byte-identical and does not re-upload", as
     JSON.parse(JSON.stringify(capture.sends[1].body)),
     "retry payload must be byte-identical to the first attempt",
   );
+});
+
+test("uploadToCdn rejects after timeoutMs when the CDN request hangs", async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = ((_url: unknown, init?: RequestInit) =>
+    new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => {
+        const err = new Error("aborted");
+        err.name = "AbortError";
+        reject(err);
+      });
+    })) as typeof fetch;
+  try {
+    await assert.rejects(
+      uploadToCdn({
+        buffer: IMAGE,
+        uploadParam: "param",
+        aesKey: crypto.randomBytes(16),
+        filekey: "f".repeat(32),
+        cdnBaseUrl: "http://fake-cdn/c2c",
+        timeoutMs: 50,
+      }),
+      /CDN upload timed out after 50ms/,
+    );
+  } finally {
+    globalThis.fetch = realFetch;
+  }
 });

--- a/tests/send-image.test.ts
+++ b/tests/send-image.test.ts
@@ -11,7 +11,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import crypto from "node:crypto";
-import { sendImageMessage, type ImageSendDeps } from "../src/weixin/send.js";
+import {
+  sendImageMessage,
+  uploadImageMedia,
+  sendImageItem,
+  type ImageSendDeps,
+} from "../src/weixin/send.js";
 import { parseAesKey, aesEcbPaddedSize } from "../src/weixin/media.js";
 import { MessageItemType, UploadMediaType } from "../src/weixin/types.js";
 import type { getUploadUrl as GetUploadUrlFn, sendMessage as SendMessageFn } from "../src/weixin/api.js";
@@ -135,5 +140,42 @@ test("sendImageMessage fails fast when no upload URL is returned", async () => {
   await assert.rejects(
     () => sendImageMessage("user123", IMAGE, OPTS, undefined, deps),
     /no upload URL/,
+  );
+});
+
+test("send retry with reused media is byte-identical and does not re-upload", async () => {
+  /**
+   * Retry semantics used by deliverImage in bridge.ts: upload once via
+   * uploadImageMedia, then retry only sendImageItem with the same media
+   * descriptor and client_id. Every attempt must serialize to an identical
+   * message so the iLink gateway can de-duplicate by client_id without a
+   * retry ever carrying different media metadata.
+   */
+  const capture = { uploadUrlReqs: [], uploads: [], sends: [] } as Parameters<typeof makeDeps>[0];
+  const deps = makeDeps(capture);
+
+  const media = await uploadImageMedia("user123", IMAGE, OPTS, deps);
+  assert.equal(capture.uploads.length, 1, "exactly one upload");
+
+  let sendCalls = 0;
+  const flakySend: NonNullable<ImageSendDeps["sendFn"]> = async (args) => {
+    capture.sends.push(args);
+    sendCalls++;
+    if (sendCalls === 1) throw new Error("connection reset");
+  };
+
+  const stableId = "wechat-acp-image-retry-id";
+  await assert.rejects(
+    () => sendImageItem("user123", media, OPTS, stableId, flakySend),
+    /connection reset/,
+  );
+  await sendImageItem("user123", media, OPTS, stableId, flakySend);
+
+  assert.equal(capture.uploads.length, 1, "retry must not re-upload");
+  assert.equal(capture.sends.length, 2);
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(capture.sends[0].body)),
+    JSON.parse(JSON.stringify(capture.sends[1].body)),
+    "retry payload must be byte-identical to the first attempt",
   );
 });


### PR DESCRIPTION
Fixes #52.

## What

Agents that return ACP `image` content blocks (in `agent_message_chunk` content or in completed `tool_call_update` content, per the [ACP image content spec](https://agentclientprotocol.com/protocol/v1/content#image-content)) previously had those blocks silently dropped. Claude Code does this for screenshots and generated charts; only the surrounding text ever reached WeChat. This PR renders them as native WeChat image messages.

## How

**Outbound iLink image pipeline** (`src/weixin/send.ts`, `media.ts`, `types.ts`, mirroring the conventions already used on the inbound path):

- `sendImageMessage(to, buffer, opts, clientId?, deps?)`: random 16-byte AES key + 32-hex `filekey`, `getuploadurl` with `media_type: IMAGE`, plaintext md5/size and PKCS7-padded ciphertext size, AES-128-ECB encrypt, CDN POST (preferring `upload_full_url` from the response, falling back to `cdnBaseUrl` + `upload_param`), then `sendmessage` with an `image_item` whose `aes_key` is the base64 of the hex key string, the same encoding `parseAesKey()` decodes for received images.
- Dependencies (`getUploadUrlFn`, `uploadFn`, `sendFn`) are injectable for tests, same pattern as `sendTextMessage`.
- Returns the `client_id` used, so retries reuse the same idempotency key and the iLink gateway de-duplicates.

**ACP client** (`src/acp/client.ts`):

- Handles `image` content in `agent_message_chunk` and in completed `tool_call_update` content (`{type: "content", content: {type: "image", ...}}`).
- Ordering: buffered text preceding the image is flushed first, and the image send rides the same per-client mutex chain as message flushes, so `text, image, text` arrives in stream order even with concurrent notifications (the SDK fires handlers without awaiting them).
- MIME allow-list (png, jpeg, gif, webp, bmp); other types are logged and skipped. Decoded payloads above 10 MiB are skipped with a placeholder.
- A failed delivery appends an `[image could not be delivered]` placeholder to the text stream, so a turn never silently loses content. Delivered images count toward `producedMessageThisTurn`, so an image-only turn does not trigger the empty-turn notice.

**Bridge** (`src/bridge.ts`, `session.ts`):

- `onReplyImage` plumbed through `SessionManager` alongside `onReply`.
- `sendImageReply` serializes on the same per-user send chain as text replies (so an image cannot interleave with the segments of a concurrent text reply), applies the existing 150ms send pacing, and retries 3 times with a stable `client_id`. The CDN upload happens once; a send-stage retry reuses the same uploaded media descriptor, so every attempt is byte-identical and gateway de-duplication is safe.
- New telemetry event `reply.image.sent` (byte size, MIME type, duration); failures report under `reply.image`. No image bytes or URLs are collected.

**Config** (`src/config.ts`, `bin/wechat-acp.ts`):

- `agent.showImages` (default `true`) and a `--hide-images` CLI flag, following the `showThoughts`/`showDiffs` pattern.

## Notes

- Claude Code also embeds the image in non-standard `_meta.claudeCode.toolResponse` and `rawOutput` fields; those are intentionally ignored, only the spec `content` array is processed, so nothing is sent twice.
- The `uri`-only variant of the image block (no `data`) is out of scope here, matching the proposal in #52.
- `package.json` version is untouched; CHANGELOG entry added under Unreleased.

## Testing

- 14 new tests (23 total, all passing): client-side handling (delivered exactly once with data intact, both update paths, text-image-text ordering, `showImages=false`, unsupported MIME, oversize skip, failure placeholder, no-sink no-throw) and protocol shape via injected deps (getuploadurl metadata, `image_item` structure, `aes_key` round-trips through `parseAesKey()` back to the announced key, `upload_full_url` preference, stable `client_id` reuse, byte-identical send retries without re-upload, fail-fast when no upload URL).
- `npm run build` clean.
- Not verified against the live iLink CDN endpoint; the protocol shape follows the reference implementation for the same bot API. Happy to adjust if live testing surfaces differences.
