### PR TITLE
fix: send image resource links as native images

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -127,6 +127,10 @@ function decodedBase64ByteLength(data: string): number {
   return Math.max(0, Math.floor((data.length * 3) / 4) - padding);
 }
 
+function base64DecodedByteUpperBound(data: string): number {
+  return Math.ceil(data.length / 4) * 3;
+}
+
 /**
  * Human-readable name for a resource: the last path segment of its URI,
  * percent-decoded and sanitized to a single line. Falls back to the full
@@ -881,7 +885,7 @@ export class WeChatAcpClient implements acp.Client {
       opts.showImages !== false &&
       opts.onImageFlush &&
       SUPPORTED_IMAGE_MIME_TYPES.has(mimeType) &&
-      decodedBytes <= MAX_IMAGE_BYTES
+      base64DecodedByteUpperBound(file.data) <= MAX_IMAGE_BYTES
     ) {
       opts.log(`[file] routing image file ${name} through image pipeline (${mimeType}, ${decodedBytes} bytes)`);
       await this.maybeSendImage({ data: file.data, mimeType }, turn);
@@ -949,8 +953,8 @@ export class WeChatAcpClient implements acp.Client {
       opts.log(`[image] skipped unsupported type: ${mimeType}`);
       return;
     }
-    // ceil(base64Len / 4) * 3 over-estimates by at most 2 bytes; fine for a cap.
-    const approxBytes = Math.ceil(image.data.length / 4) * 3;
+    // The upper bound over-estimates by at most 2 bytes; fine for a cap.
+    const approxBytes = base64DecodedByteUpperBound(image.data);
     if (approxBytes > MAX_IMAGE_BYTES) {
       opts.log(`[image] skipped oversized image (~${approxBytes} bytes > ${MAX_IMAGE_BYTES})`);
       turn.chunks.push("\n⚠️ [image too large to deliver]\n");

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -824,9 +824,17 @@ export class WeChatAcpClient implements acp.Client {
   ): Promise<boolean> {
     const opts = turn.opts;
     const name = sanitizeInlineLabel(link.name ?? resourceDisplayName(link.uri));
+    const mimeType = sanitizeInlineLabel(link.mimeType ?? "")
+      .split(";")[0]
+      .trim()
+      .toLowerCase();
+    const routesToImagePipeline =
+      SUPPORTED_IMAGE_MIME_TYPES.has(mimeType) &&
+      opts.showImages !== false &&
+      Boolean(opts.onImageFlush);
     if (opts.showResources === false) {
       opts.log(`[resource-link] skipped (showResources=false, ${name})`);
-      return false;
+      return routesToImagePipeline;
     }
     if (turn.deliveredResourceLinks.has(link.uri)) {
       opts.log(`[resource-link] skipped duplicate: ${name}`);
@@ -858,6 +866,10 @@ export class WeChatAcpClient implements acp.Client {
     }
   }
 
+  /**
+   * Deliver a resolved file and return whether it was routed through the
+   * native image pipeline. A successful generic file delivery returns false.
+   */
   private async maybeSendFile(file: AgentFile, turn: TurnState): Promise<boolean> {
     const opts = turn.opts;
     const name = sanitizeInlineLabel(file.name) || "artifact";

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -478,6 +478,7 @@ export class WeChatAcpClient implements acp.Client {
         let resourceContentBlocks = 0;
         let resourceLinkContentBlocks = 0;
         let resourceImages = 0;
+        let resourceLinkImages = 0;
         if (update.status === "completed" && update.content) {
           for (const c of update.content) {
             if (c.type === "diff") {
@@ -507,7 +508,9 @@ export class WeChatAcpClient implements acp.Client {
               }
             } else if (c.type === "content" && c.content.type === "resource_link") {
               resourceLinkContentBlocks++;
-              await this.maybeSendResourceLink(c.content, turn);
+              if (await this.maybeSendResourceLink(c.content, turn)) {
+                resourceLinkImages++;
+              }
             }
           }
         }
@@ -529,11 +532,14 @@ export class WeChatAcpClient implements acp.Client {
           rawOutputResourceImages = viaRawOutput.images;
         }
         let rawOutputResourceLinks = 0;
+        let rawOutputResourceLinkImages = 0;
         if (update.status === "completed" && resourceLinkContentBlocks === 0) {
-          rawOutputResourceLinks = await this.maybeSendRawOutputResourceLinks(
+          const viaRawOutput = await this.maybeSendRawOutputResourceLinks(
             update.rawOutput,
             turn,
           );
+          rawOutputResourceLinks = viaRawOutput.links;
+          rawOutputResourceLinkImages = viaRawOutput.images;
         }
         // Copilot CLI compatibility: the CLI emits tool-result images only in
         // rawOutput.binaryResultsForLlm and never as ACP image content blocks
@@ -546,7 +552,9 @@ export class WeChatAcpClient implements acp.Client {
           update.status === "completed" &&
           imageContentBlocks === 0 &&
           resourceImages === 0 &&
-          rawOutputResourceImages === 0
+          rawOutputResourceImages === 0 &&
+          resourceLinkImages === 0 &&
+          rawOutputResourceLinkImages === 0
         ) {
           rawOutputImages = await this.maybeSendRawOutputImages(update.rawOutput, turn);
         }
@@ -554,10 +562,10 @@ export class WeChatAcpClient implements acp.Client {
           // Surface where images came from so field issues like issue 55
           // (image present but in a non-standard location) show up in logs.
           const imageNote =
-            imageContentBlocks + resourceImages > 0
-              ? ` [images: ${imageContentBlocks + resourceImages} content block]`
-              : rawOutputImages > 0
-                ? ` [images: ${rawOutputImages} rawOutput fallback]`
+            imageContentBlocks + resourceImages + resourceLinkImages > 0
+              ? ` [images: ${imageContentBlocks + resourceImages + resourceLinkImages} content block]`
+              : rawOutputImages + rawOutputResourceLinkImages > 0
+                ? ` [images: ${rawOutputImages + rawOutputResourceLinkImages} rawOutput fallback]`
                 : "";
           const resourceNote =
             rawOutputResources > 0 ? ` [resources: ${rawOutputResources} rawOutput fallback]` : "";
@@ -777,12 +785,13 @@ export class WeChatAcpClient implements acp.Client {
   private async maybeSendRawOutputResourceLinks(
     rawOutput: unknown,
     turn: TurnState,
-  ): Promise<number> {
-    if (typeof rawOutput !== "object" || rawOutput === null) return 0;
+  ): Promise<{ links: number; images: number }> {
+    if (typeof rawOutput !== "object" || rawOutput === null) return { links: 0, images: 0 };
     const { contents } = rawOutput as { contents?: unknown };
-    if (!Array.isArray(contents)) return 0;
+    if (!Array.isArray(contents)) return { links: 0, images: 0 };
 
     let links = 0;
+    let images = 0;
     for (const entry of contents) {
       if (typeof entry !== "object" || entry === null) continue;
       const { type, uri, name, mimeType, size } = entry as {
@@ -794,7 +803,7 @@ export class WeChatAcpClient implements acp.Client {
       };
       if (type !== "resource_link" || typeof uri !== "string" || !uri) continue;
       links++;
-      await this.maybeSendResourceLink(
+      if (await this.maybeSendResourceLink(
         {
           uri,
           ...(typeof name === "string" ? { name } : {}),
@@ -802,24 +811,26 @@ export class WeChatAcpClient implements acp.Client {
           ...(typeof size === "number" ? { size } : {}),
         },
         turn,
-      );
+      )) {
+        images++;
+      }
     }
-    return links;
+    return { links, images };
   }
 
   private async maybeSendResourceLink(
     link: AgentResourceLink,
     turn: TurnState,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const opts = turn.opts;
     const name = sanitizeInlineLabel(link.name ?? resourceDisplayName(link.uri));
     if (opts.showResources === false) {
       opts.log(`[resource-link] skipped (showResources=false, ${name})`);
-      return;
+      return false;
     }
     if (turn.deliveredResourceLinks.has(link.uri)) {
       opts.log(`[resource-link] skipped duplicate: ${name}`);
-      return;
+      return false;
     }
     turn.deliveredResourceLinks.add(link.uri);
 
@@ -827,7 +838,7 @@ export class WeChatAcpClient implements acp.Client {
       turn.chunks.push(`\n📎 [resource link: ${name} - file resolver unavailable]\n`);
       turn.producedMessage = true;
       opts.log(`[resource-link] resolver unavailable: ${name}`);
-      return;
+      return false;
     }
 
     try {
@@ -836,37 +847,49 @@ export class WeChatAcpClient implements acp.Client {
         turn.chunks.push(`\n📎 [resource link: ${name} - file unavailable]\n`);
         turn.producedMessage = true;
         opts.log(`[resource-link] unavailable: ${name}`);
-        return;
+        return false;
       }
-      await this.maybeSendFile(file, turn);
+      return await this.maybeSendFile(file, turn);
     } catch (err) {
       turn.chunks.push(`\n⚠️ [file ${name} could not be resolved]\n`);
       turn.producedMessage = true;
       opts.log(`[resource-link] resolve failed for ${name}: ${String(err)}`);
+      return false;
     }
   }
 
-  private async maybeSendFile(file: AgentFile, turn: TurnState): Promise<void> {
+  private async maybeSendFile(file: AgentFile, turn: TurnState): Promise<boolean> {
     const opts = turn.opts;
     const name = sanitizeInlineLabel(file.name) || "artifact";
     const mimeType =
       sanitizeInlineLabel(file.mimeType).split(";")[0].trim().toLowerCase() ||
       "application/octet-stream";
+    const decodedBytes = decodedBase64ByteLength(file.data);
+    if (
+      opts.showImages !== false &&
+      opts.onImageFlush &&
+      SUPPORTED_IMAGE_MIME_TYPES.has(mimeType) &&
+      decodedBytes <= MAX_IMAGE_BYTES
+    ) {
+      opts.log(`[file] routing image file ${name} through image pipeline (${mimeType}, ${decodedBytes} bytes)`);
+      await this.maybeSendImage({ data: file.data, mimeType }, turn);
+      return true;
+    }
+
     if (!opts.onFileFlush) {
       turn.chunks.push(`\n📎 [file: ${name} (${mimeType}) - delivery unavailable]\n`);
       turn.producedMessage = true;
       opts.log(`[file] skipped (no file sink configured, ${name})`);
-      return;
+      return false;
     }
 
-    const decodedBytes = decodedBase64ByteLength(file.data);
     if (decodedBytes > MAX_AGENT_FILE_BYTES) {
       turn.chunks.push(`\n⚠️ [file ${name} is too large to deliver]\n`);
       turn.producedMessage = true;
       opts.log(
         `[file] skipped oversized file ${name} (${decodedBytes} bytes > ${MAX_AGENT_FILE_BYTES})`,
       );
-      return;
+      return false;
     }
 
     await this.maybeFlushMessage(turn);
@@ -874,10 +897,12 @@ export class WeChatAcpClient implements acp.Client {
       await opts.onFileFlush({ data: file.data, name, mimeType });
       opts.log(`[file] sent ${name} (${mimeType}, ${decodedBytes} bytes)`);
       turn.producedMessage = true;
+      return false;
     } catch (err) {
       turn.chunks.push(`\n⚠️ [file ${name} could not be delivered]\n`);
       turn.producedMessage = true;
       opts.log(`[file] delivery failed for ${name}: ${String(err)}`);
+      return false;
     }
   }
 

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -564,8 +564,8 @@ export class WeChatAcpClient implements acp.Client {
           const imageNote =
             imageContentBlocks + resourceImages + resourceLinkImages > 0
               ? ` [images: ${imageContentBlocks + resourceImages + resourceLinkImages} content block]`
-              : rawOutputImages + rawOutputResourceLinkImages > 0
-                ? ` [images: ${rawOutputImages + rawOutputResourceLinkImages} rawOutput fallback]`
+              : rawOutputImages + rawOutputResourceImages + rawOutputResourceLinkImages > 0
+                ? ` [images: ${rawOutputImages + rawOutputResourceImages + rawOutputResourceLinkImages} rawOutput fallback]`
                 : "";
           const resourceNote =
             rawOutputResources > 0 ? ` [resources: ${rawOutputResources} rawOutput fallback]` : "";

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -945,6 +945,43 @@ test("image resource_link resolves and delivers through the native image pipelin
   assert.equal(await client.flush(), "");
 });
 
+test("padded image at the decoded limit falls back to file delivery", async () => {
+  const maxImageBytes = 10 * 1024 * 1024;
+  const encodedLength = 4 * Math.ceil(maxImageBytes / 3);
+  const data = `${"A".repeat(encodedLength - 2)}==`;
+  const images: AgentImage[] = [];
+  const files: AgentFile[] = [];
+  const client = makeClient({
+    resolveResourceLink: async () => ({
+      data,
+      name: "limit.png",
+      mimeType: "image/png",
+    }),
+    onImageFlush: async (image) => {
+      images.push(image);
+    },
+    onFileFlush: async (file) => {
+      files.push(file);
+    },
+  });
+
+  await client.sessionUpdate({
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "resource_link",
+        uri: "wechat-acp://artifact/limit-image",
+        name: "limit.png",
+        mimeType: "image/png",
+      },
+    },
+  } as never);
+
+  assert.equal(images.length, 0);
+  assert.equal(files.length, 1);
+  assert.equal(files[0].name, "limit.png");
+});
+
 test("image resource_link falls back to file delivery when images are hidden", async () => {
   const images: AgentImage[] = [];
   const files: AgentFile[] = [];

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -898,6 +898,76 @@ test("resource_link in agent_message_chunk resolves and delivers a file", async 
   assert.equal(files[0].name, "result.zip");
 });
 
+test("image resource_link resolves and delivers through the native image pipeline", async () => {
+  const images: AgentImage[] = [];
+  const files: AgentFile[] = [];
+  const client = makeClient({
+    resolveResourceLink: async () => ({
+      data: PNG_BASE64,
+      name: "screenshot.jpg",
+      mimeType: "image/jpeg",
+    }),
+    onImageFlush: async (image) => {
+      images.push(image);
+    },
+    onFileFlush: async (file) => {
+      files.push(file);
+    },
+  });
+
+  await client.sessionUpdate({
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "resource_link",
+        uri: "wechat-acp://artifact/screenshot",
+        name: "screenshot.jpg",
+        mimeType: "image/jpeg",
+      },
+    },
+  } as never);
+
+  assert.deepEqual(images, [{ data: PNG_BASE64, mimeType: "image/jpeg" }]);
+  assert.equal(files.length, 0);
+  assert.equal(await client.flush(), "");
+});
+
+test("image resource_link falls back to file delivery when images are hidden", async () => {
+  const images: AgentImage[] = [];
+  const files: AgentFile[] = [];
+  const client = makeClient({
+    showImages: false,
+    resolveResourceLink: async () => ({
+      data: PNG_BASE64,
+      name: "hidden-image.jpg",
+      mimeType: "image/jpeg",
+    }),
+    onImageFlush: async (image) => {
+      images.push(image);
+    },
+    onFileFlush: async (file) => {
+      files.push(file);
+    },
+  });
+
+  await client.sessionUpdate({
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "resource_link",
+        uri: "wechat-acp://artifact/hidden-image",
+        name: "hidden-image.jpg",
+        mimeType: "image/jpeg",
+      },
+    },
+  } as never);
+
+  assert.equal(images.length, 0);
+  assert.deepEqual(files, [
+    { data: PNG_BASE64, name: "hidden-image.jpg", mimeType: "image/jpeg" },
+  ]);
+});
+
 test("completed tool_call resource_link is delivered for Codex-style output", async () => {
   const files: AgentFile[] = [];
   const client = makeClient({
@@ -1572,6 +1642,45 @@ test("Copilot CLI rawOutput resource_link resolves and delivers a file", async (
       message.includes("[resource link entries: 1 rawOutput fallback]"),
     ),
   );
+});
+
+test("Copilot CLI rawOutput image resource_link resolves and delivers a native image", async () => {
+  const images: AgentImage[] = [];
+  const files: AgentFile[] = [];
+  const client = makeClient({
+    resolveResourceLink: async (link) => ({
+      data: PNG_BASE64,
+      name: link.name ?? "screenshot.jpg",
+      mimeType: link.mimeType ?? "image/jpeg",
+    }),
+    onImageFlush: async (image) => {
+      images.push(image);
+    },
+    onFileFlush: async (file) => {
+      files.push(file);
+    },
+  });
+
+  await emitToolCallRawOutputImage(
+    client,
+    {
+      content: "",
+      detailedContent: "",
+      contents: [
+        {
+          type: "resource_link",
+          uri: "file:///workspace/screenshot.jpg",
+          name: "screenshot.jpg",
+          mimeType: "image/jpeg",
+          size: 128,
+        },
+      ],
+    },
+    [{ type: "content", content: { type: "text", text: "" } }],
+  );
+
+  assert.deepEqual(images, [{ data: PNG_BASE64, mimeType: "image/jpeg" }]);
+  assert.equal(files.length, 0);
 });
 
 test("standard resource_link suppresses the mirrored rawOutput link", async () => {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -429,13 +429,26 @@ test("[tool] log line reports image source: content block vs rawOutput fallback"
   await emitToolCallRawOutputImage(client, {
     binaryResultsForLlm: [{ type: "image", data: PNG_BASE64, mimeType: "image/png" }],
   });
+  await emitToolCallRawOutputImage(client, {
+    contents: [
+      {
+        type: "resource",
+        resource: {
+          uri: "file:///workspace/raw-output-resource.png",
+          blob: PNG_BASE64,
+          mimeType: "image/png",
+        },
+      },
+    ],
+  });
   await emitToolCallRawOutputImage(client, { content: "plain text result" });
 
   const toolLogs = logs.filter((l) => l.startsWith("[tool] tc-"));
-  assert.equal(toolLogs.length, 3);
+  assert.equal(toolLogs.length, 4);
   assert.match(toolLogs[0], /\[images: 1 content block\]$/);
   assert.match(toolLogs[1], /\[images: 1 rawOutput fallback\]$/);
-  assert.match(toolLogs[2], /completed$/, "no image note when the tool produced no image");
+  assert.match(toolLogs[2], /\[images: 1 rawOutput fallback\] \[resources: 1 rawOutput fallback\]$/);
+  assert.match(toolLogs[3], /completed$/, "no image note when the tool produced no image");
 });
 
 test("image in agent_message_chunk is delivered", async () => {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1089,6 +1089,49 @@ test("showResources=false does not resolve or deliver resource links", async () 
   assert.equal(await client.flush(), "");
 });
 
+test("hidden image resource_link suppresses the mirrored rawOutput image fallback", async () => {
+  let resolverCalls = 0;
+  const images: AgentImage[] = [];
+  const client = makeClient({
+    showResources: false,
+    resolveResourceLink: async () => {
+      resolverCalls++;
+      return {
+        data: PNG_BASE64,
+        name: "hidden.png",
+        mimeType: "image/png",
+      };
+    },
+    onImageFlush: async (image) => {
+      images.push(image);
+    },
+  });
+
+  await emitToolCallRawOutputImage(
+    client,
+    {
+      binaryResultsForLlm: [
+        { type: "image", data: PNG_BASE64, mimeType: "image/png" },
+      ],
+    },
+    [
+      {
+        type: "content",
+        content: {
+          type: "resource_link",
+          uri: "wechat-acp://artifact/hidden-image",
+          name: "hidden.png",
+          mimeType: "image/png",
+        },
+      },
+    ],
+  );
+
+  assert.equal(resolverCalls, 0);
+  assert.equal(images.length, 0, "the mirrored rawOutput image must not bypass showResources=false");
+  assert.equal(await client.flush(), "");
+});
+
 test("showResources=false drops resources without rendering", async () => {
   const images: AgentImage[] = [];
   const client = makeClient({


### PR DESCRIPTION
## Summary
- route resolved image resource links through the native image pipeline
- keep non-image resources and showImages=false behavior on the file path
- cover standard and Copilot rawOutput resource_link image cases with regression tests

## Tests
- npm test -- --test-name-pattern "resource_link|blob resource|file exactly|showResources=false"
- npm run build