### PR TITLE
feat: deliver agent-generated files to WeChat

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Bridge WeChat direct messages to any ACP-compatible AI agent.
 - Built-in ACP agent presets for common CLIs
 - Custom raw agent command support
 - Agent image output delivered as native WeChat image messages
+- Agent audio, embedded resources, and generated files delivered to WeChat
 - Auto-allow permission requests from the agent
 - Direct message only; group chats are ignored
 - Background daemon mode
@@ -106,7 +107,7 @@ Options:
 - `--show-diffs`: forward ACP file diffs to WeChat (default: hidden)
 - `--hide-images`: do not forward agent image output to WeChat (default: forwarded)
 - `--hide-audio`: do not forward agent audio output to WeChat (default: forwarded)
-- `--hide-resources`: do not forward agent embedded resources to WeChat (default: forwarded)
+- `--hide-resources`: do not forward agent resources or generated file attachments to WeChat (default: forwarded)
 - `inject --text <text>`: enqueue a local text message for the running daemon
 - `-V, --version`: print version and exit
 - `-h, --help`: show help
@@ -368,6 +369,24 @@ Overrides:
 
 Text-typed files (`.md`, `.json`, source code, …) and images keep their previous behavior: their content is embedded inline in the prompt as a `resource` / `image` block, no disk write needed.
 
+## Receiving agent-generated files
+
+When the ACP agent advertises HTTP MCP support, `wechat-acp` injects a local
+`attach_file` tool into the session. The agent can call it with a file it
+created under the configured working directory, and the bridge sends that
+snapshot back as a WeChat file message.
+
+The MCP server listens only on a random `127.0.0.1` port, requires a
+process-local bearer token, rejects browser-origin requests, and only reads
+regular files whose resolved path stays inside the agent working directory.
+Files are limited to 25 MiB, kept briefly in memory, and consumed once.
+
+This also handles standard ACP `resource_link` output and Copilot CLI's
+`rawOutput.contents[type=resource_link]` compatibility shape. Agents that do
+not support HTTP MCP injection or do not forward resource links cannot use the
+active `attach_file` flow. `--hide-resources` disables both the tool injection
+and outbound resource/file delivery.
+
 ## Storage
 
 By default, runtime files are stored under:
@@ -392,7 +411,7 @@ When `--instance <name>` is used, the same files live under `~/.wechat-acp/insta
 ## Current Limitations
 
 - Direct messages only; group chats are ignored
-- MCP servers are not used
+- Agent-generated file delivery depends on the agent's HTTP MCP and resource-link support
 - Permission requests are auto-approved
 - Agent communication is subprocess-only over stdio
 - Some preset agents may require separate authentication before they can respond successfully
@@ -428,7 +447,7 @@ npm run dev
 WECHAT_ACP_TELEMETRY=0 npx wechat-acp --agent copilot
 ```
 
-**What is collected** (17 event types only):
+**What is collected** (18 event types only):
 
 - `app.start` / `app.stop` — process lifecycle, agent preset name, daemon flag, uptime
 - `login.success` / `login.failure` / `token.reused` — WeChat login outcomes (no token, no QR URL)
@@ -444,8 +463,9 @@ WECHAT_ACP_TELEMETRY=0 npx wechat-acp --agent copilot
 - `reply.sent` — reply pushed back to WeChat; segment count, total length
 - `reply.image.sent`: image reply pushed back to WeChat; byte size, MIME type, duration
 - `reply.audio.sent`: audio reply pushed back to WeChat as a file message; byte size, MIME type, duration
+- `reply.file.sent`: agent-generated file pushed back to WeChat; byte size, MIME type, duration
 
-Plus exception reports for `monitor`, `prompt`, `reply`, `reply.image`, `reply.audio`, `auth`, `agent_spawn`, `enqueue`, `buffer`, `command`, and `state` failures.
+Plus exception reports for `monitor`, `prompt`, `reply`, `reply.image`, `reply.audio`, `reply.file`, `artifact_mcp`, `auth`, `agent_spawn`, `enqueue`, `buffer`, `command`, and `state` failures.
 
 **What is never collected**: message bodies, filenames, voice transcripts, image URLs, login tokens, QR codes, raw agent command strings, environment variables, working directory paths, raw WeChat user IDs.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,16 @@
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.16.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "applicationinsights": "^2.9.6",
-        "qrcode-terminal": "^0.12.0"
+        "qrcode-terminal": "^0.12.0",
+        "zod": "^4.4.3"
       },
       "bin": {
         "wechat-acp": "dist/bin/wechat-acp.js"
       },
       "devDependencies": {
+        "@types/express": "^5.0.6",
         "@types/node": "^22.0.0",
         "tsx": "^4.22.3",
         "typescript": "^5.5.0"
@@ -593,11 +596,63 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@microsoft/applicationinsights-web-snippet": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.0.1.tgz",
       "integrity": "sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ==",
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
@@ -785,6 +840,59 @@
         "node": ">=14"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz",
+      "integrity": "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
@@ -793,6 +901,41 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
@@ -807,6 +950,19 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/acorn": {
@@ -837,6 +993,39 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/applicationinsights": {
@@ -904,6 +1093,81 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/cjs-module-lexer": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
@@ -933,6 +1197,28 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/continuation-local-storage": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
@@ -941,6 +1227,55 @@
       "dependencies": {
         "async-listener": "^0.6.0",
         "emitter-listener": "^1.1.1"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -958,6 +1293,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/diagnostic-channel": {
@@ -978,6 +1322,26 @@
         "diagnostic-channel": "*"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emitter-listener": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
@@ -985,6 +1349,45 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "shimmer": "^1.2.0"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -1029,6 +1432,165 @@
         "@esbuild/win32-x64": "0.28.0"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1042,6 +1604,117 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -1070,6 +1743,22 @@
         "node": ">= 14"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/import-in-the-middle": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
@@ -1080,6 +1769,118 @@
         "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^2.2.0",
         "module-details-from-path": "^1.0.4"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/module-details-from-path": {
@@ -1094,12 +1895,166 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/qrcode-terminal": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
       "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-in-the-middle": {
@@ -1115,6 +2070,28 @@
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -1127,17 +2104,179 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shimmer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/stack-chain": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
       "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==",
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -1164,6 +2303,37 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1185,14 +2355,61 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
-      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,10 +28,13 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.16.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "applicationinsights": "^2.9.6",
-    "qrcode-terminal": "^0.12.0"
+    "qrcode-terminal": "^0.12.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/express": "^5.0.6",
     "@types/node": "^22.0.0",
     "tsx": "^4.22.3",
     "typescript": "^5.5.0"

--- a/src/acp/agent-manager.ts
+++ b/src/acp/agent-manager.ts
@@ -22,9 +22,14 @@ export async function spawnAgent(params: {
   cwd: string;
   env?: Record<string, string>;
   client: WeChatAcpClient;
+  mcpServers?: acp.McpServer[];
+  signal?: AbortSignal;
   log: (msg: string) => void;
 }): Promise<AgentProcessInfo> {
-  const { command, args, cwd, env, client, log } = params;
+  const { command, args, cwd, env, client, mcpServers = [], signal, log } = params;
+  if (signal?.aborted) {
+    throw new Error("Agent spawn aborted");
+  }
 
   // On Windows, shell mode avoids EINVAL/ENOENT for command shims like npx/claude/gemini.
   const useShell = process.platform === "win32";
@@ -47,60 +52,110 @@ export async function spawnAgent(params: {
   proc.on("exit", (code, signal) => {
     log(`Agent process exited: code=${code} signal=${signal}`);
   });
+  const abortSpawn = () => killAgent(proc);
+  signal?.addEventListener("abort", abortSpawn, { once: true });
 
-  if (!proc.stdin || !proc.stdout) {
-    proc.kill();
-    const err = new Error("Failed to get agent process stdio");
-    trackException(err, "agent_spawn");
+  try {
+    if (!proc.stdin || !proc.stdout) {
+      const err = new Error("Failed to get agent process stdio");
+      trackException(err, "agent_spawn");
+      throw err;
+    }
+
+    const input = Writable.toWeb(proc.stdin);
+    const output = Readable.toWeb(proc.stdout) as ReadableStream<Uint8Array>;
+    const stream = acp.ndJsonStream(input, output);
+
+    const connection = new acp.ClientSideConnection(() => client, stream);
+
+    // Initialize
+    log("Initializing ACP connection...");
+    const initResult = await abortable(
+      connection.initialize({
+        protocolVersion: acp.PROTOCOL_VERSION,
+        clientInfo: {
+          name: packageJson.name,
+          title: packageJson.name,
+          version: packageJson.version,
+        },
+        clientCapabilities: {
+          fs: {
+            readTextFile: true,
+            writeTextFile: true,
+          },
+        },
+      }),
+      signal,
+    );
+    log(`ACP initialized (protocol v${initResult.protocolVersion})`);
+
+    // Create session
+    const supportsHttpMcp = initResult.agentCapabilities?.mcpCapabilities?.http === true;
+    const sessionMcpServers = supportsHttpMcp
+      ? mcpServers.filter(
+          (server): server is acp.McpServerHttp & { type: "http" } =>
+            "type" in server && server.type === "http",
+        )
+      : [];
+    if (mcpServers.length > 0 && !supportsHttpMcp) {
+      log("Agent does not advertise HTTP MCP support; file attachments are unavailable");
+    }
+    log("Creating ACP session...");
+    const sessionResult = await abortable(
+      connection.newSession({
+        cwd,
+        mcpServers: sessionMcpServers,
+      }),
+      signal,
+    );
+    log(`ACP session created: ${sessionResult.sessionId}`);
+
+    return {
+      process: proc,
+      connection,
+      sessionId: sessionResult.sessionId,
+      configOptions: sessionResult.configOptions ?? [],
+    };
+  } catch (err) {
+    killAgent(proc);
     throw err;
+  } finally {
+    signal?.removeEventListener("abort", abortSpawn);
   }
-
-  const input = Writable.toWeb(proc.stdin);
-  const output = Readable.toWeb(proc.stdout) as ReadableStream<Uint8Array>;
-  const stream = acp.ndJsonStream(input, output);
-
-  const connection = new acp.ClientSideConnection(() => client, stream);
-
-  // Initialize
-  log("Initializing ACP connection...");
-  const initResult = await connection.initialize({
-    protocolVersion: acp.PROTOCOL_VERSION,
-    clientInfo: {
-      name: packageJson.name,
-      title: packageJson.name,
-      version: packageJson.version,
-    },
-    clientCapabilities: {
-      fs: {
-        readTextFile: true,
-        writeTextFile: true,
-      },
-    },
-  });
-  log(`ACP initialized (protocol v${initResult.protocolVersion})`);
-
-  // Create session
-  log("Creating ACP session...");
-  const sessionResult = await connection.newSession({
-    cwd,
-    mcpServers: [],
-  });
-  log(`ACP session created: ${sessionResult.sessionId}`);
-
-  return {
-    process: proc,
-    connection,
-    sessionId: sessionResult.sessionId,
-    configOptions: sessionResult.configOptions ?? [],
-  };
 }
 
 export function killAgent(proc: ChildProcess): void {
-  if (!proc.killed) {
+  if (proc.exitCode === null && proc.signalCode === null) {
     proc.kill("SIGTERM");
     // Force kill after 5s if still alive
     setTimeout(() => {
-      if (!proc.killed) proc.kill("SIGKILL");
+      if (proc.exitCode === null && proc.signalCode === null) {
+        proc.kill("SIGKILL");
+      }
     }, 5_000).unref();
   }
+}
+
+function abortable<T>(
+  operation: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  if (!signal) return operation;
+  if (signal.aborted) return Promise.reject(new Error("Agent spawn aborted"));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      reject(new Error("Agent spawn aborted"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    operation.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (err) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(err);
+      },
+    );
+  });
 }

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -558,7 +558,7 @@ export class WeChatAcpClient implements acp.Client {
             rawOutputResources > 0 ? ` [resources: ${rawOutputResources} rawOutput fallback]` : "";
           const linkNote =
             rawOutputResourceLinks > 0
-              ? ` [resource links: ${rawOutputResourceLinks} rawOutput fallback]`
+              ? ` [resource link entries: ${rawOutputResourceLinks} rawOutput fallback]`
               : "";
           opts.log(
             `[tool] ${update.toolCallId} → ${update.status}${imageNote}${resourceNote}${linkNote}`,

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -122,6 +122,11 @@ function sanitizeInlineLabel(value: string): string {
     : collapsed;
 }
 
+function decodedBase64ByteLength(data: string): number {
+  const padding = data.endsWith("==") ? 2 : data.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor((data.length * 3) / 4) - padding);
+}
+
 /**
  * Human-readable name for a resource: the last path segment of its URI,
  * percent-decoded and sanitized to a single line. Falls back to the full
@@ -854,12 +859,12 @@ export class WeChatAcpClient implements acp.Client {
       return;
     }
 
-    const approxBytes = Math.ceil(file.data.length / 4) * 3;
-    if (approxBytes > MAX_AGENT_FILE_BYTES) {
+    const decodedBytes = decodedBase64ByteLength(file.data);
+    if (decodedBytes > MAX_AGENT_FILE_BYTES) {
       turn.chunks.push(`\n⚠️ [file ${name} is too large to deliver]\n`);
       turn.producedMessage = true;
       opts.log(
-        `[file] skipped oversized file ${name} (~${approxBytes} bytes > ${MAX_AGENT_FILE_BYTES})`,
+        `[file] skipped oversized file ${name} (${decodedBytes} bytes > ${MAX_AGENT_FILE_BYTES})`,
       );
       return;
     }
@@ -867,7 +872,7 @@ export class WeChatAcpClient implements acp.Client {
     await this.maybeFlushMessage(turn);
     try {
       await opts.onFileFlush({ data: file.data, name, mimeType });
-      opts.log(`[file] sent ${name} (${mimeType}, ~${approxBytes} bytes)`);
+      opts.log(`[file] sent ${name} (${mimeType}, ${decodedBytes} bytes)`);
       turn.producedMessage = true;
     } catch (err) {
       turn.chunks.push(`\n⚠️ [file ${name} could not be delivered]\n`);

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -8,7 +8,14 @@
 
 import fs from "node:fs";
 import type * as acp from "@agentclientprotocol/sdk";
+import {
+  type AgentFile,
+  type AgentResourceLink,
+  MAX_AGENT_FILE_BYTES,
+} from "../artifacts/types.js";
 import { TEXT_CHUNK_LIMIT } from "../weixin/send.js";
+
+export type { AgentFile } from "../artifacts/types.js";
 
 /** An image content block produced by the agent, ready for outbound delivery. */
 export interface AgentImage {
@@ -252,6 +259,8 @@ export interface WeChatAcpClientOpts {
   onMessageFlush: (text: string) => Promise<void>;
   onImageFlush?: (image: AgentImage) => Promise<void>;
   onAudioFlush?: (audio: AgentAudio) => Promise<void>;
+  onFileFlush?: (file: AgentFile) => Promise<void>;
+  resolveResourceLink?: (link: AgentResourceLink) => Promise<AgentFile | null>;
   onConfigOptionsUpdate?: (configOptions: acp.SessionConfigOption[]) => void;
   log: (msg: string) => void;
   showThoughts: boolean;
@@ -275,10 +284,18 @@ interface TurnState {
   thoughtChunks: string[];
   producedMessage: boolean;
   lastTypingAt: number;
+  deliveredResourceLinks: Set<string>;
 }
 
 function freshTurn(opts: WeChatAcpClientOpts): TurnState {
-  return { opts, chunks: [], thoughtChunks: [], producedMessage: false, lastTypingAt: 0 };
+  return {
+    opts,
+    chunks: [],
+    thoughtChunks: [],
+    producedMessage: false,
+    lastTypingAt: 0,
+    deliveredResourceLinks: new Set(),
+  };
 }
 
 export class WeChatAcpClient implements acp.Client {
@@ -329,6 +346,7 @@ export class WeChatAcpClient implements acp.Client {
     onMessageFlush: (text: string) => Promise<void>;
     onImageFlush?: (image: AgentImage) => Promise<void>;
     onAudioFlush?: (audio: AgentAudio) => Promise<void>;
+    onFileFlush?: (file: AgentFile) => Promise<void>;
   }): Promise<void> {
     return this.enqueue(async () => {
       const previous = this.turn;
@@ -339,6 +357,7 @@ export class WeChatAcpClient implements acp.Client {
         onMessageFlush: callbacks.onMessageFlush,
         ...(callbacks.onImageFlush ? { onImageFlush: callbacks.onImageFlush } : {}),
         ...(callbacks.onAudioFlush ? { onAudioFlush: callbacks.onAudioFlush } : {}),
+        ...(callbacks.onFileFlush ? { onFileFlush: callbacks.onFileFlush } : {}),
       };
       const staleText = previous.chunks.join("");
       const staleThoughts = previous.thoughtChunks.join("");
@@ -416,6 +435,8 @@ export class WeChatAcpClient implements acp.Client {
           await this.maybeSendAudio(update.content, turn);
         } else if (update.content.type === "resource") {
           await this.maybeRenderResource(update.content.resource, turn);
+        } else if (update.content.type === "resource_link") {
+          await this.maybeSendResourceLink(update.content, turn);
         }
         // Throttle typing indicators
         await this.maybeSendTyping(turn);
@@ -424,6 +445,13 @@ export class WeChatAcpClient implements acp.Client {
       case "tool_call":
         await this.maybeFlushThoughts(turn);
         await this.maybeFlushMessage(turn);
+        if (update.status === "completed" && update.content) {
+          for (const content of update.content) {
+            if (content.type === "content" && content.content.type === "resource_link") {
+              await this.maybeSendResourceLink(content.content, turn);
+            }
+          }
+        }
         opts.log(`[tool] ${update.title} (${update.status})`);
         await this.maybeSendTyping(turn);
         break;
@@ -443,6 +471,7 @@ export class WeChatAcpClient implements acp.Client {
       case "tool_call_update": {
         let imageContentBlocks = 0;
         let resourceContentBlocks = 0;
+        let resourceLinkContentBlocks = 0;
         let resourceImages = 0;
         if (update.status === "completed" && update.content) {
           for (const c of update.content) {
@@ -471,6 +500,9 @@ export class WeChatAcpClient implements acp.Client {
               if (await this.maybeRenderResource(c.content.resource, turn)) {
                 resourceImages++;
               }
+            } else if (c.type === "content" && c.content.type === "resource_link") {
+              resourceLinkContentBlocks++;
+              await this.maybeSendResourceLink(c.content, turn);
             }
           }
         }
@@ -490,6 +522,13 @@ export class WeChatAcpClient implements acp.Client {
           const viaRawOutput = await this.maybeRenderRawOutputResources(update.rawOutput, turn);
           rawOutputResources = viaRawOutput.resources;
           rawOutputResourceImages = viaRawOutput.images;
+        }
+        let rawOutputResourceLinks = 0;
+        if (update.status === "completed" && resourceLinkContentBlocks === 0) {
+          rawOutputResourceLinks = await this.maybeSendRawOutputResourceLinks(
+            update.rawOutput,
+            turn,
+          );
         }
         // Copilot CLI compatibility: the CLI emits tool-result images only in
         // rawOutput.binaryResultsForLlm and never as ACP image content blocks
@@ -517,7 +556,13 @@ export class WeChatAcpClient implements acp.Client {
                 : "";
           const resourceNote =
             rawOutputResources > 0 ? ` [resources: ${rawOutputResources} rawOutput fallback]` : "";
-          opts.log(`[tool] ${update.toolCallId} → ${update.status}${imageNote}${resourceNote}`);
+          const linkNote =
+            rawOutputResourceLinks > 0
+              ? ` [resource links: ${rawOutputResourceLinks} rawOutput fallback]`
+              : "";
+          opts.log(
+            `[tool] ${update.toolCallId} → ${update.status}${imageNote}${resourceNote}${linkNote}`,
+          );
         }
         await this.maybeSendTyping(turn);
         break;
@@ -720,6 +765,118 @@ export class WeChatAcpClient implements acp.Client {
   }
 
   /**
+   * Copilot CLI keeps MCP resource links in rawOutput.contents rather than
+   * promoting them to ACP content blocks. Parse only the documented fields
+   * needed by the normal resource-link delivery path.
+   */
+  private async maybeSendRawOutputResourceLinks(
+    rawOutput: unknown,
+    turn: TurnState,
+  ): Promise<number> {
+    if (typeof rawOutput !== "object" || rawOutput === null) return 0;
+    const { contents } = rawOutput as { contents?: unknown };
+    if (!Array.isArray(contents)) return 0;
+
+    let links = 0;
+    for (const entry of contents) {
+      if (typeof entry !== "object" || entry === null) continue;
+      const { type, uri, name, mimeType, size } = entry as {
+        type?: unknown;
+        uri?: unknown;
+        name?: unknown;
+        mimeType?: unknown;
+        size?: unknown;
+      };
+      if (type !== "resource_link" || typeof uri !== "string" || !uri) continue;
+      links++;
+      await this.maybeSendResourceLink(
+        {
+          uri,
+          ...(typeof name === "string" ? { name } : {}),
+          ...(typeof mimeType === "string" ? { mimeType } : {}),
+          ...(typeof size === "number" ? { size } : {}),
+        },
+        turn,
+      );
+    }
+    return links;
+  }
+
+  private async maybeSendResourceLink(
+    link: AgentResourceLink,
+    turn: TurnState,
+  ): Promise<void> {
+    const opts = turn.opts;
+    const name = sanitizeInlineLabel(link.name ?? resourceDisplayName(link.uri));
+    if (opts.showResources === false) {
+      opts.log(`[resource-link] skipped (showResources=false, ${name})`);
+      return;
+    }
+    if (turn.deliveredResourceLinks.has(link.uri)) {
+      opts.log(`[resource-link] skipped duplicate: ${name}`);
+      return;
+    }
+    turn.deliveredResourceLinks.add(link.uri);
+
+    if (!opts.resolveResourceLink) {
+      turn.chunks.push(`\n📎 [resource link: ${name} - file resolver unavailable]\n`);
+      turn.producedMessage = true;
+      opts.log(`[resource-link] resolver unavailable: ${name}`);
+      return;
+    }
+
+    try {
+      const file = await opts.resolveResourceLink(link);
+      if (!file) {
+        turn.chunks.push(`\n📎 [resource link: ${name} - file unavailable]\n`);
+        turn.producedMessage = true;
+        opts.log(`[resource-link] unavailable: ${name}`);
+        return;
+      }
+      await this.maybeSendFile(file, turn);
+    } catch (err) {
+      turn.chunks.push(`\n⚠️ [file ${name} could not be resolved]\n`);
+      turn.producedMessage = true;
+      opts.log(`[resource-link] resolve failed for ${name}: ${String(err)}`);
+    }
+  }
+
+  private async maybeSendFile(file: AgentFile, turn: TurnState): Promise<void> {
+    const opts = turn.opts;
+    const name = sanitizeInlineLabel(file.name) || "artifact";
+    const mimeType =
+      sanitizeInlineLabel(file.mimeType).split(";")[0].trim().toLowerCase() ||
+      "application/octet-stream";
+    if (!opts.onFileFlush) {
+      turn.chunks.push(`\n📎 [file: ${name} (${mimeType}) - delivery unavailable]\n`);
+      turn.producedMessage = true;
+      opts.log(`[file] skipped (no file sink configured, ${name})`);
+      return;
+    }
+
+    const approxBytes = Math.ceil(file.data.length / 4) * 3;
+    if (approxBytes > MAX_AGENT_FILE_BYTES) {
+      turn.chunks.push(`\n⚠️ [file ${name} is too large to deliver]\n`);
+      turn.producedMessage = true;
+      opts.log(
+        `[file] skipped oversized file ${name} (~${approxBytes} bytes > ${MAX_AGENT_FILE_BYTES})`,
+      );
+      return;
+    }
+
+    await this.maybeFlushMessage(turn);
+    try {
+      await opts.onFileFlush({ data: file.data, name, mimeType });
+      opts.log(`[file] sent ${name} (${mimeType}, ~${approxBytes} bytes)`);
+      turn.producedMessage = true;
+    } catch (err) {
+      turn.chunks.push(`\n⚠️ [file ${name} could not be delivered]\n`);
+      turn.producedMessage = true;
+      opts.log(`[file] delivery failed for ${name}: ${String(err)}`);
+    }
+  }
+
+  /**
    * Deliver an agent-produced image content block as a native WeChat image
    * message, preserving stream order: buffered text preceding the image is
    * flushed first, then the image is sent. Runs entirely within one task on
@@ -841,8 +998,8 @@ export class WeChatAcpClient implements acp.Client {
    * with a naming header, so they flush in order with the surrounding
    * narrative through the existing buffer machinery. Blob resources with
    * an image MIME type reuse the image delivery pipeline (allow-list,
-   * size cap, ordering, placeholders); other blobs surface as a one-line
-   * placeholder instead of being dropped silently. Returns true when the
+   * size cap, ordering, placeholders); other blobs are delivered through the
+   * generic file pipeline. Returns true when the
    * resource belongs to the image pipeline (an allow-listed image blob with
    * images enabled and a sink configured), whether or not it was rendered:
    * a resource skipped by showResources=false still returns true so the
@@ -908,13 +1065,26 @@ export class WeChatAcpClient implements acp.Client {
       return true;
     }
 
-    // ceil(base64Len / 4) * 3 over-estimates by at most 2 bytes.
-    const approxBytes = Math.ceil(resource.blob.length / 4) * 3;
-    turn.chunks.push(
-      `\n📎 [resource: ${name} (${mime || "unknown type"}, ~${approxBytes} bytes) - binary content not rendered]\n`,
+    if (!opts.onFileFlush) {
+      const approxBytes = Math.ceil(resource.blob.length / 4) * 3;
+      turn.chunks.push(
+        `\n📎 [resource: ${name} (${mime || "unknown type"}, ~${approxBytes} bytes) - binary content not rendered]\n`,
+      );
+      turn.producedMessage = true;
+      opts.log(
+        `[resource] blob resource ${name} not rendered (${mime || "unknown type"}, ~${approxBytes} bytes)`,
+      );
+      return false;
+    }
+
+    await this.maybeSendFile(
+      {
+        data: resource.blob,
+        name,
+        mimeType: baseMime || "application/octet-stream",
+      },
+      turn,
     );
-    turn.producedMessage = true;
-    opts.log(`[resource] blob resource ${name} not rendered (${mime || "unknown type"}, ~${approxBytes} bytes)`);
     return false;
   }
 

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -124,7 +124,17 @@ export class SessionManager {
       if (session.mcpLease) closingLeases.push(session.mcpLease.close());
     }
     this.sessions.clear();
-    await Promise.all(closingLeases);
+    const results = await Promise.allSettled(closingLeases);
+    const failures = results.filter(
+      (result): result is PromiseRejectedResult =>
+        result.status === "rejected",
+    );
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures.map((failure) => failure.reason),
+        "Failed to close session MCP leases",
+      );
+    }
   }
 
   async enqueue(userId: string, message: PendingMessage): Promise<void> {

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -7,7 +7,13 @@
 
 import type { ChildProcess } from "node:child_process";
 import type * as acp from "@agentclientprotocol/sdk";
-import { WeChatAcpClient, type AgentImage, type AgentAudio } from "./client.js";
+import {
+  WeChatAcpClient,
+  type AgentImage,
+  type AgentAudio,
+  type AgentFile,
+} from "./client.js";
+import type { AgentResourceLink } from "../artifacts/types.js";
 import { spawnAgent, killAgent, type AgentProcessInfo } from "./agent-manager.js";
 import { trackEvent, trackException, hashUserId } from "../telemetry/index.js";
 
@@ -46,11 +52,17 @@ export interface UserSession {
   contextToken: string;
   client: WeChatAcpClient;
   agentInfo: AgentProcessInfo;
+  mcpLease?: SessionMcpLease;
   configOptions: acp.SessionConfigOption[];
   queue: PendingMessage[];
   processing: boolean;
   lastActivity: number;
   createdAt: number;
+}
+
+export interface SessionMcpLease {
+  mcpServer: acp.McpServer;
+  close(): Promise<void>;
 }
 
 export interface SessionManagerOpts {
@@ -66,15 +78,21 @@ export interface SessionManagerOpts {
   showImages?: boolean;
   showAudio?: boolean;
   showResources?: boolean;
+  createMcpLease?: () => SessionMcpLease;
   log: (msg: string) => void;
   onReply: (userId: string, contextToken: string, text: string) => Promise<void>;
   onReplyImage?: (userId: string, contextToken: string, image: AgentImage) => Promise<void>;
   onReplyAudio?: (userId: string, contextToken: string, audio: AgentAudio) => Promise<void>;
+  onReplyFile?: (userId: string, contextToken: string, file: AgentFile) => Promise<void>;
+  resolveResourceLink?: (link: AgentResourceLink) => Promise<AgentFile | null>;
   sendTyping: (userId: string, contextToken: string) => Promise<void>;
 }
 
 export class SessionManager {
   private sessions = new Map<string, UserSession>();
+  private pendingSessions = new Map<string, Promise<UserSession>>();
+  private creationChain: Promise<void> = Promise.resolve();
+  private creationAbortController = new AbortController();
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
   private opts: SessionManagerOpts;
   private aborted = false;
@@ -91,17 +109,22 @@ export class SessionManager {
 
   async stop(): Promise<void> {
     this.aborted = true;
+    this.creationAbortController.abort();
     if (this.cleanupTimer) {
       clearInterval(this.cleanupTimer);
       this.cleanupTimer = null;
     }
+    await Promise.allSettled([...this.pendingSessions.values()]);
     // Kill all agent processes
+    const closingLeases: Promise<void>[] = [];
     for (const [userId, session] of this.sessions) {
       this.opts.log(`Stopping session for ${userId}`);
       this.rejectQueuedCompletions(session, new Error("Session stopped before queued message was processed"));
       killAgent(session.agentInfo.process);
+      if (session.mcpLease) closingLeases.push(session.mcpLease.close());
     }
     this.sessions.clear();
+    await Promise.all(closingLeases);
   }
 
   async enqueue(userId: string, message: PendingMessage): Promise<void> {
@@ -109,17 +132,9 @@ export class SessionManager {
       throw new Error("Session manager is stopped");
     }
 
-    let session = this.sessions.get(userId);
-
-    if (!session) {
-      if (this.sessions.size >= this.opts.maxConcurrentUsers) {
-        // Evict oldest idle session
-        this.evictOldest();
-      }
-
-      session = await this.createSession(userId, message.contextToken);
-      this.sessions.set(userId, session);
-    }
+    const session =
+      this.sessions.get(userId) ??
+      (await this.getOrCreateSession(userId, message.contextToken));
 
     // Always update contextToken to the latest
     session.contextToken = message.contextToken;
@@ -223,6 +238,69 @@ export class SessionManager {
     return this.sessions.size;
   }
 
+  private getOrCreateSession(
+    userId: string,
+    contextToken: string,
+  ): Promise<UserSession> {
+    const existing = this.sessions.get(userId);
+    if (existing) return Promise.resolve(existing);
+    const pending = this.pendingSessions.get(userId);
+    if (pending) return pending;
+
+    const creation = this.withCreationLock(async () => {
+      if (this.aborted) {
+        throw new Error("Session manager is stopped");
+      }
+      const existingAfterWait = this.sessions.get(userId);
+      if (existingAfterWait) return existingAfterWait;
+      if (this.sessions.size >= this.opts.maxConcurrentUsers) {
+        this.evictOldest();
+      }
+      if (this.sessions.size >= this.opts.maxConcurrentUsers) {
+        throw new Error(
+          `Maximum concurrent sessions reached (${this.opts.maxConcurrentUsers})`,
+        );
+      }
+
+      const created = await this.createSession(userId, contextToken);
+      if (this.aborted) {
+        killAgent(created.agentInfo.process);
+        await created.mcpLease?.close();
+        throw new Error("Session manager stopped while creating a session");
+      }
+
+      const winner = this.sessions.get(userId);
+      if (winner) {
+        killAgent(created.agentInfo.process);
+        await created.mcpLease?.close();
+        return winner;
+      }
+      this.sessions.set(userId, created);
+      return created;
+    });
+    this.pendingSessions.set(userId, creation);
+    void creation.finally(() => {
+      if (this.pendingSessions.get(userId) === creation) {
+        this.pendingSessions.delete(userId);
+      }
+    }).catch(() => {});
+    return creation;
+  }
+
+  private withCreationLock<T>(task: () => Promise<T>): Promise<T> {
+    const run = this.creationChain.then(task);
+    this.creationChain = run.then(
+      () =>
+        new Promise<void>((resolve) => {
+          // Let the creator enqueue its first message and mark the session
+          // processing before another user can treat it as idle and evict it.
+          setImmediate(resolve);
+        }),
+      () => undefined,
+    );
+    return run;
+  }
+
   private async createSession(userId: string, contextToken: string): Promise<UserSession> {
     this.opts.log(`Creating new session for ${userId}`);
 
@@ -236,6 +314,10 @@ export class SessionManager {
       ...(this.opts.onReplyAudio
         ? { onAudioFlush: (audio: AgentAudio) => this.opts.onReplyAudio!(userId, contextToken, audio) }
         : {}),
+      ...(this.opts.onReplyFile
+        ? { onFileFlush: (file: AgentFile) => this.opts.onReplyFile!(userId, contextToken, file) }
+        : {}),
+      resolveResourceLink: this.opts.resolveResourceLink,
       onConfigOptionsUpdate: (configOptions) => {
         const session = this.sessions.get(userId);
         if (!session || session.client !== client) return;
@@ -250,14 +332,23 @@ export class SessionManager {
       showResources: this.opts.showResources ?? true,
     });
 
-    const agentInfo = await spawnAgent({
-      command: this.opts.agentCommand,
-      args: this.opts.agentArgs,
-      cwd: this.opts.agentCwd,
-      env: this.opts.agentEnv,
-      client,
-      log: (msg) => this.opts.log(`[${userId}] ${msg}`),
-    });
+    const mcpLease = this.opts.createMcpLease?.();
+    let agentInfo: AgentProcessInfo;
+    try {
+      agentInfo = await spawnAgent({
+        command: this.opts.agentCommand,
+        args: this.opts.agentArgs,
+        cwd: this.opts.agentCwd,
+        env: this.opts.agentEnv,
+        client,
+        mcpServers: mcpLease ? [mcpLease.mcpServer] : [],
+        signal: this.creationAbortController.signal,
+        log: (msg) => this.opts.log(`[${userId}] ${msg}`),
+      });
+    } catch (err) {
+      await mcpLease?.close();
+      throw err;
+    }
 
     trackEvent(
       "session.created",
@@ -276,6 +367,9 @@ export class SessionManager {
         this.opts.log(`Agent process for ${userId} exited, removing session`);
         this.rejectQueuedCompletions(s, new Error("Agent process exited before queued message was processed"));
         this.sessions.delete(userId);
+        void s.mcpLease?.close().catch((err) => {
+          this.opts.log(`[${userId}] Failed to close artifact MCP lease: ${String(err)}`);
+        });
       }
     });
 
@@ -284,6 +378,7 @@ export class SessionManager {
       contextToken,
       client,
       agentInfo,
+      mcpLease,
       configOptions: agentInfo.configOptions,
       queue: [],
       processing: false,
@@ -318,6 +413,12 @@ export class SessionManager {
             ? {
                 onAudioFlush: (audio: AgentAudio) =>
                   this.opts.onReplyAudio!(session.userId, pending.contextToken, audio),
+              }
+            : {}),
+          ...(this.opts.onReplyFile
+            ? {
+                onFileFlush: (file: AgentFile) =>
+                  this.opts.onReplyFile!(session.userId, pending.contextToken, file),
               }
             : {}),
         });
@@ -397,6 +498,7 @@ export class SessionManager {
             this.opts.log(`[${session.userId}] Agent process died, removing session`);
             this.rejectQueuedCompletions(session, err);
             this.sessions.delete(session.userId);
+            await session.mcpLease?.close();
             return;
           }
 
@@ -436,6 +538,9 @@ export class SessionManager {
         this.opts.log(`Session for ${userId} idle for ${Math.round((now - session.lastActivity) / 60_000)}min, removing`);
         killAgent(session.agentInfo.process);
         this.sessions.delete(userId);
+        void session.mcpLease?.close().catch((err) => {
+          this.opts.log(`[${userId}] Failed to close artifact MCP lease: ${String(err)}`);
+        });
       }
     }
   }
@@ -454,6 +559,9 @@ export class SessionManager {
         this.rejectQueuedCompletions(session, new Error("Session evicted before queued message was processed"));
         killAgent(session.agentInfo.process);
         this.sessions.delete(oldest.userId);
+        void session.mcpLease?.close().catch((err) => {
+          this.opts.log(`[${oldest.userId}] Failed to close artifact MCP lease: ${String(err)}`);
+        });
       }
     }
   }

--- a/src/artifacts/server.ts
+++ b/src/artifacts/server.ts
@@ -1,0 +1,288 @@
+import type { Server as HttpServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { randomBytes, randomUUID } from "node:crypto";
+
+import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { NextFunction, Request, Response } from "express";
+import { z } from "zod";
+
+import { ArtifactStore } from "./store.js";
+import type { AgentFile, AgentResourceLink } from "./types.js";
+
+const MCP_PATH = "/mcp";
+
+export interface ArtifactMcpLease {
+  mcpServer: {
+    name: string;
+    url: string;
+    headers: Array<{ name: string; value: string }>;
+    type: "http";
+  };
+  close(): Promise<void>;
+}
+
+export interface ArtifactMcpServer {
+  createLease(): ArtifactMcpLease;
+  resolveResourceLink(link: AgentResourceLink): Promise<AgentFile | null>;
+  close(): Promise<void>;
+}
+
+export async function startArtifactMcpServer(options: {
+  rootDir: string;
+  log: (message: string) => void;
+}): Promise<ArtifactMcpServer> {
+  const store = await ArtifactStore.create({ rootDir: options.rootDir });
+  const sessions = new Map<
+    string,
+    {
+      mcp: McpServer;
+      transport: StreamableHTTPServerTransport;
+      leaseToken: string;
+    }
+  >();
+  const leases = new Map<string, Set<string>>();
+
+  const app = createMcpExpressApp({ host: "127.0.0.1" });
+  app.use(
+    MCP_PATH,
+    (req: Request, res: Response, next: NextFunction) => {
+      if (req.headers.origin) {
+        res.status(403).json({ error: "Origin requests are not allowed" });
+        return;
+      }
+      const token = bearerToken(req.headers.authorization);
+      if (!token || !leases.has(token)) {
+        res.status(401).json({ error: "Unauthorized" });
+        return;
+      }
+      res.locals.artifactLeaseToken = token;
+      next();
+    },
+  );
+
+  app.all(MCP_PATH, async (req: Request, res: Response) => {
+    const leaseToken = res.locals.artifactLeaseToken as string;
+    const leaseSessions = leases.get(leaseToken);
+    if (!leaseSessions) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+    const sessionIdHeader = req.headers["mcp-session-id"];
+    const sessionId =
+      typeof sessionIdHeader === "string" ? sessionIdHeader : undefined;
+    let session = sessionId ? sessions.get(sessionId) : undefined;
+    let isNewSession = false;
+    if (session && session.leaseToken !== leaseToken) {
+      session = undefined;
+    }
+
+    if (!session) {
+      if (
+        req.method !== "POST" ||
+        typeof req.body !== "object" ||
+        req.body === null ||
+        req.body.method !== "initialize"
+      ) {
+        res.status(sessionId ? 404 : 400).json({
+          error: sessionId ? "Unknown MCP session" : "Missing MCP initialization",
+        });
+        return;
+      }
+      const created = await createMcpSession(store, options.log);
+      session = { ...created, leaseToken };
+      isNewSession = true;
+    }
+
+    try {
+      await session.transport.handleRequest(req, res, req.body);
+      if (isNewSession) {
+        const newSessionId = session.transport.sessionId;
+        if (!newSessionId) {
+          throw new Error("MCP transport did not create a session ID");
+        }
+        sessions.set(newSessionId, session);
+        leaseSessions.add(newSessionId);
+      } else if (req.method === "DELETE" && sessionId) {
+        sessions.delete(sessionId);
+        leaseSessions.delete(sessionId);
+        await session.mcp.close();
+      }
+    } catch (err) {
+      options.log(`[artifact-mcp] request failed: ${String(err)}`);
+      if (isNewSession) await session.mcp.close();
+      if (!res.headersSent) {
+        res.status(500).json({ error: "MCP request failed" });
+      }
+    }
+  });
+
+  const httpServer = await listen(app);
+  const address = httpServer.address() as AddressInfo;
+  const url = `http://127.0.0.1:${address.port}${MCP_PATH}`;
+  options.log(`[artifact-mcp] listening at ${url}`);
+
+  return {
+    createLease: () => {
+      const token = randomBytes(32).toString("base64url");
+      leases.set(token, new Set());
+      let closed = false;
+      return {
+        mcpServer: {
+          name: "wechat-acp-artifacts",
+          url,
+          headers: [{ name: "Authorization", value: `Bearer ${token}` }],
+          type: "http",
+        },
+        close: async () => {
+          if (closed) return;
+          closed = true;
+          await closeLease(token, leases, sessions);
+        },
+      };
+    },
+    resolveResourceLink: (link) => store.resolveResourceLink(link),
+    close: async () => {
+      const results = await Promise.allSettled(
+        [...sessions.values()].map(({ mcp }) => mcp.close()),
+      );
+      sessions.clear();
+      leases.clear();
+      let httpError: unknown;
+      try {
+        await closeHttpServer(httpServer);
+      } catch (err) {
+        httpError = err;
+      } finally {
+        store.close();
+      }
+      const failures = results.filter(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      if (failures.length > 0 || httpError !== undefined) {
+        throw new AggregateError(
+          [
+            ...failures.map((failure) => failure.reason),
+            ...(httpError !== undefined ? [httpError] : []),
+          ],
+          "Failed to close artifact MCP server",
+        );
+      }
+    },
+  };
+}
+
+async function closeLease(
+  token: string,
+  leases: Map<string, Set<string>>,
+  sessions: Map<
+    string,
+    {
+      mcp: McpServer;
+      transport: StreamableHTTPServerTransport;
+      leaseToken: string;
+    }
+  >,
+): Promise<void> {
+  const sessionIds = leases.get(token);
+  if (!sessionIds) return;
+  leases.delete(token);
+  const closing: Promise<void>[] = [];
+  for (const sessionId of sessionIds) {
+    const session = sessions.get(sessionId);
+    if (!session || session.leaseToken !== token) continue;
+    sessions.delete(sessionId);
+    closing.push(session.mcp.close());
+  }
+  await Promise.all(closing);
+}
+
+function bearerToken(authorization: string | undefined): string | null {
+  if (!authorization?.startsWith("Bearer ")) return null;
+  const token = authorization.slice("Bearer ".length);
+  return token || null;
+}
+
+async function createMcpSession(
+  store: ArtifactStore,
+  log: (message: string) => void,
+): Promise<{ mcp: McpServer; transport: StreamableHTTPServerTransport }> {
+  const mcp = new McpServer({
+    name: "wechat-acp-artifacts",
+    version: "1.0.0",
+  });
+  mcp.registerTool(
+    "attach_file",
+    {
+      title: "Attach a file",
+      description:
+        "Attach an existing file from the current workspace to the user. " +
+        "Call this after creating a file that the user should receive.",
+      inputSchema: {
+        path: z.string().min(1).describe("Workspace-relative or absolute path"),
+        name: z.string().min(1).max(255).optional(),
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async ({ path, name }) => {
+      try {
+        const artifact = await store.publish(path, name);
+        return {
+          content: [
+            {
+              type: "resource_link" as const,
+              uri: artifact.uri,
+              name: artifact.name,
+              mimeType: artifact.mimeType,
+              size: artifact.size,
+              description: "File attachment for the current user",
+            },
+          ],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log(`[artifact-mcp] attach_file rejected: ${message}`);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Unable to attach file: ${message}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: randomUUID,
+  });
+  transport.onerror = (err) => {
+    log(`[artifact-mcp] transport error: ${err.message}`);
+  };
+  await mcp.connect(transport);
+  return { mcp, transport };
+}
+
+function listen(
+  app: ReturnType<typeof createMcpExpressApp>,
+): Promise<HttpServer> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, "127.0.0.1", () => resolve(server));
+    server.once("error", reject);
+  });
+}
+
+function closeHttpServer(server: HttpServer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}

--- a/src/artifacts/server.ts
+++ b/src/artifacts/server.ts
@@ -196,7 +196,17 @@ async function closeLease(
     sessions.delete(sessionId);
     closing.push(session.mcp.close());
   }
-  await Promise.all(closing);
+  const results = await Promise.allSettled(closing);
+  const failures = results.filter(
+    (result): result is PromiseRejectedResult =>
+      result.status === "rejected",
+  );
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures.map((failure) => failure.reason),
+      "Failed to close artifact MCP lease",
+    );
+  }
 }
 
 function bearerToken(authorization: string | undefined): string | null {

--- a/src/artifacts/store.ts
+++ b/src/artifacts/store.ts
@@ -1,0 +1,254 @@
+import { randomUUID } from "node:crypto";
+import { constants, promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  AgentFile,
+  AgentResourceLink,
+  MAX_AGENT_FILE_BYTES,
+} from "./types.js";
+
+const DEFAULT_TOTAL_BYTES = 100 * 1024 * 1024;
+const DEFAULT_TTL_MS = 10 * 60 * 1000;
+
+interface StoredArtifact {
+  data: Buffer;
+  name: string;
+  mimeType: string;
+  byteLength: number;
+  expiresAt: number;
+}
+
+export interface ArtifactStoreOptions {
+  rootDir: string;
+  maxFileBytes?: number;
+  maxTotalBytes?: number;
+  ttlMs?: number;
+}
+
+export interface PublishedArtifact {
+  uri: string;
+  name: string;
+  mimeType: string;
+  size: number;
+}
+
+export class ArtifactStore {
+  private readonly artifacts = new Map<string, StoredArtifact>();
+  private readonly rootDir: string;
+  private readonly maxFileBytes: number;
+  private readonly maxTotalBytes: number;
+  private readonly ttlMs: number;
+  private readonly cleanupTimer: NodeJS.Timeout;
+  private fileReadChain: Promise<void> = Promise.resolve();
+  private totalBytes = 0;
+
+  private constructor(rootDir: string, options: ArtifactStoreOptions) {
+    this.rootDir = rootDir;
+    this.maxFileBytes = options.maxFileBytes ?? MAX_AGENT_FILE_BYTES;
+    this.maxTotalBytes = options.maxTotalBytes ?? DEFAULT_TOTAL_BYTES;
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.cleanupTimer = setInterval(() => this.purgeExpired(), 60_000);
+    this.cleanupTimer.unref();
+  }
+
+  static async create(options: ArtifactStoreOptions): Promise<ArtifactStore> {
+    const rootDir = await fs.realpath(options.rootDir);
+    const stat = await fs.stat(rootDir);
+    if (!stat.isDirectory()) {
+      throw new Error("Artifact root is not a directory");
+    }
+    return new ArtifactStore(rootDir, options);
+  }
+
+  async publish(
+    filePath: string,
+    requestedName?: string,
+  ): Promise<PublishedArtifact> {
+    return this.withFileReadLock(async () => {
+      this.purgeExpired();
+      const file = await this.readAllowedFile(filePath, (size) => {
+        if (this.totalBytes + size > this.maxTotalBytes) {
+          throw new Error(
+            `Artifact store capacity exceeded (${this.maxTotalBytes} bytes)`,
+          );
+        }
+      });
+
+      const id = randomUUID();
+      const name = sanitizeFileName(
+        requestedName ?? path.basename(file.realPath),
+      );
+      const mimeType = inferMimeType(name);
+      this.artifacts.set(id, {
+        data: file.data,
+        name,
+        mimeType,
+        byteLength: file.byteLength,
+        expiresAt: Date.now() + this.ttlMs,
+      });
+      this.totalBytes += file.byteLength;
+
+      return {
+        uri: `wechat-acp://artifact/${id}`,
+        name,
+        mimeType,
+        size: file.byteLength,
+      };
+    });
+  }
+
+  async resolveResourceLink(
+    link: AgentResourceLink,
+  ): Promise<AgentFile | null> {
+    if (link.uri.startsWith("wechat-acp://artifact/")) {
+      return this.consume(link.uri.slice("wechat-acp://artifact/".length));
+    }
+
+    let filePath: string;
+    try {
+      filePath = link.uri.startsWith("file:")
+        ? fileURLToPath(link.uri)
+        : link.uri;
+    } catch {
+      return null;
+    }
+    if (!path.isAbsolute(filePath)) return null;
+
+    return this.withFileReadLock(async () => {
+      const file = await this.readAllowedFile(filePath);
+      const name = sanitizeFileName(link.name ?? path.basename(file.realPath));
+      return {
+        data: file.data.toString("base64"),
+        name,
+        mimeType: link.mimeType ?? inferMimeType(name),
+      };
+    });
+  }
+
+  close(): void {
+    clearInterval(this.cleanupTimer);
+    this.artifacts.clear();
+    this.totalBytes = 0;
+  }
+
+  private consume(id: string): AgentFile | null {
+    this.purgeExpired();
+    const artifact = this.artifacts.get(id);
+    if (!artifact) return null;
+    this.artifacts.delete(id);
+    this.totalBytes -= artifact.byteLength;
+    return {
+      data: artifact.data.toString("base64"),
+      name: artifact.name,
+      mimeType: artifact.mimeType,
+    };
+  }
+
+  private async readAllowedFile(
+    filePath: string,
+    beforeRead?: (size: number) => void,
+  ): Promise<{
+    data: Buffer;
+    byteLength: number;
+    realPath: string;
+  }> {
+    const candidate = path.resolve(this.rootDir, filePath);
+    const realPath = await fs.realpath(candidate);
+    const relative = path.relative(this.rootDir, realPath);
+    if (
+      relative === ".." ||
+      relative.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relative)
+    ) {
+      throw new Error("File is outside the allowed workspace");
+    }
+
+    const noFollow = constants.O_NOFOLLOW ?? 0;
+    const handle = await fs.open(realPath, constants.O_RDONLY | noFollow);
+    try {
+      const stat = await handle.stat();
+      if (!stat.isFile()) throw new Error("Path is not a regular file");
+      if (stat.size > this.maxFileBytes) {
+        throw new Error(`File exceeds the ${this.maxFileBytes} byte limit`);
+      }
+      beforeRead?.(stat.size);
+
+      const allocated = Buffer.alloc(stat.size);
+      let offset = 0;
+      while (offset < allocated.byteLength) {
+        const { bytesRead } = await handle.read(
+          allocated,
+          offset,
+          allocated.byteLength - offset,
+          offset,
+        );
+        if (bytesRead === 0) break;
+        offset += bytesRead;
+      }
+      const data =
+        offset === allocated.byteLength
+          ? allocated
+          : Buffer.from(allocated.subarray(0, offset));
+      return { data, byteLength: data.byteLength, realPath };
+    } finally {
+      await handle.close();
+    }
+  }
+
+  private withFileReadLock<T>(task: () => Promise<T>): Promise<T> {
+    const run = this.fileReadChain.then(task);
+    this.fileReadChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private purgeExpired(): void {
+    const now = Date.now();
+    for (const [id, artifact] of this.artifacts) {
+      if (artifact.expiresAt > now) continue;
+      this.artifacts.delete(id);
+      this.totalBytes -= artifact.byteLength;
+    }
+  }
+}
+
+export function sanitizeFileName(name: string): string {
+  const sanitized = path
+    .basename(name)
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .trim()
+    .slice(0, 255);
+  return sanitized || "artifact";
+}
+
+export function inferMimeType(name: string): string {
+  const extension = path.extname(name).toLowerCase();
+  const mimeTypes: Record<string, string> = {
+    ".aac": "audio/aac",
+    ".csv": "text/csv",
+    ".gif": "image/gif",
+    ".htm": "text/html",
+    ".html": "text/html",
+    ".jpeg": "image/jpeg",
+    ".jpg": "image/jpeg",
+    ".json": "application/json",
+    ".md": "text/markdown",
+    ".m4a": "audio/mp4",
+    ".mp3": "audio/mpeg",
+    ".mp4": "video/mp4",
+    ".pdf": "application/pdf",
+    ".png": "image/png",
+    ".svg": "image/svg+xml",
+    ".tar": "application/x-tar",
+    ".txt": "text/plain",
+    ".wav": "audio/wav",
+    ".webp": "image/webp",
+    ".xml": "application/xml",
+    ".zip": "application/zip",
+  };
+  return mimeTypes[extension] ?? "application/octet-stream";
+}

--- a/src/artifacts/store.ts
+++ b/src/artifacts/store.ts
@@ -219,7 +219,12 @@ export class ArtifactStore {
 export function sanitizeFileName(name: string): string {
   const sanitized = path
     .basename(name)
-    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    // Strip controls that can create new lines or alter bidirectional rendering.
+    .replace(
+      /[\u0000-\u001f\u007f-\u009f\u061c\u200e\u200f\u2028\u2029\u202a-\u202e\u2066-\u2069]+/g,
+      " ",
+    )
+    .replace(/\s+/g, " ")
     .trim()
     .slice(0, 255);
   return sanitized || "artifact";

--- a/src/artifacts/types.ts
+++ b/src/artifacts/types.ts
@@ -1,0 +1,14 @@
+export const MAX_AGENT_FILE_BYTES = 25 * 1024 * 1024;
+
+export interface AgentFile {
+  data: string;
+  name: string;
+  mimeType: string;
+}
+
+export interface AgentResourceLink {
+  uri: string;
+  name?: string | null;
+  mimeType?: string | null;
+  size?: number | null;
+}

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -16,7 +16,12 @@ import { TypingStatus, MessageType } from "./weixin/types.js";
 import type { WeixinMessage } from "./weixin/types.js";
 import { SessionManager } from "./acp/session.js";
 import { AUDIO_MIME_EXTENSIONS } from "./acp/client.js";
-import type { AgentImage, AgentAudio } from "./acp/client.js";
+import type { AgentImage, AgentAudio, AgentFile } from "./acp/client.js";
+import {
+  startArtifactMcpServer,
+  type ArtifactMcpServer,
+} from "./artifacts/server.js";
+import { sanitizeFileName } from "./artifacts/store.js";
 import { weixinMessageToPrompt } from "./adapter/inbound.js";
 import type { WeChatAcpConfig } from "./config.js";
 import { BRIDGE_COMMANDS, resolveCommandAliases, resolveCommandNames } from "./config.js";
@@ -48,6 +53,7 @@ export class WeChatAcpBridge {
   private config: WeChatAcpConfig;
   private abortController = new AbortController();
   private sessionManager: SessionManager | null = null;
+  private artifactMcpServer: ArtifactMcpServer | null = null;
   private injectionMonitor: InjectionMonitor | null = null;
   private tokenData: TokenData | null = null;
   private stateUpdate = Promise.resolve();
@@ -123,60 +129,109 @@ export class WeChatAcpBridge {
       this.log(`Use --login to force re-login`);
     }
 
-    // 2. Create SessionManager
-    this.sessionManager = new SessionManager({
-      agentCommand: this.config.agent.command,
-      agentArgs: this.config.agent.args,
-      agentCwd: this.config.agent.cwd,
-      agentEnv: this.config.agent.env,
-      agentPreset: this.config.agent.preset ?? "raw",
-      idleTimeoutMs: this.config.session.idleTimeoutMs,
-      maxConcurrentUsers: this.config.session.maxConcurrentUsers,
-      showThoughts: this.config.agent.showThoughts,
-      showDiffs: this.config.agent.showDiffs ?? false,
-      showImages: this.config.agent.showImages ?? true,
-      showAudio: this.config.agent.showAudio ?? true,
-      showResources: this.config.agent.showResources ?? true,
-      log: this.log,
-      onReply: (userId, contextToken, text) => this.sendReply(userId, contextToken, text),
-      onReplyImage: (userId, contextToken, image) => this.sendImageReply(userId, contextToken, image),
-      onReplyAudio: (userId, contextToken, audio) => this.sendAudioReply(userId, contextToken, audio),
-      sendTyping: (userId, contextToken) => this.sendTypingIndicator(userId, contextToken),
-    });
-    this.sessionManager.start();
-
-    if (this.config.storage.injectDir && this.config.storage.stateFile) {
-      this.injectionMonitor = new InjectionMonitor({
-        injectDir: this.config.storage.injectDir,
+    try {
+      // 2. Start the local artifact MCP server and create SessionManager
+      if (this.config.agent.showResources ?? true) {
+        try {
+          this.artifactMcpServer = await startArtifactMcpServer({
+            rootDir: this.config.agent.cwd,
+            log: this.log,
+          });
+        } catch (err) {
+          this.log(`Artifact MCP unavailable; agent file attachments disabled: ${String(err)}`);
+          trackException(err, "artifact_mcp");
+        }
+      }
+      this.sessionManager = new SessionManager({
+        agentCommand: this.config.agent.command,
+        agentArgs: this.config.agent.args,
+        agentCwd: this.config.agent.cwd,
+        agentEnv: this.config.agent.env,
+        agentPreset: this.config.agent.preset ?? "raw",
+        idleTimeoutMs: this.config.session.idleTimeoutMs,
+        maxConcurrentUsers: this.config.session.maxConcurrentUsers,
+        showThoughts: this.config.agent.showThoughts,
+        showDiffs: this.config.agent.showDiffs ?? false,
+        showImages: this.config.agent.showImages ?? true,
+        showAudio: this.config.agent.showAudio ?? true,
+        showResources: this.config.agent.showResources ?? true,
+        createMcpLease: this.artifactMcpServer
+          ? () => this.artifactMcpServer!.createLease()
+          : undefined,
         log: this.log,
-        onMessage: (job) => this.enqueueInjectedMessage(job),
+        onReply: (userId, contextToken, text) => this.sendReply(userId, contextToken, text),
+        onReplyImage: (userId, contextToken, image) => this.sendImageReply(userId, contextToken, image),
+        onReplyAudio: (userId, contextToken, audio) => this.sendAudioReply(userId, contextToken, audio),
+        onReplyFile: (userId, contextToken, file) => this.sendFileReply(userId, contextToken, file),
+        resolveResourceLink: this.artifactMcpServer
+          ? (link) => this.artifactMcpServer!.resolveResourceLink(link)
+          : undefined,
+        sendTyping: (userId, contextToken) => this.sendTypingIndicator(userId, contextToken),
       });
-      await this.injectionMonitor.start();
-      this.log(`Injection queue: ${this.config.storage.injectDir}`);
-    }
+      this.sessionManager.start();
 
-    // 3. Start monitor loop
-    this.log("Starting message polling...");
-    await startMonitor({
-      baseUrl: this.tokenData.baseUrl,
-      token: this.tokenData.token,
-      storageDir: this.config.storage.dir,
-      abortSignal: this.abortController.signal,
-      log: this.log,
-      onMessage: (msg) => this.handleMessage(msg),
-    });
+      if (this.config.storage.injectDir && this.config.storage.stateFile) {
+        this.injectionMonitor = new InjectionMonitor({
+          injectDir: this.config.storage.injectDir,
+          log: this.log,
+          onMessage: (job) => this.enqueueInjectedMessage(job),
+        });
+        await this.injectionMonitor.start();
+        this.log(`Injection queue: ${this.config.storage.injectDir}`);
+      }
+
+      // 3. Start monitor loop
+      this.log("Starting message polling...");
+      await startMonitor({
+        baseUrl: this.tokenData.baseUrl,
+        token: this.tokenData.token,
+        storageDir: this.config.storage.dir,
+        abortSignal: this.abortController.signal,
+        log: this.log,
+        onMessage: (msg) => this.handleMessage(msg),
+      });
+    } catch (err) {
+      try {
+        await this.stop();
+      } catch (cleanupErr) {
+        throw new AggregateError(
+          [err, cleanupErr],
+          "Bridge startup failed and cleanup also failed",
+        );
+      }
+      throw err;
+    }
   }
 
   async stop(): Promise<void> {
     this.log("Stopping bridge...");
     this.abortController.abort();
-    await this.injectionMonitor?.stop();
-    await this.sessionManager?.stop();
+    const cleanupErrors: unknown[] = [];
+    try {
+      await this.injectionMonitor?.stop();
+    } catch (err) {
+      cleanupErrors.push(err);
+    }
+    try {
+      await this.sessionManager?.stop();
+    } catch (err) {
+      cleanupErrors.push(err);
+    }
+    try {
+      await this.artifactMcpServer?.close();
+    } catch (err) {
+      cleanupErrors.push(err);
+    } finally {
+      this.artifactMcpServer = null;
+    }
     await this.stateUpdate.catch((err) => {
       this.log(`Failed to flush state before stop: ${String(err)}`);
       trackException(sanitizeStateError(err), "state");
     });
     this.log("Bridge stopped");
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(cleanupErrors, "Bridge cleanup failed");
+    }
   }
 
   private handleMessage(msg: WeixinMessage): void {
@@ -755,12 +810,37 @@ export class WeChatAcpBridge {
   }
 
   private async sendAudioReply(userId: string, contextToken: string, audio: AgentAudio): Promise<void> {
-    // Ride the same per-user chain as text and image replies so an audio
-    // file cannot interleave with the segments of a concurrent reply.
+    const mime = audio.mimeType.trim().toLowerCase();
+    const ext = Object.hasOwn(AUDIO_MIME_EXTENSIONS, mime) ? AUDIO_MIME_EXTENSIONS[mime] : "bin";
+    const fileName = `audio-${new Date().toISOString().replace(/[:.]/g, "-")}.${ext}`;
+    return this.queueFileReply(
+      userId,
+      contextToken,
+      { data: audio.data, name: fileName, mimeType: audio.mimeType },
+      "audio",
+    );
+  }
+
+  private async sendFileReply(
+    userId: string,
+    contextToken: string,
+    file: AgentFile,
+  ): Promise<void> {
+    return this.queueFileReply(userId, contextToken, file, "file");
+  }
+
+  private async queueFileReply(
+    userId: string,
+    contextToken: string,
+    file: AgentFile,
+    telemetryKind: "audio" | "file",
+  ): Promise<void> {
+    // Ride the same per-user chain as text and image replies so a file cannot
+    // interleave with the segments of a concurrent reply.
     const previous = this.sendChains.get(userId) ?? Promise.resolve();
     const current = previous
       .catch(() => {})
-      .then(() => this.deliverAudio(userId, contextToken, audio));
+      .then(() => this.deliverFile(userId, contextToken, file, telemetryKind));
     this.sendChains.set(
       userId,
       current.catch(() => {}),
@@ -768,16 +848,18 @@ export class WeChatAcpBridge {
     return current;
   }
 
-  private async deliverAudio(userId: string, contextToken: string, audio: AgentAudio): Promise<void> {
-    const buffer = Buffer.from(audio.data, "base64");
+  private async deliverFile(
+    userId: string,
+    contextToken: string,
+    file: AgentFile,
+    telemetryKind: "audio" | "file",
+  ): Promise<void> {
+    const buffer = Buffer.from(file.data, "base64");
     const startedAt = Date.now();
-    // Stable idempotency key and file name across attempts, same contract
-    // as deliverImage: together with reusing the uploaded media descriptor,
-    // every send attempt carries a byte-identical payload.
+    // Stable idempotency key and name across attempts, same contract as
+    // deliverImage: every send attempt carries a byte-identical payload.
     const clientId = `wechat-acp-${crypto.randomUUID()}`;
-    const mime = audio.mimeType.trim().toLowerCase();
-    const ext = Object.hasOwn(AUDIO_MIME_EXTENSIONS, mime) ? AUDIO_MIME_EXTENSIONS[mime] : "bin";
-    const fileName = `audio-${new Date().toISOString().replace(/[:.]/g, "-")}.${ext}`;
+    const fileName = sanitizeFileName(file.name);
     const sendOpts = {
       baseUrl: this.tokenData!.baseUrl,
       token: this.tokenData!.token,
@@ -795,11 +877,11 @@ export class WeChatAcpBridge {
         await this.paceConsecutiveSend(userId);
         await sendFileItem(userId, media, fileName, sendOpts, clientId);
         trackEvent(
-          "reply.audio.sent",
+          `reply.${telemetryKind}.sent`,
           {
             userIdHash: hashUserId(userId),
             bytes: buffer.length,
-            mimeType: audio.mimeType,
+            mimeType: file.mimeType,
             durationMs: Date.now() - startedAt,
           },
           hashUserId(userId),
@@ -808,7 +890,7 @@ export class WeChatAcpBridge {
         return;
       } catch (err) {
         lastError = err;
-        trackException(err, "reply.audio", hashUserId(userId));
+        trackException(err, `reply.${telemetryKind}`, hashUserId(userId));
         if (attempt < SEGMENT_SEND_MAX_ATTEMPTS) {
           await new Promise((r) => setTimeout(r, SEGMENT_SEND_RETRY_BASE_MS * attempt));
         }
@@ -818,7 +900,7 @@ export class WeChatAcpBridge {
     // Propagate so the ACP client appends its delivery-failure placeholder.
     throw lastError instanceof Error
       ? lastError
-      : new Error(`deliverAudio: failed after ${SEGMENT_SEND_MAX_ATTEMPTS} attempts`);
+      : new Error(`deliverFile: failed after ${SEGMENT_SEND_MAX_ATTEMPTS} attempts`);
   }
 
   /**

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -38,7 +38,8 @@ export type EventName =
   | "prompt.completed"
   | "reply.sent"
   | "reply.image.sent"
-  | "reply.audio.sent";
+  | "reply.audio.sent"
+  | "reply.file.sent";
 
 type PropValue = string | number | boolean;
 

--- a/tests/agent-manager.test.ts
+++ b/tests/agent-manager.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { spawnAgent } from "../src/acp/agent-manager.js";
+import { WeChatAcpClient } from "../src/acp/client.js";
+
+test("spawnAgent aborts an agent stuck during ACP initialization", async () => {
+  const client = new WeChatAcpClient({
+    sendTyping: async () => {},
+    onThoughtFlush: async () => {},
+    onMessageFlush: async () => {},
+    log: () => {},
+    showThoughts: false,
+  });
+  const controller = new AbortController();
+  const spawning = spawnAgent({
+    command: process.execPath,
+    args: ["-e", "setInterval(() => {}, 1000)"],
+    cwd: process.cwd(),
+    client,
+    signal: controller.signal,
+    log: () => {},
+  });
+  setTimeout(() => controller.abort(), 25);
+
+  await assert.rejects(spawning);
+});

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -8,7 +8,10 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 import { startArtifactMcpServer } from "../src/artifacts/server.js";
-import { ArtifactStore } from "../src/artifacts/store.js";
+import {
+  ArtifactStore,
+  sanitizeFileName,
+} from "../src/artifacts/store.js";
 
 async function withTempDir(
   run: (dir: string) => Promise<void>,
@@ -20,6 +23,15 @@ async function withTempDir(
     await fs.rm(dir, { recursive: true, force: true });
   }
 }
+
+test("sanitizeFileName strips line and bidirectional controls", () => {
+  assert.equal(
+    sanitizeFileName(
+      "  report\u2028\t\u202Eevil\u2069  \u061C\u200F.pdf  ",
+    ),
+    "report evil .pdf",
+  );
+});
 
 test("ArtifactStore snapshots allowed files and consumes artifacts once", async () => {
   await withTempDir(async (dir) => {

--- a/tests/artifact.test.ts
+++ b/tests/artifact.test.ts
@@ -1,0 +1,240 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+import { startArtifactMcpServer } from "../src/artifacts/server.js";
+import { ArtifactStore } from "../src/artifacts/store.js";
+
+async function withTempDir(
+  run: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "wechat-acp-artifact-"));
+  try {
+    await run(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("ArtifactStore snapshots allowed files and consumes artifacts once", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = path.join(dir, "report.txt");
+    await fs.writeFile(filePath, "version one");
+    const store = await ArtifactStore.create({ rootDir: dir });
+    try {
+      const published = await store.publish("report.txt");
+      await fs.writeFile(filePath, "version two");
+
+      const first = await store.resolveResourceLink({
+        uri: published.uri,
+        name: published.name,
+      });
+      assert.equal(
+        Buffer.from(first!.data, "base64").toString(),
+        "version one",
+        "the published artifact must be an immutable snapshot",
+      );
+      assert.equal(first!.name, "report.txt");
+      assert.equal(first!.mimeType, "text/plain");
+      assert.equal(
+        await store.resolveResourceLink({ uri: published.uri }),
+        null,
+        "artifact links are one-shot",
+      );
+    } finally {
+      store.close();
+    }
+  });
+});
+
+test("ArtifactStore rejects paths outside the workspace and symlink escapes", async () => {
+  await withTempDir(async (dir) => {
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "wechat-acp-outside-"));
+    const outsideFile = path.join(outsideDir, "secret.txt");
+    await fs.writeFile(outsideFile, "secret");
+    await fs.symlink(outsideFile, path.join(dir, "escape.txt"));
+    const store = await ArtifactStore.create({ rootDir: dir });
+    try {
+      await assert.rejects(() => store.publish(outsideFile), /outside the allowed workspace/);
+      await assert.rejects(() => store.publish("escape.txt"), /outside the allowed workspace/);
+    } finally {
+      store.close();
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+});
+
+test("ArtifactStore enforces file size and expiry limits", async () => {
+  await withTempDir(async (dir) => {
+    await fs.writeFile(path.join(dir, "large.bin"), "12345");
+    await fs.writeFile(path.join(dir, "short.txt"), "ok");
+    const store = await ArtifactStore.create({
+      rootDir: dir,
+      maxFileBytes: 4,
+      ttlMs: 5,
+    });
+    try {
+      await assert.rejects(() => store.publish("large.bin"), /byte limit/);
+      const published = await store.publish("short.txt");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      assert.equal(await store.resolveResourceLink({ uri: published.uri }), null);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+test("ArtifactStore serializes concurrent publishes against total capacity", async () => {
+  await withTempDir(async (dir) => {
+    await fs.writeFile(path.join(dir, "first.bin"), "1234");
+    await fs.writeFile(path.join(dir, "second.bin"), "5678");
+    const store = await ArtifactStore.create({
+      rootDir: dir,
+      maxFileBytes: 4,
+      maxTotalBytes: 6,
+    });
+    try {
+      const results = await Promise.allSettled([
+        store.publish("first.bin"),
+        store.publish("second.bin"),
+      ]);
+      assert.equal(
+        results.filter((result) => result.status === "fulfilled").length,
+        1,
+      );
+      const rejection = results.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      assert.match(String(rejection?.reason), /capacity exceeded/);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+test("artifact MCP requires auth and returns a resolvable resource_link", async () => {
+  await withTempDir(async (dir) => {
+    await fs.writeFile(path.join(dir, "artifact.txt"), "MCP attachment");
+    const server = await startArtifactMcpServer({
+      rootDir: dir,
+      log: () => {},
+    });
+    const lease = server.createLease();
+    try {
+      const unauthorized = await fetch(lease.mcpServer.url, { method: "POST" });
+      assert.equal(unauthorized.status, 401);
+
+      const headers = Object.fromEntries(
+        lease.mcpServer.headers.map(({ name, value }) => [name, value]),
+      );
+      const originRequest = await fetch(lease.mcpServer.url, {
+        method: "POST",
+        headers: { ...headers, Origin: "https://example.com" },
+      });
+      assert.equal(originRequest.status, 403);
+
+      const transport = new StreamableHTTPClientTransport(
+        new URL(lease.mcpServer.url),
+        { requestInit: { headers } },
+      );
+      const client = new Client(
+        { name: "artifact-test", version: "1.0.0" },
+        { capabilities: {} },
+      );
+      await client.connect(transport);
+      try {
+        const tools = await client.listTools();
+        assert.ok(tools.tools.some((tool) => tool.name === "attach_file"));
+
+        const result = await client.callTool({
+          name: "attach_file",
+          arguments: { path: "artifact.txt" },
+        });
+        const content = result.content as Array<Record<string, unknown>>;
+        assert.equal(content.length, 1);
+        assert.equal(content[0].type, "resource_link");
+        assert.equal(content[0].name, "artifact.txt");
+        assert.equal(content[0].mimeType, "text/plain");
+        assert.match(String(content[0].uri), /^wechat-acp:\/\/artifact\//);
+
+        const resolved = await server.resolveResourceLink({
+          uri: String(content[0].uri),
+          name: String(content[0].name),
+          mimeType: String(content[0].mimeType),
+        });
+        assert.equal(
+          Buffer.from(resolved!.data, "base64").toString(),
+          "MCP attachment",
+        );
+
+        const secondLease = server.createLease();
+        const secondHeaders = Object.fromEntries(
+          secondLease.mcpServer.headers.map(({ name, value }) => [name, value]),
+        );
+        const secondTransport = new StreamableHTTPClientTransport(
+          new URL(secondLease.mcpServer.url),
+          { requestInit: { headers: secondHeaders } },
+        );
+        const secondClient = new Client(
+          { name: "artifact-test-2", version: "1.0.0" },
+          { capabilities: {} },
+        );
+        await secondClient.connect(secondTransport);
+        const secondTools = await secondClient.listTools();
+        assert.ok(
+          secondTools.tools.some((tool) => tool.name === "attach_file"),
+          "the loopback server must support concurrent agent sessions",
+        );
+        await secondLease.close();
+        await secondClient.close().catch(() => {});
+      } finally {
+        await client.close();
+        await lease.close();
+      }
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+test("artifact MCP shutdown closes active transports before the HTTP server", async () => {
+  await withTempDir(async (dir) => {
+    const server = await startArtifactMcpServer({ rootDir: dir, log: () => {} });
+    const lease = server.createLease();
+    const headers = Object.fromEntries(
+      lease.mcpServer.headers.map(({ name, value }) => [name, value]),
+    );
+    const transport = new StreamableHTTPClientTransport(
+      new URL(lease.mcpServer.url),
+      { requestInit: { headers } },
+    );
+    const client = new Client(
+      { name: "shutdown-test", version: "1.0.0" },
+      { capabilities: {} },
+    );
+    await client.connect(transport);
+
+    let timeout: NodeJS.Timeout;
+    try {
+      await Promise.race([
+        server.close(),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("artifact MCP shutdown timed out")),
+            500,
+          );
+          timeout.unref();
+        }),
+      ]);
+    } finally {
+      clearTimeout(timeout!);
+    }
+    await client.close().catch(() => {});
+  });
+});

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -9,7 +9,13 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { WeChatAcpClient, type AgentImage, type AgentAudio } from "../src/acp/client.js";
+import {
+  WeChatAcpClient,
+  type AgentImage,
+  type AgentAudio,
+  type AgentFile,
+} from "../src/acp/client.js";
+import type { AgentResourceLink } from "../src/artifacts/types.js";
 import { splitText } from "../src/weixin/send.js";
 
 // ---------------------------------------------------------------------------
@@ -22,6 +28,8 @@ function makeClient(opts: {
   onThoughtFlush?: (text: string) => Promise<void>;
   onImageFlush?: (image: AgentImage) => Promise<void>;
   onAudioFlush?: (audio: AgentAudio) => Promise<void>;
+  onFileFlush?: (file: AgentFile) => Promise<void>;
+  resolveResourceLink?: (link: AgentResourceLink) => Promise<AgentFile | null>;
   showImages?: boolean;
   showAudio?: boolean;
   showResources?: boolean;
@@ -45,6 +53,8 @@ function makeClient(opts: {
       }),
     onImageFlush: opts.onImageFlush,
     onAudioFlush: opts.onAudioFlush,
+    onFileFlush: opts.onFileFlush,
+    resolveResourceLink: opts.resolveResourceLink,
     log: opts.log ?? (() => {}),
     showThoughts: false,
     showImages: opts.showImages,
@@ -808,6 +818,171 @@ test("blob resource without a MIME type reports unknown type in the placeholder"
   assert.match(text, /📎 \[resource: mystery \(unknown type, ~\d+ bytes\) - binary content not rendered\]/);
 });
 
+test("non-image blob resource is delivered through the generic file pipeline", async () => {
+  const files: AgentFile[] = [];
+  const blob = Buffer.from("binary-data-here").toString("base64");
+  const client = makeClient({
+    onFileFlush: async (file) => {
+      files.push(file);
+    },
+  });
+
+  await emitToolCallResource(client, {
+    uri: "file:///report.pdf",
+    mimeType: "application/pdf",
+    blob,
+  });
+
+  assert.deepEqual(files, [
+    { data: blob, name: "report.pdf", mimeType: "application/pdf" },
+  ]);
+  assert.equal(await client.flush(), "");
+  assert.equal(client.hasProducedMessage, true);
+});
+
+test("resource_link in agent_message_chunk resolves and delivers a file", async () => {
+  const files: AgentFile[] = [];
+  const seen: AgentResourceLink[] = [];
+  const client = makeClient({
+    resolveResourceLink: async (link) => {
+      seen.push(link);
+      return {
+        data: Buffer.from("attachment").toString("base64"),
+        name: "result.zip",
+        mimeType: "application/zip",
+      };
+    },
+    onFileFlush: async (file) => {
+      files.push(file);
+    },
+  });
+
+  await client.sessionUpdate({
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "resource_link",
+        uri: "wechat-acp://artifact/123",
+        name: "result.zip",
+        mimeType: "application/zip",
+      },
+    },
+  } as never);
+
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].uri, "wechat-acp://artifact/123");
+  assert.equal(files.length, 1);
+  assert.equal(files[0].name, "result.zip");
+});
+
+test("completed tool_call resource_link is delivered for Codex-style output", async () => {
+  const files: AgentFile[] = [];
+  const client = makeClient({
+    resolveResourceLink: async () => ({
+      data: Buffer.from("codex-file").toString("base64"),
+      name: "codex.txt",
+      mimeType: "text/plain",
+    }),
+    onFileFlush: async (file) => {
+      files.push(file);
+    },
+  });
+
+  await client.sessionUpdate({
+    update: {
+      sessionUpdate: "tool_call",
+      toolCallId: "tc-codex-link",
+      title: "Create file",
+      status: "completed",
+      content: [
+        {
+          type: "content",
+          content: {
+            type: "resource_link",
+            uri: "file:///workspace/codex.txt",
+            name: "codex.txt",
+          },
+        },
+      ],
+    },
+  } as never);
+
+  assert.equal(files.length, 1);
+  assert.equal(files[0].name, "codex.txt");
+});
+
+test("resource_link in tool_call_update preserves text-before-file ordering", async () => {
+  const order: string[] = [];
+  const client = makeClient({
+    onMessageFlush: async (text) => {
+      order.push(`text:${text}`);
+    },
+    resolveResourceLink: async () => ({
+      data: Buffer.from("file").toString("base64"),
+      name: "output.txt",
+      mimeType: "text/plain",
+    }),
+    onFileFlush: async (file) => {
+      order.push(`file:${file.name}`);
+    },
+  });
+  await emitMessageChunk(client, "before");
+
+  await client.sessionUpdate({
+    update: {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "tc-link",
+      status: "completed",
+      content: [
+        {
+          type: "content",
+          content: {
+            type: "resource_link",
+            uri: "wechat-acp://artifact/output",
+            name: "output.txt",
+          },
+        },
+      ],
+    },
+  } as never);
+
+  assert.deepEqual(order, ["text:before", "file:output.txt"]);
+});
+
+test("showResources=false does not resolve or deliver resource links", async () => {
+  let resolverCalls = 0;
+  const files: AgentFile[] = [];
+  const client = makeClient({
+    showResources: false,
+    resolveResourceLink: async () => {
+      resolverCalls++;
+      return {
+        data: Buffer.from("hidden").toString("base64"),
+        name: "hidden.txt",
+        mimeType: "text/plain",
+      };
+    },
+    onFileFlush: async (file) => {
+      files.push(file);
+    },
+  });
+
+  await client.sessionUpdate({
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "resource_link",
+        uri: "wechat-acp://artifact/hidden",
+        name: "hidden.txt",
+      },
+    },
+  } as never);
+
+  assert.equal(resolverCalls, 0);
+  assert.equal(files.length, 0);
+  assert.equal(await client.flush(), "");
+});
+
 test("showResources=false drops resources without rendering", async () => {
   const images: AgentImage[] = [];
   const client = makeClient({
@@ -1160,6 +1335,34 @@ test("beginTurn rebinds the audio sink to the new turn's callbacks", async () =>
   assert.equal(secondTurn.length, 1);
 });
 
+test("beginTurn rebinds the file sink to the new turn's callbacks", async () => {
+  const firstTurn: AgentFile[] = [];
+  const secondTurn: AgentFile[] = [];
+  const client = makeClient({
+    onFileFlush: async (file) => {
+      firstTurn.push(file);
+    },
+  });
+
+  await client.beginTurn({
+    sendTyping: async () => {},
+    onThoughtFlush: async () => {},
+    onMessageFlush: async () => {},
+    onFileFlush: async (file) => {
+      secondTurn.push(file);
+    },
+  });
+  await emitToolCallResource(client, {
+    uri: "file:///result.bin",
+    mimeType: "application/octet-stream",
+    blob: Buffer.from("result").toString("base64"),
+  });
+
+  assert.equal(firstTurn.length, 0);
+  assert.equal(secondTurn.length, 1);
+  assert.equal(secondTurn[0].name, "result.bin");
+});
+
 // ---------------------------------------------------------------------------
 // Cross-turn callback binding (issue 54)
 // ---------------------------------------------------------------------------
@@ -1301,6 +1504,71 @@ test("late old-turn notification queued after beginTurn cannot leak into the new
 // ---------------------------------------------------------------------------
 
 const BLOB_BASE64 = Buffer.from("COPILOT_RESOURCE_SENTINEL").toString("base64");
+
+test("Copilot CLI rawOutput resource_link resolves and delivers a file", async () => {
+  const files: AgentFile[] = [];
+  const client = makeClient({
+    resolveResourceLink: async (link) => ({
+      data: Buffer.from(`resolved:${link.uri}`).toString("base64"),
+      name: link.name ?? "artifact.txt",
+      mimeType: link.mimeType ?? "application/octet-stream",
+    }),
+    onFileFlush: async (file) => {
+      files.push(file);
+    },
+  });
+
+  await emitToolCallRawOutputImage(
+    client,
+    {
+      content: "",
+      detailedContent: "",
+      contents: [
+        {
+          type: "resource_link",
+          uri: "file:///workspace/artifact.txt",
+          name: "artifact.txt",
+          description: "Copilot ACP resource-link probe artifact",
+          mimeType: "text/plain",
+          size: 31,
+        },
+      ],
+    },
+    [{ type: "content", content: { type: "text", text: "" } }],
+  );
+
+  assert.equal(files.length, 1);
+  assert.equal(files[0].name, "artifact.txt");
+  assert.equal(files[0].mimeType, "text/plain");
+});
+
+test("standard resource_link suppresses the mirrored rawOutput link", async () => {
+  const files: AgentFile[] = [];
+  const client = makeClient({
+    resolveResourceLink: async (link) => ({
+      data: Buffer.from("one-file").toString("base64"),
+      name: link.name ?? "artifact.txt",
+      mimeType: "text/plain",
+    }),
+    onFileFlush: async (file) => {
+      files.push(file);
+    },
+  });
+
+  const link = {
+    type: "resource_link",
+    uri: "wechat-acp://artifact/duplicate",
+    name: "artifact.txt",
+    mimeType: "text/plain",
+  };
+  await emitToolCallRawOutputImage(
+    client,
+    { contents: [link] },
+    [{ type: "content", content: link }],
+  );
+
+  assert.equal(files.length, 1, "the standard and rawOutput copies must deliver once");
+});
 
 test("Copilot CLI shape: resource only in rawOutput renders exactly once", async () => {
   // Exact captured payload shape from Copilot CLI 1.0.73: an empty text

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1507,6 +1507,7 @@ const BLOB_BASE64 = Buffer.from("COPILOT_RESOURCE_SENTINEL").toString("base64");
 
 test("Copilot CLI rawOutput resource_link resolves and delivers a file", async () => {
   const files: AgentFile[] = [];
+  const logs: string[] = [];
   const client = makeClient({
     resolveResourceLink: async (link) => ({
       data: Buffer.from(`resolved:${link.uri}`).toString("base64"),
@@ -1515,6 +1516,9 @@ test("Copilot CLI rawOutput resource_link resolves and delivers a file", async (
     }),
     onFileFlush: async (file) => {
       files.push(file);
+    },
+    log: (message) => {
+      logs.push(message);
     },
   });
 
@@ -1540,6 +1544,11 @@ test("Copilot CLI rawOutput resource_link resolves and delivers a file", async (
   assert.equal(files.length, 1);
   assert.equal(files[0].name, "artifact.txt");
   assert.equal(files[0].mimeType, "text/plain");
+  assert.ok(
+    logs.some((message) =>
+      message.includes("[resource link entries: 1 rawOutput fallback]"),
+    ),
+  );
 });
 
 test("standard resource_link suppresses the mirrored rawOutput link", async () => {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -15,7 +15,10 @@ import {
   type AgentAudio,
   type AgentFile,
 } from "../src/acp/client.js";
-import type { AgentResourceLink } from "../src/artifacts/types.js";
+import {
+  MAX_AGENT_FILE_BYTES,
+  type AgentResourceLink,
+} from "../src/artifacts/types.js";
 import { splitText } from "../src/weixin/send.js";
 
 // ---------------------------------------------------------------------------
@@ -838,6 +841,26 @@ test("non-image blob resource is delivered through the generic file pipeline", a
   ]);
   assert.equal(await client.flush(), "");
   assert.equal(client.hasProducedMessage, true);
+});
+
+test("file exactly at the decoded size limit is delivered despite base64 padding", async () => {
+  let delivered = false;
+  const encodedLength = 4 * Math.ceil(MAX_AGENT_FILE_BYTES / 3);
+  const data = `${"A".repeat(encodedLength - 2)}==`;
+  const client = makeClient({
+    onFileFlush: async () => {
+      delivered = true;
+    },
+  });
+
+  await emitToolCallResource(client, {
+    uri: "file:///limit.bin",
+    mimeType: "application/octet-stream",
+    blob: data,
+  });
+
+  assert.equal(delivered, true);
+  assert.equal(await client.flush(), "");
 });
 
 test("resource_link in agent_message_chunk resolves and delivers a file", async () => {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -57,3 +57,66 @@ test("concurrent session creation reserves maxConcurrentUsers capacity", async (
   assert.deepEqual(createdUsers, ["user-1"]);
   await manager.stop();
 });
+
+test("SessionManager.stop waits for every MCP lease before reporting failures", async () => {
+  const manager = new SessionManager({
+    agentCommand: "unused",
+    agentArgs: [],
+    agentCwd: process.cwd(),
+    idleTimeoutMs: 0,
+    maxConcurrentUsers: 2,
+    showThoughts: false,
+    log: () => {},
+    onReply: async () => {},
+    sendTyping: async () => {},
+  });
+  const events: string[] = [];
+  const sessions = (
+    manager as unknown as { sessions: Map<string, UserSession> }
+  ).sessions;
+  const makeSession = (
+    userId: string,
+    close: () => Promise<void>,
+  ): UserSession => ({
+    userId,
+    contextToken: `${userId}-context`,
+    client: {} as never,
+    agentInfo: {
+      process: { killed: true } as never,
+      connection: {} as never,
+      sessionId: userId,
+      configOptions: [],
+    },
+    mcpLease: { mcpServer: {} as never, close },
+    configOptions: [],
+    queue: [],
+    processing: false,
+    lastActivity: Date.now(),
+    createdAt: Date.now(),
+  });
+  sessions.set(
+    "user-1",
+    makeSession("user-1", async () => {
+      events.push("first-start");
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      events.push("first-failed");
+      throw new Error("first close failed");
+    }),
+  );
+  sessions.set(
+    "user-2",
+    makeSession("user-2", async () => {
+      events.push("second-start");
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      events.push("second-finished");
+    }),
+  );
+
+  await assert.rejects(manager.stop(), AggregateError);
+  assert.deepEqual(events, [
+    "first-start",
+    "second-start",
+    "first-failed",
+    "second-finished",
+  ]);
+});

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  SessionManager,
+  type UserSession,
+} from "../src/acp/session.js";
+
+test("concurrent session creation reserves maxConcurrentUsers capacity", async () => {
+  const manager = new SessionManager({
+    agentCommand: "unused",
+    agentArgs: [],
+    agentCwd: process.cwd(),
+    idleTimeoutMs: 0,
+    maxConcurrentUsers: 1,
+    showThoughts: false,
+    log: () => {},
+    onReply: async () => {},
+    sendTyping: async () => {},
+  });
+  const createdUsers: string[] = [];
+  const internal = manager as unknown as {
+    createSession(userId: string, contextToken: string): Promise<UserSession>;
+    getOrCreateSession(userId: string, contextToken: string): Promise<UserSession>;
+  };
+  internal.createSession = async (userId, contextToken) => {
+    createdUsers.push(userId);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    return {
+      userId,
+      contextToken,
+      client: {} as never,
+      agentInfo: {
+        process: { killed: true } as never,
+        connection: {} as never,
+        sessionId: userId,
+        configOptions: [],
+      },
+      configOptions: [],
+      queue: [],
+      processing: false,
+      lastActivity: Date.now(),
+      createdAt: Date.now(),
+    };
+  };
+
+  const first = internal
+    .getOrCreateSession("user-1", "context-1")
+    .then((session) => {
+      session.processing = true;
+      return session;
+    });
+  const second = internal.getOrCreateSession("user-2", "context-2");
+
+  assert.equal((await first).userId, "user-1");
+  await assert.rejects(second, /Maximum concurrent sessions reached/);
+  assert.deepEqual(createdUsers, ["user-1"]);
+  await manager.stop();
+});


### PR DESCRIPTION
## Summary

- add a loopback authenticated Streamable HTTP MCP server with an `attach_file` tool and one-shot in-memory artifact snapshots
- deliver standard ACP `resource_link`, embedded blob resources, Codex completed tool-call links, and Copilot CLI `rawOutput.contents` links as native WeChat file messages
- enforce workspace path boundaries, regular-file checks, 25 MiB file limits, bounded reads, per-agent MCP leases, and lifecycle-safe cleanup
- reuse the existing WeChat CDN upload/retry/idempotency pipeline and add file telemetry, documentation, and regression coverage

## Compatibility

The active `attach_file` flow is injected only when the ACP agent advertises HTTP MCP support. Copilot CLI is supported through its captured `rawOutput.contents[type=resource_link]` shape; standard ACP resource links remain the primary path for other compatible agents.

## Testing

- `npm test` — 106 tests passed
- `npm run build`
- real Copilot CLI 1.0.73 E2E: Copilot created `attachment-e2e.txt`, called `attach_file`, emitted the resource link through ACP rawOutput, and the file sink received the exact expected content