### PR TITLE
Deliver Copilot CLI tool-result images from rawOutput.binaryResultsForLlm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -604,7 +604,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -815,7 +814,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -967,7 +965,6 @@
       "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
       "integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       }

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -317,16 +317,16 @@ export class WeChatAcpClient implements acp.Client {
     // rawOutput fallback) validates and delivers the same normalized value.
     const mimeType = image.mimeType.trim();
     if (this.opts.showImages === false) {
-      this.opts.log(`[image] skipped (showImages=false, ${image.mimeType})`);
+      this.opts.log(`[image] skipped (showImages=false, ${mimeType})`);
       return;
     }
     if (!this.opts.onImageFlush) {
-      this.opts.log(`[image] skipped (no image sink configured, ${image.mimeType})`);
+      this.opts.log(`[image] skipped (no image sink configured, ${mimeType})`);
       return;
     }
     const mime = mimeType.toLowerCase();
     if (!SUPPORTED_IMAGE_MIME_TYPES.has(mime)) {
-      this.opts.log(`[image] skipped unsupported type: ${image.mimeType}`);
+      this.opts.log(`[image] skipped unsupported type: ${mimeType}`);
       return;
     }
     // ceil(base64Len / 4) * 3 over-estimates by at most 2 bytes; fine for a cap.

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -286,12 +286,17 @@ export class WeChatAcpClient implements acp.Client {
         data?: unknown;
         mimeType?: unknown;
       };
-      // Normalize once so validation, delivery, and the [tool] image note
-      // all agree on what counts as a usable MIME type.
-      const mime = typeof mimeType === "string" ? mimeType.trim() : "";
-      if (type === "image" && typeof data === "string" && data && mime) {
+      // maybeSendImage normalizes the MIME type; here just require it to be
+      // non-blank so blank entries are not counted or logged as images.
+      if (
+        type === "image" &&
+        typeof data === "string" &&
+        data &&
+        typeof mimeType === "string" &&
+        mimeType.trim()
+      ) {
         images++;
-        await this.maybeSendImage({ data, mimeType: mime });
+        await this.maybeSendImage({ data, mimeType });
       }
     }
     return images;
@@ -308,6 +313,9 @@ export class WeChatAcpClient implements acp.Client {
    * loses content.
    */
   private async maybeSendImage(image: { data: string; mimeType: string }): Promise<void> {
+    // Trim once here so every image path (content block, message chunk,
+    // rawOutput fallback) validates and delivers the same normalized value.
+    const mimeType = image.mimeType.trim();
     if (this.opts.showImages === false) {
       this.opts.log(`[image] skipped (showImages=false, ${image.mimeType})`);
       return;
@@ -316,7 +324,7 @@ export class WeChatAcpClient implements acp.Client {
       this.opts.log(`[image] skipped (no image sink configured, ${image.mimeType})`);
       return;
     }
-    const mime = image.mimeType.toLowerCase();
+    const mime = mimeType.toLowerCase();
     if (!SUPPORTED_IMAGE_MIME_TYPES.has(mime)) {
       this.opts.log(`[image] skipped unsupported type: ${image.mimeType}`);
       return;
@@ -342,8 +350,8 @@ export class WeChatAcpClient implements acp.Client {
       // Single attempt here: the bridge-side sink owns retries (with a stable
       // client_id for gateway de-duplication), so retrying again at this layer
       // would multiply CDN uploads.
-      await this.opts.onImageFlush(image);
-      this.opts.log(`[image] sent (${image.mimeType}, ~${approxBytes} bytes)`);
+      await this.opts.onImageFlush({ data: image.data, mimeType });
+      this.opts.log(`[image] sent (${mimeType}, ~${approxBytes} bytes)`);
       this.producedMessageThisTurn = true;
     } catch (err) {
       this.opts.log(`[image] delivery failed: ${String(err)}`);

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -286,15 +286,12 @@ export class WeChatAcpClient implements acp.Client {
         data?: unknown;
         mimeType?: unknown;
       };
-      if (
-        type === "image" &&
-        typeof data === "string" &&
-        data &&
-        typeof mimeType === "string" &&
-        mimeType.trim()
-      ) {
+      // Normalize once so validation, delivery, and the [tool] image note
+      // all agree on what counts as a usable MIME type.
+      const mime = typeof mimeType === "string" ? mimeType.trim() : "";
+      if (type === "image" && typeof data === "string" && data && mime) {
         images++;
-        await this.maybeSendImage({ data, mimeType });
+        await this.maybeSendImage({ data, mimeType: mime });
       }
     }
     return images;

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -159,7 +159,8 @@ export class WeChatAcpClient implements acp.Client {
         await this.maybeSendTyping();
         break;
 
-      case "tool_call_update":
+      case "tool_call_update": {
+        let sawImageContentBlock = false;
         if (update.status === "completed" && update.content) {
           for (const c of update.content) {
             if (c.type === "diff") {
@@ -178,15 +179,25 @@ export class WeChatAcpClient implements acp.Client {
               this.chunks.push("\n```diff\n" + lines.join("\n") + "\n```\n");
               this.producedMessageThisTurn = true;
             } else if (c.type === "content" && c.content.type === "image") {
+              sawImageContentBlock = true;
               await this.maybeSendImage(c.content);
             }
           }
+        }
+        // Copilot CLI compatibility: the CLI emits tool-result images only in
+        // rawOutput.binaryResultsForLlm and never as ACP image content blocks
+        // (formulahendry/wechat-acp issue 55). Fall back to rawOutput only
+        // when the standard path produced no image, so an agent that one day
+        // populates both fields never delivers the same image twice.
+        if (update.status === "completed" && !sawImageContentBlock) {
+          await this.maybeSendRawOutputImages(update.rawOutput);
         }
         if (update.status) {
           this.opts.log(`[tool] ${update.toolCallId} → ${update.status}`);
         }
         await this.maybeSendTyping();
         break;
+      }
 
       case "plan":
         // Log plan entries
@@ -237,6 +248,37 @@ export class WeChatAcpClient implements acp.Client {
       this.lastTypingAt = 0;
       return text;
     });
+  }
+
+  /**
+   * Compatibility fallback for agents that emit tool-result images only in
+   * `rawOutput` instead of ACP image content blocks. GitHub Copilot CLI puts
+   * them in `rawOutput.binaryResultsForLlm[]` as `{type: "image", data,
+   * mimeType}` and leaves `update.content` unset (issue 55). The spec types
+   * `rawOutput` as `unknown`, so every field is validated before use and
+   * anything malformed is ignored.
+   */
+  private async maybeSendRawOutputImages(rawOutput: unknown): Promise<void> {
+    if (typeof rawOutput !== "object" || rawOutput === null) {
+      return;
+    }
+    const bin = (rawOutput as { binaryResultsForLlm?: unknown }).binaryResultsForLlm;
+    if (!Array.isArray(bin)) {
+      return;
+    }
+    for (const entry of bin) {
+      if (typeof entry !== "object" || entry === null) {
+        continue;
+      }
+      const { type, data, mimeType } = entry as {
+        type?: unknown;
+        data?: unknown;
+        mimeType?: unknown;
+      };
+      if (type === "image" && typeof data === "string" && data && typeof mimeType === "string") {
+        await this.maybeSendImage({ data, mimeType });
+      }
+    }
   }
 
   /**

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -160,7 +160,7 @@ export class WeChatAcpClient implements acp.Client {
         break;
 
       case "tool_call_update": {
-        let sawImageContentBlock = false;
+        let imageContentBlocks = 0;
         if (update.status === "completed" && update.content) {
           for (const c of update.content) {
             if (c.type === "diff") {
@@ -179,7 +179,7 @@ export class WeChatAcpClient implements acp.Client {
               this.chunks.push("\n```diff\n" + lines.join("\n") + "\n```\n");
               this.producedMessageThisTurn = true;
             } else if (c.type === "content" && c.content.type === "image") {
-              sawImageContentBlock = true;
+              imageContentBlocks++;
               await this.maybeSendImage(c.content);
             }
           }
@@ -189,11 +189,20 @@ export class WeChatAcpClient implements acp.Client {
         // (formulahendry/wechat-acp issue 55). Fall back to rawOutput only
         // when the standard path produced no image, so an agent that one day
         // populates both fields never delivers the same image twice.
-        if (update.status === "completed" && !sawImageContentBlock) {
-          await this.maybeSendRawOutputImages(update.rawOutput);
+        let rawOutputImages = 0;
+        if (update.status === "completed" && imageContentBlocks === 0) {
+          rawOutputImages = await this.maybeSendRawOutputImages(update.rawOutput);
         }
         if (update.status) {
-          this.opts.log(`[tool] ${update.toolCallId} → ${update.status}`);
+          // Surface where images came from so field issues like issue 55
+          // (image present but in a non-standard location) show up in logs.
+          const imageNote =
+            imageContentBlocks > 0
+              ? ` [images: ${imageContentBlocks} content block]`
+              : rawOutputImages > 0
+                ? ` [images: ${rawOutputImages} rawOutput fallback]`
+                : "";
+          this.opts.log(`[tool] ${update.toolCallId} → ${update.status}${imageNote}`);
         }
         await this.maybeSendTyping();
         break;
@@ -256,16 +265,18 @@ export class WeChatAcpClient implements acp.Client {
    * them in `rawOutput.binaryResultsForLlm[]` as `{type: "image", data,
    * mimeType}` and leaves `update.content` unset (issue 55). The spec types
    * `rawOutput` as `unknown`, so every field is validated before use and
-   * anything malformed is ignored.
+   * anything malformed is ignored. Returns the number of valid image entries
+   * handed to `maybeSendImage`, so the caller can log the delivery source.
    */
-  private async maybeSendRawOutputImages(rawOutput: unknown): Promise<void> {
+  private async maybeSendRawOutputImages(rawOutput: unknown): Promise<number> {
     if (typeof rawOutput !== "object" || rawOutput === null) {
-      return;
+      return 0;
     }
     const bin = (rawOutput as { binaryResultsForLlm?: unknown }).binaryResultsForLlm;
     if (!Array.isArray(bin)) {
-      return;
+      return 0;
     }
+    let images = 0;
     for (const entry of bin) {
       if (typeof entry !== "object" || entry === null) {
         continue;
@@ -276,9 +287,11 @@ export class WeChatAcpClient implements acp.Client {
         mimeType?: unknown;
       };
       if (type === "image" && typeof data === "string" && data && typeof mimeType === "string") {
+        images++;
         await this.maybeSendImage({ data, mimeType });
       }
     }
+    return images;
   }
 
   /**

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -286,7 +286,13 @@ export class WeChatAcpClient implements acp.Client {
         data?: unknown;
         mimeType?: unknown;
       };
-      if (type === "image" && typeof data === "string" && data && typeof mimeType === "string") {
+      if (
+        type === "image" &&
+        typeof data === "string" &&
+        data &&
+        typeof mimeType === "string" &&
+        mimeType.trim()
+      ) {
         images++;
         await this.maybeSendImage({ data, mimeType });
       }

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -291,6 +291,17 @@ test("rawOutput mimeType with surrounding whitespace is normalized and delivered
   assert.equal(images[0].mimeType, "image/png", "delivered MIME type must be trimmed");
 });
 
+test("content-block mimeType with surrounding whitespace is normalized and delivered", async () => {
+  const images: AgentImage[] = [];
+  const client = makeClient({ onImageFlush: async (img) => { images.push(img); } });
+  client.newTurn();
+
+  await emitToolCallImage(client, { data: PNG_BASE64, mimeType: " image/PNG " });
+
+  assert.equal(images.length, 1);
+  assert.equal(images[0].mimeType, "image/PNG", "delivered MIME type must be trimmed");
+});
+
 test("rawOutput fallback is skipped when a standard image content block is present", async () => {
   const images: AgentImage[] = [];
   const client = makeClient({ onImageFlush: async (img) => { images.push(img); } });

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -79,6 +79,23 @@ async function emitToolCallImage(
   } as never);
 }
 
+/** Copilot CLI shape: image only in rawOutput.binaryResultsForLlm, no content blocks. */
+async function emitToolCallRawOutputImage(
+  client: WeChatAcpClient,
+  rawOutput: unknown,
+  content?: unknown[],
+): Promise<void> {
+  await client.sessionUpdate({
+    update: {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "tc-raw-1",
+      status: "completed",
+      ...(content ? { content } : {}),
+      rawOutput,
+    },
+  } as never);
+}
+
 async function emitMessageChunkImage(
   client: WeChatAcpClient,
   image: { data: string; mimeType: string },
@@ -234,6 +251,66 @@ test("image in completed tool_call_update is delivered exactly once with data in
   assert.equal(images[0].data, PNG_BASE64);
   assert.equal(images[0].mimeType, "image/png");
   assert.equal(client.hasProducedMessage, true, "image counts as produced output");
+});
+
+test("Copilot CLI shape: image only in rawOutput.binaryResultsForLlm is delivered", async () => {
+  const images: AgentImage[] = [];
+  const client = makeClient({ onImageFlush: async (img) => { images.push(img); } });
+  client.newTurn();
+
+  await emitToolCallRawOutputImage(client, {
+    content: "Viewed image file successfully.",
+    detailedContent: "Viewed image file at path /tmp/white.png",
+    binaryResultsForLlm: [
+      {
+        type: "image",
+        data: PNG_BASE64,
+        mimeType: "image/png",
+        description: "Image file at path /tmp/white.png",
+      },
+    ],
+  });
+
+  assert.equal(images.length, 1);
+  assert.equal(images[0].data, PNG_BASE64);
+  assert.equal(images[0].mimeType, "image/png");
+  assert.equal(client.hasProducedMessage, true, "fallback image counts as produced output");
+});
+
+test("rawOutput fallback is skipped when a standard image content block is present", async () => {
+  const images: AgentImage[] = [];
+  const client = makeClient({ onImageFlush: async (img) => { images.push(img); } });
+  client.newTurn();
+
+  await emitToolCallRawOutputImage(
+    client,
+    { binaryResultsForLlm: [{ type: "image", data: PNG_BASE64, mimeType: "image/png" }] },
+    [{ type: "content", content: { type: "image", data: PNG_BASE64, mimeType: "image/png" } }],
+  );
+
+  assert.equal(images.length, 1, "image must be delivered exactly once, not per source");
+});
+
+test("malformed rawOutput shapes are ignored without throwing", async () => {
+  const images: AgentImage[] = [];
+  const client = makeClient({ onImageFlush: async (img) => { images.push(img); } });
+  client.newTurn();
+
+  await emitToolCallRawOutputImage(client, "not an object");
+  await emitToolCallRawOutputImage(client, null);
+  await emitToolCallRawOutputImage(client, { binaryResultsForLlm: "not an array" });
+  await emitToolCallRawOutputImage(client, {
+    binaryResultsForLlm: [
+      null,
+      "string entry",
+      { type: "text", text: "not an image" },
+      { type: "image", data: 123, mimeType: "image/png" },
+      { type: "image", data: PNG_BASE64 },
+      { type: "image", data: "", mimeType: "image/png" },
+    ],
+  });
+
+  assert.equal(images.length, 0);
 });
 
 test("image in agent_message_chunk is delivered", async () => {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -294,7 +294,11 @@ test("rawOutput fallback is skipped when a standard image content block is prese
 
 test("malformed rawOutput shapes are ignored without throwing", async () => {
   const images: AgentImage[] = [];
-  const client = makeClient({ onImageFlush: async (img) => { images.push(img); } });
+  const logs: string[] = [];
+  const client = makeClient({
+    onImageFlush: async (img) => { images.push(img); },
+    log: (m) => { logs.push(m); },
+  });
   client.newTurn();
 
   await emitToolCallRawOutputImage(client, "not an object");
@@ -308,10 +312,14 @@ test("malformed rawOutput shapes are ignored without throwing", async () => {
       { type: "image", data: 123, mimeType: "image/png" },
       { type: "image", data: PNG_BASE64 },
       { type: "image", data: "", mimeType: "image/png" },
+      { type: "image", data: PNG_BASE64, mimeType: "" },
+      { type: "image", data: PNG_BASE64, mimeType: "   " },
     ],
   });
 
   assert.equal(images.length, 0);
+  const imageNotes = logs.filter((l) => l.includes("[images:"));
+  assert.deepEqual(imageNotes, [], "malformed entries must not be counted as images");
 });
 
 test("[tool] log line reports image source: content block vs rawOutput fallback", async () => {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -22,6 +22,7 @@ function makeClient(opts: {
   onImageFlush?: (image: AgentImage) => Promise<void>;
   showImages?: boolean;
   sendDelay?: number;
+  log?: (msg: string) => void;
 }): WeChatAcpClient {
   const { sendDelay = 0 } = opts;
   const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
@@ -39,7 +40,7 @@ function makeClient(opts: {
         if (sendDelay) await delay(sendDelay);
       }),
     onImageFlush: opts.onImageFlush,
-    log: () => {},
+    log: opts.log ?? (() => {}),
     showThoughts: false,
     showImages: opts.showImages,
   });
@@ -311,6 +312,27 @@ test("malformed rawOutput shapes are ignored without throwing", async () => {
   });
 
   assert.equal(images.length, 0);
+});
+
+test("[tool] log line reports image source: content block vs rawOutput fallback", async () => {
+  const logs: string[] = [];
+  const client = makeClient({
+    onImageFlush: async () => {},
+    log: (m) => { logs.push(m); },
+  });
+  client.newTurn();
+
+  await emitToolCallImage(client, { data: PNG_BASE64, mimeType: "image/png" });
+  await emitToolCallRawOutputImage(client, {
+    binaryResultsForLlm: [{ type: "image", data: PNG_BASE64, mimeType: "image/png" }],
+  });
+  await emitToolCallRawOutputImage(client, { content: "plain text result" });
+
+  const toolLogs = logs.filter((l) => l.startsWith("[tool] tc-"));
+  assert.equal(toolLogs.length, 3);
+  assert.match(toolLogs[0], /\[images: 1 content block\]$/);
+  assert.match(toolLogs[1], /\[images: 1 rawOutput fallback\]$/);
+  assert.match(toolLogs[2], /completed$/, "no image note when the tool produced no image");
 });
 
 test("image in agent_message_chunk is delivered", async () => {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -278,6 +278,19 @@ test("Copilot CLI shape: image only in rawOutput.binaryResultsForLlm is delivere
   assert.equal(client.hasProducedMessage, true, "fallback image counts as produced output");
 });
 
+test("rawOutput mimeType with surrounding whitespace is normalized and delivered", async () => {
+  const images: AgentImage[] = [];
+  const client = makeClient({ onImageFlush: async (img) => { images.push(img); } });
+  client.newTurn();
+
+  await emitToolCallRawOutputImage(client, {
+    binaryResultsForLlm: [{ type: "image", data: PNG_BASE64, mimeType: " image/png " }],
+  });
+
+  assert.equal(images.length, 1);
+  assert.equal(images[0].mimeType, "image/png", "delivered MIME type must be trimmed");
+});
+
 test("rawOutput fallback is skipped when a standard image content block is present", async () => {
   const images: AgentImage[] = [];
   const client = makeClient({ onImageFlush: async (img) => { images.push(img); } });


### PR DESCRIPTION
Fixes #55

## Problem

When GitHub Copilot CLI is the agent, tool-result images (e.g. from viewing an image file) never reach WeChat. The CLI puts the image bytes only in `rawOutput.binaryResultsForLlm[]` of the `tool_call_update` notification and never emits a standard ACP image content block in `update.content[]`. The `tool_call_update` handler reads images exclusively from `update.content[]`, so the image was silently dropped. Full root cause analysis with the captured raw payload is in issue #55.

## Fix

Add a narrow compatibility fallback in the `tool_call_update` handler of `src/acp/client.ts`:

- While iterating `update.content[]`, track whether any image content block was seen.
- On a `completed` update with no image content block, scan `update.rawOutput.binaryResultsForLlm[]` (new helper `maybeSendRawOutputImages`) and deliver entries whose `type` is `image` with non-empty string `data` and string `mimeType` through the existing `maybeSendImage()` path, so MIME allowlist, size cap, ordering, and failure placeholders all apply unchanged.
- The fallback only runs when the standard path produced no image. If Copilot CLI later conforms and populates both fields, nothing is delivered twice.
- `rawOutput` is typed `unknown` by the ACP spec, so every field is validated defensively and malformed shapes are ignored.

`rawOutput` is a legal field on `ToolCallUpdate`, so no cast of the update object is needed; only its contents are runtime-checked.

## Tests

Three new tests in `tests/client.test.ts`, all green alongside the existing suite (30 pass, 0 fail):

1) Copilot CLI shape (the exact captured payload structure) delivers the image once with data intact.
2) When both a standard image content block and `rawOutput` carry the image, it is delivered exactly once.
3) Malformed `rawOutput` shapes (non-object, non-array, wrong entry types, missing or empty fields) are ignored without throwing.
