### PR TITLE
fix: bind notification delivery to its own turn's callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix session notifications queued across a turn boundary delivering with the next turn's context. The client now captures its delivery callbacks when a notification arrives (not when the queued task runs), and the turn switch itself (`beginTurn`) runs as a task on the same serialized queue: stragglers from a failed `prompt()` deliver with their own turn's binding, and residual undelivered buffers are discarded at the boundary instead of leaking into the new turn. Fixes #54.
+- Fix session notifications queued across a turn boundary delivering with the next turn's context. All per-turn mutable state (delivery callbacks, text/thought buffers, delivery flags) now lives in a turn-state object captured when a notification arrives, and the turn switch itself (`beginTurn`) runs as a task on the same serialized queue: stragglers from a failed `prompt()` deliver with their own turn's binding, a late notification queued behind the boundary writes into its own closed turn's state instead of the new turn's buffers, and residual undelivered buffers are discarded at the boundary instead of leaking into the new turn. Fixes #54.
 
 ## 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix session notifications queued across a turn boundary delivering with the next turn's context. The client now captures its delivery callbacks when a notification arrives (not when the queued task runs), and the turn switch itself (`beginTurn`) runs as a task on the same serialized queue: stragglers from a failed `prompt()` deliver with their own turn's binding, and residual undelivered buffers are discarded at the boundary instead of leaking into the new turn. Fixes #54.
+
 ## 0.9.0
 
 - Render ACP `image` content blocks from the agent (in `agent_message_chunk` and completed `tool_call_update` content) as native WeChat image messages, instead of silently dropping them. Images are uploaded to the WeChat CDN (AES-128-ECB, `getuploadurl` + `sendmessage` with an `image_item`) and delivered in stream order relative to surrounding text: all session notifications are handled on a serialized per-client task queue, and outbound sends ride the per-user reply queue. Supported types: png, jpeg, gif, webp, bmp. Unsupported MIME types are skipped with a log line; an image above 10 MiB surfaces as an `[image too large to deliver]` placeholder in the text reply, and a failed delivery as `[image could not be delivered]`. Enabled by default; disable with `--hide-images` or `agent.showImages: false`. Adds one telemetry event: `reply.image.sent`. Fixes #52.

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -63,7 +63,7 @@ export class WeChatAcpClient implements acp.Client {
     return this.producedMessageThisTurn;
   }
 
-  /** Reset per-turn delivery state. Call at the start of each prompt. */
+  /** Reset per-turn delivery state. Called by beginTurn; exposed for tests. */
   newTurn(): void {
     this.producedMessageThisTurn = false;
   }
@@ -72,19 +72,43 @@ export class WeChatAcpClient implements acp.Client {
     this.opts = opts;
   }
 
-  updateCallbacks(callbacks: {
+  /**
+   * Start a new turn: rebind delivery callbacks to the new turn's context and
+   * reset per-turn state. Runs as a task on the notification queue, so every
+   * task from the previous turn (including ones left queued when a failed
+   * `prompt()` rejected early) finishes delivering with its own turn's
+   * callbacks before the swap; a notification can never deliver with the next
+   * turn's binding (issue 54). Residual undelivered buffers (text the final
+   * flush never read, trailing thoughts) are discarded at the boundary
+   * instead of leaking into the new turn. Await this before sending the next
+   * prompt.
+   */
+  async beginTurn(callbacks: {
     sendTyping: () => Promise<void>;
     onThoughtFlush: (text: string) => Promise<void>;
     onMessageFlush: (text: string) => Promise<void>;
     onImageFlush?: (image: AgentImage) => Promise<void>;
-  }): void {
-    this.opts = {
-      ...this.opts,
-      sendTyping: callbacks.sendTyping,
-      onThoughtFlush: callbacks.onThoughtFlush,
-      onMessageFlush: callbacks.onMessageFlush,
-      ...(callbacks.onImageFlush ? { onImageFlush: callbacks.onImageFlush } : {}),
-    };
+  }): Promise<void> {
+    return this.enqueue(async () => {
+      this.opts = {
+        ...this.opts,
+        sendTyping: callbacks.sendTyping,
+        onThoughtFlush: callbacks.onThoughtFlush,
+        onMessageFlush: callbacks.onMessageFlush,
+        ...(callbacks.onImageFlush ? { onImageFlush: callbacks.onImageFlush } : {}),
+      };
+      const staleText = this.chunks.join("");
+      const staleThoughts = this.thoughtChunks.join("");
+      if (staleText.trim() || staleThoughts.trim()) {
+        this.opts.log(
+          `[turn] discarding residue from previous turn (${staleText.length} chars text, ${staleThoughts.length} chars thoughts)`,
+        );
+      }
+      this.chunks = [];
+      this.thoughtChunks = [];
+      this.lastTypingAt = 0;
+      this.newTurn();
+    });
   }
 
   async requestPermission(
@@ -119,44 +143,53 @@ export class WeChatAcpClient implements acp.Client {
   }
 
   async sessionUpdate(params: acp.SessionNotification): Promise<void> {
-    return this.enqueue(() => this.handleSessionUpdate(params));
+    // Bind the notification to the callbacks active at arrival time. A task
+    // can sit queued across a turn boundary (beginTurn's swap is enqueued
+    // behind it), and a straggler can even arrive while the previous turn's
+    // residue is still draining; capturing here guarantees it delivers with
+    // the binding of the turn it belongs to, never the next turn's (issue 54).
+    const opts = this.opts;
+    return this.enqueue(() => this.handleSessionUpdate(params, opts));
   }
 
-  private async handleSessionUpdate(params: acp.SessionNotification): Promise<void> {
+  private async handleSessionUpdate(
+    params: acp.SessionNotification,
+    opts: WeChatAcpClientOpts,
+  ): Promise<void> {
     const update = params.update;
 
     switch (update.sessionUpdate) {
       case "agent_message_chunk":
-        await this.maybeFlushThoughts();
+        await this.maybeFlushThoughts(opts);
         if (update.content.type === "text") {
           this.chunks.push(update.content.text);
           if (update.content.text.trim()) {
             this.producedMessageThisTurn = true;
           }
         } else if (update.content.type === "image") {
-          await this.maybeSendImage(update.content);
+          await this.maybeSendImage(update.content, opts);
         }
         // Throttle typing indicators
-        await this.maybeSendTyping();
+        await this.maybeSendTyping(opts);
         break;
 
       case "tool_call":
-        await this.maybeFlushThoughts();
-        await this.maybeFlushMessage();
-        this.opts.log(`[tool] ${update.title} (${update.status})`);
-        await this.maybeSendTyping();
+        await this.maybeFlushThoughts(opts);
+        await this.maybeFlushMessage(opts);
+        opts.log(`[tool] ${update.title} (${update.status})`);
+        await this.maybeSendTyping(opts);
         break;
 
       case "agent_thought_chunk":
-        await this.maybeFlushMessage();
+        await this.maybeFlushMessage(opts);
         if (update.content.type === "text") {
           const text = update.content.text;
-          this.opts.log(`[thought] ${text.length > 80 ? text.substring(0, 80) + "..." : text}`);
-          if (this.opts.showThoughts) {
+          opts.log(`[thought] ${text.length > 80 ? text.substring(0, 80) + "..." : text}`);
+          if (opts.showThoughts) {
             this.thoughtChunks.push(text);
           }
         }
-        await this.maybeSendTyping();
+        await this.maybeSendTyping(opts);
         break;
 
       case "tool_call_update": {
@@ -164,7 +197,7 @@ export class WeChatAcpClient implements acp.Client {
         if (update.status === "completed" && update.content) {
           for (const c of update.content) {
             if (c.type === "diff") {
-              if (this.opts.showDiffs === false) {
+              if (opts.showDiffs === false) {
                 continue;
               }
               const diff = c as acp.Diff;
@@ -180,7 +213,7 @@ export class WeChatAcpClient implements acp.Client {
               this.producedMessageThisTurn = true;
             } else if (c.type === "content" && c.content.type === "image") {
               imageContentBlocks++;
-              await this.maybeSendImage(c.content);
+              await this.maybeSendImage(c.content, opts);
             }
           }
         }
@@ -191,7 +224,7 @@ export class WeChatAcpClient implements acp.Client {
         // populates both fields never delivers the same image twice.
         let rawOutputImages = 0;
         if (update.status === "completed" && imageContentBlocks === 0) {
-          rawOutputImages = await this.maybeSendRawOutputImages(update.rawOutput);
+          rawOutputImages = await this.maybeSendRawOutputImages(update.rawOutput, opts);
         }
         if (update.status) {
           // Surface where images came from so field issues like issue 55
@@ -202,9 +235,9 @@ export class WeChatAcpClient implements acp.Client {
               : rawOutputImages > 0
                 ? ` [images: ${rawOutputImages} rawOutput fallback]`
                 : "";
-          this.opts.log(`[tool] ${update.toolCallId} → ${update.status}${imageNote}`);
+          opts.log(`[tool] ${update.toolCallId} → ${update.status}${imageNote}`);
         }
-        await this.maybeSendTyping();
+        await this.maybeSendTyping(opts);
         break;
       }
 
@@ -214,14 +247,14 @@ export class WeChatAcpClient implements acp.Client {
           const items = update.entries
             .map((e: acp.PlanEntry, i: number) => `  ${i + 1}. [${e.status}] ${e.content}`)
             .join("\n");
-          this.opts.log(`[plan]\n${items}`);
+          opts.log(`[plan]\n${items}`);
         }
-        await this.maybeSendTyping();
+        await this.maybeSendTyping(opts);
         break;
 
       case "config_option_update":
-        this.opts.onConfigOptionsUpdate?.(update.configOptions);
-        this.opts.log(`[config] ${update.configOptions.length} option(s) updated`);
+        opts.onConfigOptionsUpdate?.(update.configOptions);
+        opts.log(`[config] ${update.configOptions.length} option(s) updated`);
         break;
     }
   }
@@ -249,9 +282,11 @@ export class WeChatAcpClient implements acp.Client {
     // Joins the task queue so any in-flight notification work (a pending text
     // send, an image upload) completes before the buffer is read. This also
     // guarantees hasProducedMessage is final when flush() resolves, so an
-    // image-only turn is never mistaken for an empty one.
+    // image-only turn is never mistaken for an empty one. Captures the
+    // callbacks at call time for the same reason sessionUpdate does.
+    const opts = this.opts;
     return this.enqueue(async () => {
-      await this.maybeFlushThoughts();
+      await this.maybeFlushThoughts(opts);
       const text = this.chunks.join("");
       this.chunks = [];
       this.lastTypingAt = 0;
@@ -268,7 +303,10 @@ export class WeChatAcpClient implements acp.Client {
    * anything malformed is ignored. Returns the number of valid image entries
    * handed to `maybeSendImage`, so the caller can log the delivery source.
    */
-  private async maybeSendRawOutputImages(rawOutput: unknown): Promise<number> {
+  private async maybeSendRawOutputImages(
+    rawOutput: unknown,
+    opts: WeChatAcpClientOpts,
+  ): Promise<number> {
     if (typeof rawOutput !== "object" || rawOutput === null) {
       return 0;
     }
@@ -296,7 +334,7 @@ export class WeChatAcpClient implements acp.Client {
         mimeType.trim()
       ) {
         images++;
-        await this.maybeSendImage({ data, mimeType });
+        await this.maybeSendImage({ data, mimeType }, opts);
       }
     }
     return images;
@@ -312,27 +350,30 @@ export class WeChatAcpClient implements acp.Client {
    * in the text stream, as is a failed delivery, so the turn never silently
    * loses content.
    */
-  private async maybeSendImage(image: { data: string; mimeType: string }): Promise<void> {
+  private async maybeSendImage(
+    image: { data: string; mimeType: string },
+    opts: WeChatAcpClientOpts,
+  ): Promise<void> {
     // Trim once here so every image path (content block, message chunk,
     // rawOutput fallback) validates and delivers the same normalized value.
     const mimeType = image.mimeType.trim();
-    if (this.opts.showImages === false) {
-      this.opts.log(`[image] skipped (showImages=false, ${mimeType})`);
+    if (opts.showImages === false) {
+      opts.log(`[image] skipped (showImages=false, ${mimeType})`);
       return;
     }
-    if (!this.opts.onImageFlush) {
-      this.opts.log(`[image] skipped (no image sink configured, ${mimeType})`);
+    if (!opts.onImageFlush) {
+      opts.log(`[image] skipped (no image sink configured, ${mimeType})`);
       return;
     }
     const mime = mimeType.toLowerCase();
     if (!SUPPORTED_IMAGE_MIME_TYPES.has(mime)) {
-      this.opts.log(`[image] skipped unsupported type: ${mimeType}`);
+      opts.log(`[image] skipped unsupported type: ${mimeType}`);
       return;
     }
     // ceil(base64Len / 4) * 3 over-estimates by at most 2 bytes; fine for a cap.
     const approxBytes = Math.ceil(image.data.length / 4) * 3;
     if (approxBytes > MAX_IMAGE_BYTES) {
-      this.opts.log(`[image] skipped oversized image (~${approxBytes} bytes > ${MAX_IMAGE_BYTES})`);
+      opts.log(`[image] skipped oversized image (~${approxBytes} bytes > ${MAX_IMAGE_BYTES})`);
       this.chunks.push("\n⚠️ [image too large to deliver]\n");
       this.producedMessageThisTurn = true;
       return;
@@ -344,17 +385,17 @@ export class WeChatAcpClient implements acp.Client {
     // now. Strict ordering is knowingly traded for content preservation
     // here; dropping or deferring a deliverable image because a text
     // segment hit a transient send failure would lose more than it saves.
-    await this.maybeFlushMessage();
+    await this.maybeFlushMessage(opts);
 
     try {
       // Single attempt here: the bridge-side sink owns retries (with a stable
       // client_id for gateway de-duplication), so retrying again at this layer
       // would multiply CDN uploads.
-      await this.opts.onImageFlush({ data: image.data, mimeType });
-      this.opts.log(`[image] sent (${mimeType}, ~${approxBytes} bytes)`);
+      await opts.onImageFlush({ data: image.data, mimeType });
+      opts.log(`[image] sent (${mimeType}, ~${approxBytes} bytes)`);
       this.producedMessageThisTurn = true;
     } catch (err) {
-      this.opts.log(`[image] delivery failed: ${String(err)}`);
+      opts.log(`[image] delivery failed: ${String(err)}`);
       // Queue serialization means no later text has been buffered yet, so the
       // placeholder lands exactly where the image belonged in the stream.
       this.chunks.push("\n⚠️ [image could not be delivered]\n");
@@ -362,17 +403,18 @@ export class WeChatAcpClient implements acp.Client {
     }
   }
 
-  private async maybeFlushThoughts(): Promise<void> {
+  private async maybeFlushThoughts(opts: WeChatAcpClientOpts): Promise<void> {
     if (this.thoughtChunks.length === 0) return;
     const thoughtText = this.thoughtChunks.join("");
     this.thoughtChunks = [];
     if (!thoughtText.trim()) return;
     const ok = await this.sendWithRetry(
-      () => this.opts.onThoughtFlush(`💭 [Thinking]\n${thoughtText}`),
+      () => opts.onThoughtFlush(`💭 [Thinking]\n${thoughtText}`),
       "thought",
+      opts,
     );
     if (!ok) {
-      this.opts.log(`[flush] dropping ${thoughtText.length} chars of thought after retries`);
+      opts.log(`[flush] dropping ${thoughtText.length} chars of thought after retries`);
     }
   }
 
@@ -384,7 +426,7 @@ export class WeChatAcpClient implements acp.Client {
    * within a task on the notification queue, which guarantees FIFO send
    * order without needing its own mutex.
    */
-  private async maybeFlushMessage(): Promise<void> {
+  private async maybeFlushMessage(opts: WeChatAcpClientOpts): Promise<void> {
     if (this.chunks.length === 0) return;
     const text = this.chunks.join("");
     this.chunks = [];
@@ -392,13 +434,13 @@ export class WeChatAcpClient implements acp.Client {
       return;
     }
 
-    const ok = await this.sendWithRetry(() => this.opts.onMessageFlush(text), "message");
+    const ok = await this.sendWithRetry(() => opts.onMessageFlush(text), "message", opts);
     if (!ok) {
       // Send failed after all retries. Prepend the unsent text back so the
       // final flush() returns it and session.ts re-attempts via onReply (which
       // surfaces failure to the user).
       this.chunks = [text, ...this.chunks];
-      this.opts.log(
+      opts.log(
         `[flush] message send failed after retries; retaining ${text.length} chars for final flush`,
       );
     }
@@ -410,13 +452,17 @@ export class WeChatAcpClient implements acp.Client {
    * (logging each failure so transient WeChat send errors are surfaced
    * instead of silently swallowed).
    */
-  private async sendWithRetry(send: () => Promise<void>, label: string): Promise<boolean> {
+  private async sendWithRetry(
+    send: () => Promise<void>,
+    label: string,
+    opts: WeChatAcpClientOpts,
+  ): Promise<boolean> {
     for (let attempt = 1; attempt <= WeChatAcpClient.SEND_MAX_ATTEMPTS; attempt++) {
       try {
         await send();
         return true;
       } catch (err) {
-        this.opts.log(
+        opts.log(
           `[flush] ${label} send failed (attempt ${attempt}/${WeChatAcpClient.SEND_MAX_ATTEMPTS}): ${String(err)}`,
         );
         if (attempt < WeChatAcpClient.SEND_MAX_ATTEMPTS) {
@@ -427,12 +473,12 @@ export class WeChatAcpClient implements acp.Client {
     return false;
   }
 
-  private async maybeSendTyping(): Promise<void> {
+  private async maybeSendTyping(opts: WeChatAcpClientOpts): Promise<void> {
     const now = Date.now();
     if (now - this.lastTypingAt < WeChatAcpClient.TYPING_INTERVAL_MS) return;
     this.lastTypingAt = now;
     try {
-      await this.opts.sendTyping();
+      await opts.sendTyping();
     } catch {
       // typing is best-effort
     }

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -41,12 +41,30 @@ export interface WeChatAcpClientOpts {
   showImages?: boolean;
 }
 
+/**
+ * All mutable state scoped to a single prompt turn: the delivery callbacks
+ * plus the text/thought buffers and per-turn delivery flags. Notifications
+ * capture the turn object at arrival time, so a task that runs after the
+ * turn ended (queued behind `beginTurn`, or delayed by a stalled chain)
+ * reads and writes its own closed turn's state, which the next turn's
+ * `flush()` can never observe (issue 54).
+ */
+interface TurnState {
+  opts: WeChatAcpClientOpts;
+  chunks: string[];
+  thoughtChunks: string[];
+  producedMessage: boolean;
+  lastTypingAt: number;
+}
+
+function freshTurn(opts: WeChatAcpClientOpts): TurnState {
+  return { opts, chunks: [], thoughtChunks: [], producedMessage: false, lastTypingAt: 0 };
+}
+
 export class WeChatAcpClient implements acp.Client {
-  private chunks: string[] = [];
-  private thoughtChunks: string[] = [];
-  private opts: WeChatAcpClientOpts;
-  private lastTypingAt = 0;
-  private producedMessageThisTurn = false;
+  // Per-turn mutable state (callbacks, buffers, flags). Swapped wholesale by
+  // beginTurn; queued tasks operate on the turn object captured at arrival.
+  private turn: TurnState;
   // FIFO task queue serializing all session-notification handling and flush()
   // reads. The ACP SDK dispatches notifications without awaiting handlers, so
   // without this two sessionUpdate calls interleave at their first await:
@@ -60,28 +78,30 @@ export class WeChatAcpClient implements acp.Client {
 
   /** Whether the agent emitted any non-empty message content during the current turn. */
   get hasProducedMessage(): boolean {
-    return this.producedMessageThisTurn;
+    return this.turn.producedMessage;
   }
 
-  /** Reset per-turn delivery state. Called by beginTurn; exposed for tests. */
+  /** Reset the produced-message flag on the current turn. Exposed for tests;
+   * production code starts turns via beginTurn, which creates fresh state. */
   newTurn(): void {
-    this.producedMessageThisTurn = false;
+    this.turn.producedMessage = false;
   }
 
   constructor(opts: WeChatAcpClientOpts) {
-    this.opts = opts;
+    this.turn = freshTurn(opts);
   }
 
   /**
-   * Start a new turn: rebind delivery callbacks to the new turn's context and
-   * reset per-turn state. Runs as a task on the notification queue, so every
-   * task from the previous turn (including ones left queued when a failed
-   * `prompt()` rejected early) finishes delivering with its own turn's
-   * callbacks before the swap; a notification can never deliver with the next
-   * turn's binding (issue 54). Residual undelivered buffers (text the final
-   * flush never read, trailing thoughts) are discarded at the boundary
-   * instead of leaking into the new turn. Await this before sending the next
-   * prompt.
+   * Start a new turn: swap in a fresh per-turn state object (buffers, flags)
+   * bound to the new turn's delivery callbacks. Runs as a task on the
+   * notification queue, so every task from the previous turn that is already
+   * queued finishes delivering with its own turn's state before the swap.
+   * Tasks that run after the swap (a late notification queued behind this
+   * boundary while the chain was stalled) still write into the previous
+   * turn's captured state object, which the new turn's flush() can never
+   * observe; buffered residue they produce is dropped with the closed turn
+   * (issue 54). Residual undelivered buffers present at the boundary are
+   * logged and discarded. Await this before sending the next prompt.
    */
   async beginTurn(callbacks: {
     sendTyping: () => Promise<void>;
@@ -90,24 +110,22 @@ export class WeChatAcpClient implements acp.Client {
     onImageFlush?: (image: AgentImage) => Promise<void>;
   }): Promise<void> {
     return this.enqueue(async () => {
-      this.opts = {
-        ...this.opts,
+      const previous = this.turn;
+      const opts: WeChatAcpClientOpts = {
+        ...previous.opts,
         sendTyping: callbacks.sendTyping,
         onThoughtFlush: callbacks.onThoughtFlush,
         onMessageFlush: callbacks.onMessageFlush,
         ...(callbacks.onImageFlush ? { onImageFlush: callbacks.onImageFlush } : {}),
       };
-      const staleText = this.chunks.join("");
-      const staleThoughts = this.thoughtChunks.join("");
+      const staleText = previous.chunks.join("");
+      const staleThoughts = previous.thoughtChunks.join("");
       if (staleText.trim() || staleThoughts.trim()) {
-        this.opts.log(
+        opts.log(
           `[turn] discarding residue from previous turn (${staleText.length} chars text, ${staleThoughts.length} chars thoughts)`,
         );
       }
-      this.chunks = [];
-      this.thoughtChunks = [];
-      this.lastTypingAt = 0;
-      this.newTurn();
+      this.turn = freshTurn(opts);
     });
   }
 
@@ -120,7 +138,9 @@ export class WeChatAcpClient implements acp.Client {
     );
     const optionId = allowOpt?.optionId ?? params.options[0]?.optionId ?? "allow";
 
-    this.opts.log(`[permission] auto-allowed: ${params.toolCall?.title ?? "unknown"} → ${optionId}`);
+    this.turn.opts.log(
+      `[permission] auto-allowed: ${params.toolCall?.title ?? "unknown"} → ${optionId}`,
+    );
 
     return {
       outcome: {
@@ -143,53 +163,55 @@ export class WeChatAcpClient implements acp.Client {
   }
 
   async sessionUpdate(params: acp.SessionNotification): Promise<void> {
-    // Bind the notification to the callbacks active at arrival time. A task
+    // Bind the notification to the turn state active at arrival time. A task
     // can sit queued across a turn boundary (beginTurn's swap is enqueued
-    // behind it), and a straggler can even arrive while the previous turn's
-    // residue is still draining; capturing here guarantees it delivers with
-    // the binding of the turn it belongs to, never the next turn's (issue 54).
-    const opts = this.opts;
-    return this.enqueue(() => this.handleSessionUpdate(params, opts));
+    // behind it), or even end up queued after the boundary task when a
+    // stalled chain delays the swap; operating on the captured turn object
+    // guarantees it reads and writes the state of the turn it belongs to,
+    // never the next turn's buffers or callbacks (issue 54).
+    const turn = this.turn;
+    return this.enqueue(() => this.handleSessionUpdate(params, turn));
   }
 
   private async handleSessionUpdate(
     params: acp.SessionNotification,
-    opts: WeChatAcpClientOpts,
+    turn: TurnState,
   ): Promise<void> {
     const update = params.update;
+    const opts = turn.opts;
 
     switch (update.sessionUpdate) {
       case "agent_message_chunk":
-        await this.maybeFlushThoughts(opts);
+        await this.maybeFlushThoughts(turn);
         if (update.content.type === "text") {
-          this.chunks.push(update.content.text);
+          turn.chunks.push(update.content.text);
           if (update.content.text.trim()) {
-            this.producedMessageThisTurn = true;
+            turn.producedMessage = true;
           }
         } else if (update.content.type === "image") {
-          await this.maybeSendImage(update.content, opts);
+          await this.maybeSendImage(update.content, turn);
         }
         // Throttle typing indicators
-        await this.maybeSendTyping(opts);
+        await this.maybeSendTyping(turn);
         break;
 
       case "tool_call":
-        await this.maybeFlushThoughts(opts);
-        await this.maybeFlushMessage(opts);
+        await this.maybeFlushThoughts(turn);
+        await this.maybeFlushMessage(turn);
         opts.log(`[tool] ${update.title} (${update.status})`);
-        await this.maybeSendTyping(opts);
+        await this.maybeSendTyping(turn);
         break;
 
       case "agent_thought_chunk":
-        await this.maybeFlushMessage(opts);
+        await this.maybeFlushMessage(turn);
         if (update.content.type === "text") {
           const text = update.content.text;
           opts.log(`[thought] ${text.length > 80 ? text.substring(0, 80) + "..." : text}`);
           if (opts.showThoughts) {
-            this.thoughtChunks.push(text);
+            turn.thoughtChunks.push(text);
           }
         }
-        await this.maybeSendTyping(opts);
+        await this.maybeSendTyping(turn);
         break;
 
       case "tool_call_update": {
@@ -209,11 +231,11 @@ export class WeChatAcpClient implements acp.Client {
               if (diff.newText != null) {
                 for (const l of diff.newText.split("\n")) lines.push(`+ ${l}`);
               }
-              this.chunks.push("\n```diff\n" + lines.join("\n") + "\n```\n");
-              this.producedMessageThisTurn = true;
+              turn.chunks.push("\n```diff\n" + lines.join("\n") + "\n```\n");
+              turn.producedMessage = true;
             } else if (c.type === "content" && c.content.type === "image") {
               imageContentBlocks++;
-              await this.maybeSendImage(c.content, opts);
+              await this.maybeSendImage(c.content, turn);
             }
           }
         }
@@ -224,7 +246,7 @@ export class WeChatAcpClient implements acp.Client {
         // populates both fields never delivers the same image twice.
         let rawOutputImages = 0;
         if (update.status === "completed" && imageContentBlocks === 0) {
-          rawOutputImages = await this.maybeSendRawOutputImages(update.rawOutput, opts);
+          rawOutputImages = await this.maybeSendRawOutputImages(update.rawOutput, turn);
         }
         if (update.status) {
           // Surface where images came from so field issues like issue 55
@@ -237,7 +259,7 @@ export class WeChatAcpClient implements acp.Client {
                 : "";
           opts.log(`[tool] ${update.toolCallId} → ${update.status}${imageNote}`);
         }
-        await this.maybeSendTyping(opts);
+        await this.maybeSendTyping(turn);
         break;
       }
 
@@ -249,7 +271,7 @@ export class WeChatAcpClient implements acp.Client {
             .join("\n");
           opts.log(`[plan]\n${items}`);
         }
-        await this.maybeSendTyping(opts);
+        await this.maybeSendTyping(turn);
         break;
 
       case "config_option_update":
@@ -282,14 +304,14 @@ export class WeChatAcpClient implements acp.Client {
     // Joins the task queue so any in-flight notification work (a pending text
     // send, an image upload) completes before the buffer is read. This also
     // guarantees hasProducedMessage is final when flush() resolves, so an
-    // image-only turn is never mistaken for an empty one. Captures the
-    // callbacks at call time for the same reason sessionUpdate does.
-    const opts = this.opts;
+    // image-only turn is never mistaken for an empty one. Captures the turn
+    // state at call time for the same reason sessionUpdate does.
+    const turn = this.turn;
     return this.enqueue(async () => {
-      await this.maybeFlushThoughts(opts);
-      const text = this.chunks.join("");
-      this.chunks = [];
-      this.lastTypingAt = 0;
+      await this.maybeFlushThoughts(turn);
+      const text = turn.chunks.join("");
+      turn.chunks = [];
+      turn.lastTypingAt = 0;
       return text;
     });
   }
@@ -303,10 +325,7 @@ export class WeChatAcpClient implements acp.Client {
    * anything malformed is ignored. Returns the number of valid image entries
    * handed to `maybeSendImage`, so the caller can log the delivery source.
    */
-  private async maybeSendRawOutputImages(
-    rawOutput: unknown,
-    opts: WeChatAcpClientOpts,
-  ): Promise<number> {
+  private async maybeSendRawOutputImages(rawOutput: unknown, turn: TurnState): Promise<number> {
     if (typeof rawOutput !== "object" || rawOutput === null) {
       return 0;
     }
@@ -334,7 +353,7 @@ export class WeChatAcpClient implements acp.Client {
         mimeType.trim()
       ) {
         images++;
-        await this.maybeSendImage({ data, mimeType }, opts);
+        await this.maybeSendImage({ data, mimeType }, turn);
       }
     }
     return images;
@@ -352,8 +371,9 @@ export class WeChatAcpClient implements acp.Client {
    */
   private async maybeSendImage(
     image: { data: string; mimeType: string },
-    opts: WeChatAcpClientOpts,
+    turn: TurnState,
   ): Promise<void> {
+    const opts = turn.opts;
     // Trim once here so every image path (content block, message chunk,
     // rawOutput fallback) validates and delivers the same normalized value.
     const mimeType = image.mimeType.trim();
@@ -374,8 +394,8 @@ export class WeChatAcpClient implements acp.Client {
     const approxBytes = Math.ceil(image.data.length / 4) * 3;
     if (approxBytes > MAX_IMAGE_BYTES) {
       opts.log(`[image] skipped oversized image (~${approxBytes} bytes > ${MAX_IMAGE_BYTES})`);
-      this.chunks.push("\n⚠️ [image too large to deliver]\n");
-      this.producedMessageThisTurn = true;
+      turn.chunks.push("\n⚠️ [image too large to deliver]\n");
+      turn.producedMessage = true;
       return;
     }
 
@@ -385,7 +405,7 @@ export class WeChatAcpClient implements acp.Client {
     // now. Strict ordering is knowingly traded for content preservation
     // here; dropping or deferring a deliverable image because a text
     // segment hit a transient send failure would lose more than it saves.
-    await this.maybeFlushMessage(opts);
+    await this.maybeFlushMessage(turn);
 
     try {
       // Single attempt here: the bridge-side sink owns retries (with a stable
@@ -393,28 +413,28 @@ export class WeChatAcpClient implements acp.Client {
       // would multiply CDN uploads.
       await opts.onImageFlush({ data: image.data, mimeType });
       opts.log(`[image] sent (${mimeType}, ~${approxBytes} bytes)`);
-      this.producedMessageThisTurn = true;
+      turn.producedMessage = true;
     } catch (err) {
       opts.log(`[image] delivery failed: ${String(err)}`);
       // Queue serialization means no later text has been buffered yet, so the
       // placeholder lands exactly where the image belonged in the stream.
-      this.chunks.push("\n⚠️ [image could not be delivered]\n");
-      this.producedMessageThisTurn = true;
+      turn.chunks.push("\n⚠️ [image could not be delivered]\n");
+      turn.producedMessage = true;
     }
   }
 
-  private async maybeFlushThoughts(opts: WeChatAcpClientOpts): Promise<void> {
-    if (this.thoughtChunks.length === 0) return;
-    const thoughtText = this.thoughtChunks.join("");
-    this.thoughtChunks = [];
+  private async maybeFlushThoughts(turn: TurnState): Promise<void> {
+    if (turn.thoughtChunks.length === 0) return;
+    const thoughtText = turn.thoughtChunks.join("");
+    turn.thoughtChunks = [];
     if (!thoughtText.trim()) return;
     const ok = await this.sendWithRetry(
-      () => opts.onThoughtFlush(`💭 [Thinking]\n${thoughtText}`),
+      () => turn.opts.onThoughtFlush(`💭 [Thinking]\n${thoughtText}`),
       "thought",
-      opts,
+      turn,
     );
     if (!ok) {
-      opts.log(`[flush] dropping ${thoughtText.length} chars of thought after retries`);
+      turn.opts.log(`[flush] dropping ${thoughtText.length} chars of thought after retries`);
     }
   }
 
@@ -426,21 +446,21 @@ export class WeChatAcpClient implements acp.Client {
    * within a task on the notification queue, which guarantees FIFO send
    * order without needing its own mutex.
    */
-  private async maybeFlushMessage(opts: WeChatAcpClientOpts): Promise<void> {
-    if (this.chunks.length === 0) return;
-    const text = this.chunks.join("");
-    this.chunks = [];
+  private async maybeFlushMessage(turn: TurnState): Promise<void> {
+    if (turn.chunks.length === 0) return;
+    const text = turn.chunks.join("");
+    turn.chunks = [];
     if (!text.trim()) {
       return;
     }
 
-    const ok = await this.sendWithRetry(() => opts.onMessageFlush(text), "message", opts);
+    const ok = await this.sendWithRetry(() => turn.opts.onMessageFlush(text), "message", turn);
     if (!ok) {
       // Send failed after all retries. Prepend the unsent text back so the
       // final flush() returns it and session.ts re-attempts via onReply (which
       // surfaces failure to the user).
-      this.chunks = [text, ...this.chunks];
-      opts.log(
+      turn.chunks = [text, ...turn.chunks];
+      turn.opts.log(
         `[flush] message send failed after retries; retaining ${text.length} chars for final flush`,
       );
     }
@@ -455,14 +475,14 @@ export class WeChatAcpClient implements acp.Client {
   private async sendWithRetry(
     send: () => Promise<void>,
     label: string,
-    opts: WeChatAcpClientOpts,
+    turn: TurnState,
   ): Promise<boolean> {
     for (let attempt = 1; attempt <= WeChatAcpClient.SEND_MAX_ATTEMPTS; attempt++) {
       try {
         await send();
         return true;
       } catch (err) {
-        opts.log(
+        turn.opts.log(
           `[flush] ${label} send failed (attempt ${attempt}/${WeChatAcpClient.SEND_MAX_ATTEMPTS}): ${String(err)}`,
         );
         if (attempt < WeChatAcpClient.SEND_MAX_ATTEMPTS) {
@@ -473,12 +493,12 @@ export class WeChatAcpClient implements acp.Client {
     return false;
   }
 
-  private async maybeSendTyping(opts: WeChatAcpClientOpts): Promise<void> {
+  private async maybeSendTyping(turn: TurnState): Promise<void> {
     const now = Date.now();
-    if (now - this.lastTypingAt < WeChatAcpClient.TYPING_INTERVAL_MS) return;
-    this.lastTypingAt = now;
+    if (now - turn.lastTypingAt < WeChatAcpClient.TYPING_INTERVAL_MS) return;
+    turn.lastTypingAt = now;
     try {
-      await opts.sendTyping();
+      await turn.opts.sendTyping();
     } catch {
       // typing is best-effort
     }

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -290,8 +290,13 @@ export class SessionManager {
         const pending = session.queue.shift()!;
         let completionError: unknown;
 
-        // Keep the ACP client instance stable because the connection is bound to it.
-        session.client.updateCallbacks({
+        // Keep the ACP client instance stable because the connection is bound
+        // to it. beginTurn runs on the client's notification queue: every task
+        // from the previous turn (including ones left queued when a failed
+        // prompt() rejected early) delivers with its own turn's callbacks
+        // before the swap, and residual undelivered buffers are discarded at
+        // the boundary instead of leaking into this turn (issue 54).
+        await session.client.beginTurn({
           sendTyping: () => this.opts.sendTyping(session.userId, pending.contextToken),
           onThoughtFlush: (text) => this.opts.onReply(session.userId, pending.contextToken, text),
           onMessageFlush: (text) => this.opts.onReply(session.userId, pending.contextToken, text),
@@ -302,10 +307,6 @@ export class SessionManager {
               }
             : {}),
         });
-
-        // Reset chunks for the new turn
-        await session.client.flush();
-        session.client.newTurn();
 
         const promptStartedAt = Date.now();
         try {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -543,3 +543,96 @@ test("failure placeholder keeps stream position when text arrives during the ima
   assert.ok(textAt >= 0, "later text must be preserved");
   assert.ok(placeholderAt < textAt, `placeholder must precede later text, got: ${JSON.stringify(text)}`);
 });
+
+// ---------------------------------------------------------------------------
+// Cross-turn callback binding (issue 54)
+// ---------------------------------------------------------------------------
+
+function turnCallbacks(sinks: {
+  messages?: string[];
+  images?: AgentImage[];
+  onImageFlush?: (img: AgentImage) => Promise<void>;
+}) {
+  return {
+    sendTyping: async () => {},
+    onThoughtFlush: async () => {},
+    onMessageFlush: async (t: string) => {
+      sinks.messages?.push(t);
+    },
+    onImageFlush:
+      sinks.onImageFlush ??
+      (async (img: AgentImage) => {
+        sinks.images?.push(img);
+      }),
+  };
+}
+
+test("notification queued across a turn boundary delivers with its own turn's callbacks", async () => {
+  /**
+   * Regression for issue 54: a failed prompt() leaves notification tasks
+   * queued; the old code rebound callbacks via plain mutation, so a queued
+   * image task delivered into the NEXT turn's context token. Now
+   * sessionUpdate captures the callbacks at arrival time and beginTurn's
+   * swap is itself a queued task, so the straggler lands in turn 1's sink.
+   */
+  const turn1Images: AgentImage[] = [];
+  const turn2Images: AgentImage[] = [];
+  let releaseImage!: () => void;
+
+  const client = makeClient({});
+  await client.beginTurn(
+    turnCallbacks({
+      onImageFlush: async (img) => {
+        await new Promise<void>((r) => { releaseImage = r; });
+        turn1Images.push(img);
+      },
+    }),
+  );
+
+  // Straggler notification from turn 1; prompt() has already rejected, so
+  // the session loop advances to turn 2 without draining the queue.
+  const straggler = emitToolCallImage(client, { data: PNG_BASE64, mimeType: "image/png" });
+
+  // Turn 2 rebinding queues up behind the straggler.
+  const turn2 = client.beginTurn(turnCallbacks({ images: turn2Images }));
+
+  await new Promise((r) => setTimeout(r, 10));
+  releaseImage();
+  await Promise.all([straggler, turn2]);
+
+  assert.equal(turn1Images.length, 1, "straggler image must deliver to its own turn's sink");
+  assert.equal(turn2Images.length, 0, "next turn's sink must not receive the previous turn's image");
+});
+
+test("text flushed by a straggler boundary event goes to its own turn's sink", async () => {
+  const turn1Messages: string[] = [];
+  const turn2Messages: string[] = [];
+
+  const client = makeClient({});
+  await client.beginTurn(turnCallbacks({ messages: turn1Messages }));
+
+  // Turn 1 buffers text; the boundary event that flushes it is still queued
+  // when turn 2 begins.
+  await emitMessageChunk(client, "turn-1 status");
+  const straggler = emitToolCall(client);
+  const turn2 = client.beginTurn(turnCallbacks({ messages: turn2Messages }));
+  await Promise.all([straggler, turn2]);
+
+  assert.deepEqual(turn1Messages, ["turn-1 status"], "flush must use turn 1's binding");
+  assert.deepEqual(turn2Messages, [], "turn 2 must not receive turn 1's text");
+});
+
+test("beginTurn discards residual undelivered text instead of leaking it into the new turn", async () => {
+  const client = makeClient({});
+  await client.beginTurn(turnCallbacks({}));
+
+  // Turn 1 buffers text but no boundary event flushes it and no final
+  // flush() runs (the failed-prompt path).
+  await emitMessageChunk(client, "undelivered turn-1 text");
+
+  await client.beginTurn(turnCallbacks({}));
+
+  const text = await client.flush();
+  assert.equal(text, "", "turn-1 residue must not surface in turn 2's flush");
+  assert.equal(client.hasProducedMessage, false, "beginTurn must reset per-turn state");
+});

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -636,3 +636,46 @@ test("beginTurn discards residual undelivered text instead of leaking it into th
   assert.equal(text, "", "turn-1 residue must not surface in turn 2's flush");
   assert.equal(client.hasProducedMessage, false, "beginTurn must reset per-turn state");
 });
+
+test("late old-turn notification queued after beginTurn cannot leak into the new turn", async () => {
+  /**
+   * Maintainer repro on PR 57: block a turn-1 image task so the chain
+   * stalls, enqueue turn-2 beginTurn, then let a turn-1 text notification
+   * arrive. It captures turn-1 state at arrival but runs after the boundary
+   * task. With buffers shared on the client it wrote into the freshly reset
+   * fields and turn 2's flush() returned turn-1 text under the new context;
+   * with per-turn state it writes into the closed turn's object instead.
+   */
+  const turn2Messages: string[] = [];
+  let releaseImage!: () => void;
+
+  const client = makeClient({});
+  await client.beginTurn(
+    turnCallbacks({
+      onImageFlush: async () => {
+        await new Promise<void>((r) => { releaseImage = r; });
+      },
+    }),
+  );
+
+  // Turn-1 image task blocks the chain.
+  const blocked = emitToolCallImage(client, { data: PNG_BASE64, mimeType: "image/png" });
+  // Turn-2 boundary task queues behind it.
+  const turn2 = client.beginTurn(turnCallbacks({ messages: turn2Messages }));
+  // Late turn-1 text arrives after beginTurn was enqueued: it must bind to
+  // turn-1 state even though it runs after the swap.
+  const lateText = emitMessageChunk(client, "stale turn-1 text");
+
+  await new Promise((r) => setTimeout(r, 10));
+  releaseImage();
+  await Promise.all([blocked, turn2, lateText]);
+
+  const text = await client.flush();
+  assert.equal(text, "", "turn-2 flush must not return turn-1 text");
+  assert.equal(
+    client.hasProducedMessage,
+    false,
+    "late turn-1 text must not mark turn 2 as having produced output",
+  );
+  assert.deepEqual(turn2Messages, [], "turn 2 sinks must stay untouched");
+});


### PR DESCRIPTION
Fixes #54.

## Problem

`WeChatAcpClient` serializes all notification handling on a FIFO task chain, but the callback set the tasks read (`this.opts`) was swapped by plain mutation at turn start. A failed `prompt()` rejects while notification tasks are still queued (the catch path does not drain the queue), so those stragglers executed after `updateCallbacks()` and delivered their text/images with the next turn's `contextToken`. The pre-turn `flush()` made it worse for thoughts: residue from the previous turn was actively sent through the new turn's callbacks.

## Fix

Two parts, matching the proposal in the issue:

1) **Capture at arrival.** `sessionUpdate()` and `flush()` snapshot `this.opts` before enqueuing and thread it through the task. A task always delivers with the binding of the turn it belongs to, no matter when it runs.

2) **The turn switch is itself a queued task.** `updateCallbacks()` + pre-turn `flush()` + `newTurn()` are replaced by a single awaited `beginTurn(callbacks)` that runs on the same chain. Queue order then guarantees every task from the previous turn finishes delivering before the swap. Residual undelivered buffers (text the final flush never read, trailing thoughts) are logged and discarded at the boundary instead of leaking.

Discarding residue matches the old behavior for text (`processQueue` ignored the pre-turn `flush()` return value) and improves it for thoughts, which were previously delivered with the wrong token.

## Tests

Three regression tests (36 total, all green):

- a straggler image task queued across the boundary delivers to its own turn's sink, not the next turn's, even when `beginTurn` is called while it is in flight
- text flushed by a straggler boundary event uses its own turn's binding
- residual undelivered text is discarded by `beginTurn` and per-turn state is reset

`npm run build` clean under `strict: true`.
