### PR TITLE
feat: resume ACP sessions after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Add opt-in ACP session persistence across bridge restarts. Configure
+  `session.resume` or pass `--session-resume <off|auto|required>`. The bridge
+  checks the agent's advertised `loadSession` capability at runtime, restores
+  supported sessions with fresh MCP connections, and suppresses history replay
+  from being re-sent to WeChat. Preset identities remain stable across bundled
+  argument changes; raw agents are isolated by command, arguments, and cwd.
 - Add an opt-in standalone turn completion message so WeChat users can tell when a streamed or long-running ACP prompt has actually ended. Configure `session.turnEndMessage` or pass `--turn-end-message <text>`; the bridge sends the text after `prompt()` resolves and the turn's queued output has drained. Fixes #66.
 
 ## 0.10.0

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Options:
 - `--instance <name>`: run as a named, isolated instance. See "Running multiple instances" below.
 - `--idle-timeout <minutes>`: session idle timeout, default `1440` (use `0` for unlimited)
 - `--max-sessions <count>`: maximum concurrent user sessions, default `10`
+- `--session-resume <mode>`: persistence policy across bridge restarts: `off` (default), `auto`, or `required`
 - `--turn-end-message <text>`: send a standalone message after each completed agent turn (default: disabled)
 - `--inbox-dir <dir>`: directory where received binary files are saved (default: `<storage.dir>/inbox`). The agent sees the absolute saved path in the prompt and can read the file directly.
 - `--no-inbox`: do not save received files; the agent only sees a size notice.
@@ -163,10 +164,28 @@ Example:
   "session": {
     "idleTimeoutMs": 86400000,
     "maxConcurrentUsers": 10,
+    "resume": "auto",
     "turnEndMessage": "✅ Turn complete"
   }
 }
 ```
+
+`session.resume` controls whether each WeChat user's ACP conversation is
+restored after the bridge restarts:
+
+- `off` keeps the existing behavior and always starts a new ACP session.
+- `auto` loads a saved session when the agent advertises the ACP
+  `loadSession` capability. It starts a new session when loading is unsupported
+  or the saved session no longer exists, but surfaces other load failures.
+- `required` requires an existing saved session to load successfully. A user
+  without a saved session can still start their first conversation.
+
+Session IDs are saved only after the first prompt completes. Loading replays
+history at the ACP protocol level, but the bridge suppresses that replay so old
+messages are not sent to WeChat again. Sessions are isolated by agent and
+absolute working directory: built-in presets use their stable preset ID, while
+raw agents use their command and arguments. Environment variables are never
+stored or included in the identity.
 
 `session.turnEndMessage` is optional. When set to a non-empty string, the
 bridge sends it as a standalone WeChat message after the ACP prompt resolves
@@ -238,6 +257,7 @@ Notes:
 ## Runtime Behavior
 
 - Each WeChat user gets a dedicated ACP session and subprocess.
+- With session resume enabled, persisted sessions can survive subprocess and bridge restarts.
 - Messages are processed serially per user.
 - Replies are formatted for WeChat before sending.
 - Typing indicators are sent when supported by the WeChat API.

--- a/bin/wechat-acp.ts
+++ b/bin/wechat-acp.ts
@@ -22,6 +22,7 @@ import {
   defaultConfig,
   defaultStorageDir,
   listBuiltInAgents,
+  parseSessionResumePolicy,
   resolveAgentSelection,
   validateCommandAliases,
   validateInstanceName,
@@ -75,6 +76,9 @@ Options:
   --idle-timeout <m>  Session idle timeout in minutes (default: 1440)
                       Use 0 to disable idle cleanup
   --max-sessions <n>  Max concurrent user sessions (default: 10)
+  --session-resume <mode>
+                      Resume ACP sessions after restart: off, auto, or required
+                      (default: off)
   --turn-end-message <text>
                       Send a standalone message after each completed agent turn
   --hide-thoughts     Do not forward agent thinking to WeChat (default: forwarded)
@@ -135,6 +139,7 @@ function parseArgs(argv: string[]): {
   disableInbox: boolean;
   idleTimeout?: number;
   maxSessions?: number;
+  sessionResume?: string;
   turnEndMessage?: string;
   injectText?: string;
   injectFile?: string;
@@ -204,6 +209,9 @@ function parseArgs(argv: string[]): {
         break;
       case "--max-sessions":
         result.maxSessions = parseInt(args[++i], 10);
+        break;
+      case "--session-resume":
+        result.sessionResume = args[++i];
         break;
       case "--turn-end-message":
         result.turnEndMessage = args[++i];
@@ -503,7 +511,7 @@ async function main(): Promise<void> {
     }
   }
 
-  if (args.cwd) config.agent.cwd = path.resolve(args.cwd);
+  config.agent.cwd = path.resolve(args.cwd ?? config.agent.cwd);
   if (args.idleTimeout !== undefined) {
     if (!Number.isFinite(args.idleTimeout) || args.idleTimeout < 0) {
       console.error("Error: invalid --idle-timeout value");
@@ -513,6 +521,14 @@ async function main(): Promise<void> {
     config.session.idleTimeoutMs = args.idleTimeout * 60_000;
   }
   if (args.maxSessions) config.session.maxConcurrentUsers = args.maxSessions;
+  try {
+    config.session.resume = parseSessionResumePolicy(
+      args.sessionResume ?? config.session.resume,
+    );
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
+    process.exit(1);
+  }
   if (args.turnEndMessage !== undefined) {
     config.session.turnEndMessage = args.turnEndMessage;
   }

--- a/src/acp/agent-manager.ts
+++ b/src/acp/agent-manager.ts
@@ -7,13 +7,17 @@ import { Writable, Readable } from "node:stream";
 import * as acp from "@agentclientprotocol/sdk";
 import packageJson from "../../package.json" with { type: "json" };
 import type { WeChatAcpClient } from "./client.js";
+import type { SessionResumePolicy } from "../config.js";
 import { trackException } from "../telemetry/index.js";
+
+export type AgentSessionOutcome = "new" | "loaded" | "unsupported" | "not_found";
 
 export interface AgentProcessInfo {
   process: ChildProcess;
   connection: acp.ClientSideConnection;
   sessionId: string;
   configOptions: acp.SessionConfigOption[];
+  sessionOutcome: AgentSessionOutcome;
 }
 
 export async function spawnAgent(params: {
@@ -23,10 +27,23 @@ export async function spawnAgent(params: {
   env?: Record<string, string>;
   client: WeChatAcpClient;
   mcpServers?: acp.McpServer[];
+  resumePolicy?: SessionResumePolicy;
+  persistedSessionId?: string;
   signal?: AbortSignal;
   log: (msg: string) => void;
 }): Promise<AgentProcessInfo> {
-  const { command, args, cwd, env, client, mcpServers = [], signal, log } = params;
+  const {
+    command,
+    args,
+    cwd,
+    env,
+    client,
+    mcpServers = [],
+    resumePolicy = "off",
+    persistedSessionId,
+    signal,
+    log,
+  } = params;
   if (signal?.aborted) {
     throw new Error("Agent spawn aborted");
   }
@@ -89,7 +106,7 @@ export async function spawnAgent(params: {
     );
     log(`ACP initialized (protocol v${initResult.protocolVersion})`);
 
-    // Create session
+    // Create or load session
     const supportsHttpMcp = initResult.agentCapabilities?.mcpCapabilities?.http === true;
     const sessionMcpServers = supportsHttpMcp
       ? mcpServers.filter(
@@ -100,6 +117,49 @@ export async function spawnAgent(params: {
     if (mcpServers.length > 0 && !supportsHttpMcp) {
       log("Agent does not advertise HTTP MCP support; file attachments are unavailable");
     }
+
+    let sessionOutcome: AgentSessionOutcome = "new";
+    if (persistedSessionId && resumePolicy !== "off") {
+      if (initResult.agentCapabilities?.loadSession !== true) {
+        if (resumePolicy === "required") {
+          throw new Error(
+            `Agent does not support loading persisted ACP session ${persistedSessionId}`,
+          );
+        }
+        sessionOutcome = "unsupported";
+        log("Agent does not advertise session/load; creating a new ACP session");
+      } else {
+        log(`Loading ACP session: ${persistedSessionId}`);
+        client.beginSessionReplay();
+        try {
+          const loadResult = await abortable(
+            connection.loadSession({
+              cwd,
+              mcpServers: sessionMcpServers,
+              sessionId: persistedSessionId,
+            }),
+            signal,
+          );
+          await client.endSessionReplay();
+          log(`ACP session loaded: ${persistedSessionId}`);
+          return {
+            process: proc,
+            connection,
+            sessionId: persistedSessionId,
+            configOptions: loadResult.configOptions ?? [],
+            sessionOutcome: "loaded",
+          };
+        } catch (err) {
+          await client.endSessionReplay();
+          if (resumePolicy !== "auto" || !isResourceNotFound(err)) {
+            throw normalizeError(err);
+          }
+          sessionOutcome = "not_found";
+          log(`Persisted ACP session not found: ${persistedSessionId}; creating a new session`);
+        }
+      }
+    }
+
     log("Creating ACP session...");
     const sessionResult = await abortable(
       connection.newSession({
@@ -115,12 +175,35 @@ export async function spawnAgent(params: {
       connection,
       sessionId: sessionResult.sessionId,
       configOptions: sessionResult.configOptions ?? [],
+      sessionOutcome,
     };
   } catch (err) {
     killAgent(proc);
     throw err;
   } finally {
     signal?.removeEventListener("abort", abortSpawn);
+  }
+
+  function isResourceNotFound(err: unknown): boolean {
+    return (
+      typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      err.code === -32002
+    );
+  }
+
+  function normalizeError(err: unknown): Error {
+    if (err instanceof Error) return err;
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "message" in err &&
+      typeof err.message === "string"
+    ) {
+      return new Error(err.message, { cause: err });
+    }
+    return new Error(String(err), { cause: err });
   }
 }
 

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -311,6 +311,7 @@ export class WeChatAcpClient implements acp.Client {
   // Per-turn mutable state (callbacks, buffers, flags). Swapped wholesale by
   // beginTurn; queued tasks operate on the turn object captured at arrival.
   private turn: TurnState;
+  private suppressSessionUpdates = false;
   // FIFO task queue serializing all session-notification handling and flush()
   // reads. The ACP SDK dispatches notifications without awaiting handlers, so
   // without this two sessionUpdate calls interleave at their first await:
@@ -379,6 +380,22 @@ export class WeChatAcpClient implements acp.Client {
     });
   }
 
+  beginSessionReplay(): void {
+    this.suppressSessionUpdates = true;
+  }
+
+  /**
+   * Wait for all replay notifications to drain before accepting live updates.
+   * ACP requires `session/load` to replay history, which must not be forwarded
+   * to WeChat as if it were new agent output.
+   */
+  async endSessionReplay(): Promise<void> {
+    return this.enqueue(async () => {
+      this.suppressSessionUpdates = false;
+      this.turn = freshTurn(this.turn.opts);
+    });
+  }
+
   async requestPermission(
     params: acp.RequestPermissionRequest,
   ): Promise<acp.RequestPermissionResponse> {
@@ -420,7 +437,10 @@ export class WeChatAcpClient implements acp.Client {
     // guarantees it reads and writes the state of the turn it belongs to,
     // never the next turn's buffers or callbacks (issue 54).
     const turn = this.turn;
-    return this.enqueue(() => this.handleSessionUpdate(params, turn));
+    const suppressed = this.suppressSessionUpdates;
+    return this.enqueue(() =>
+      suppressed ? Promise.resolve() : this.handleSessionUpdate(params, turn),
+    );
   }
 
   private async handleSessionUpdate(

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -15,6 +15,7 @@ import {
 } from "./client.js";
 import type { AgentResourceLink } from "../artifacts/types.js";
 import { spawnAgent, killAgent, type AgentProcessInfo } from "./agent-manager.js";
+import type { SessionResumePolicy } from "../config.js";
 import { trackEvent, trackException, hashUserId } from "../telemetry/index.js";
 
 /**
@@ -56,6 +57,7 @@ export interface UserSession {
   configOptions: acp.SessionConfigOption[];
   queue: PendingMessage[];
   processing: boolean;
+  sessionIdPersisted?: boolean;
   lastActivity: number;
   createdAt: number;
 }
@@ -73,6 +75,10 @@ export interface SessionManagerOpts {
   agentPreset?: string;
   idleTimeoutMs: number;
   maxConcurrentUsers: number;
+  resumePolicy?: SessionResumePolicy;
+  getPersistedSessionId?: (userId: string) => Promise<string | undefined>;
+  persistSessionId?: (userId: string, sessionId: string) => Promise<void>;
+  removePersistedSessionId?: (userId: string) => Promise<void>;
   turnEndMessage?: string;
   showThoughts: boolean;
   showDiffs?: boolean;
@@ -143,9 +149,23 @@ export class SessionManager {
       throw new Error("Session manager is stopped");
     }
 
-    const session =
-      this.sessions.get(userId) ??
-      (await this.getOrCreateSession(userId, message.contextToken));
+    let session: UserSession;
+    try {
+      session =
+        this.sessions.get(userId) ??
+        (await this.getOrCreateSession(userId, message.contextToken));
+    } catch (err) {
+      try {
+        await this.opts.onReply(
+          userId,
+          message.contextToken,
+          `⚠️ Agent session error: ${errorMessage(err)}`,
+        );
+      } catch (replyErr) {
+        this.opts.log(`[${userId}] Failed to send session error: ${String(replyErr)}`);
+      }
+      throw err;
+    }
 
     // Always update contextToken to the latest
     session.contextToken = message.contextToken;
@@ -158,6 +178,19 @@ export class SessionManager {
       this.processQueue(session).catch((err) => {
         this.opts.log(`[${userId}] queue processing error: ${String(err)}`);
       });
+    }
+
+    function errorMessage(err: unknown): string {
+      if (err instanceof Error) return err.message;
+      if (
+        typeof err === "object" &&
+        err !== null &&
+        "message" in err &&
+        typeof err.message === "string"
+      ) {
+        return err.message;
+      }
+      return String(err);
     }
   }
 
@@ -344,6 +377,11 @@ export class SessionManager {
     });
 
     const mcpLease = this.opts.createMcpLease?.();
+    const resumePolicy = this.opts.resumePolicy ?? "off";
+    const persistedSessionId =
+      resumePolicy === "off"
+        ? undefined
+        : await this.opts.getPersistedSessionId?.(userId);
     let agentInfo: AgentProcessInfo;
     try {
       agentInfo = await spawnAgent({
@@ -353,6 +391,8 @@ export class SessionManager {
         env: this.opts.agentEnv,
         client,
         mcpServers: mcpLease ? [mcpLease.mcpServer] : [],
+        resumePolicy,
+        persistedSessionId,
         signal: this.creationAbortController.signal,
         log: (msg) => this.opts.log(`[${userId}] ${msg}`),
       });
@@ -361,12 +401,22 @@ export class SessionManager {
       throw err;
     }
 
+    if (agentInfo.sessionOutcome === "not_found") {
+      try {
+        await this.opts.removePersistedSessionId?.(userId);
+      } catch (err) {
+        this.opts.log(`[${userId}] Failed to remove invalid persisted session: ${String(err)}`);
+        trackException(err, "session.persistence", hashUserId(userId));
+      }
+    }
+
     trackEvent(
       "session.created",
       {
         userIdHash: hashUserId(userId),
         agentPreset: this.opts.agentPreset ?? "raw",
         activeSessions: this.sessions.size + 1,
+        sessionOutcome: agentInfo.sessionOutcome,
       },
       hashUserId(userId),
     );
@@ -393,6 +443,7 @@ export class SessionManager {
       configOptions: agentInfo.configOptions,
       queue: [],
       processing: false,
+      sessionIdPersisted: agentInfo.sessionOutcome === "loaded",
       lastActivity: Date.now(),
       createdAt: Date.now(),
     };
@@ -445,6 +496,7 @@ export class SessionManager {
             sessionId: session.agentInfo.sessionId,
             prompt: pending.prompt,
           });
+          await this.persistSessionId(session);
 
           // Collect accumulated text
           let replyText = await session.client.flush();
@@ -595,6 +647,18 @@ export class SessionManager {
   private rejectQueuedCompletions(session: UserSession, err: unknown): void {
     for (const pending of session.queue.splice(0)) {
       pending.completion?.reject(err);
+    }
+  }
+
+  private async persistSessionId(session: UserSession): Promise<void> {
+    if (session.sessionIdPersisted || !this.opts.persistSessionId) return;
+    try {
+      await this.opts.persistSessionId(session.userId, session.agentInfo.sessionId);
+      session.sessionIdPersisted = true;
+      this.opts.log(`[${session.userId}] Persisted ACP session ${session.agentInfo.sessionId}`);
+    } catch (err) {
+      this.opts.log(`[${session.userId}] Failed to persist ACP session: ${String(err)}`);
+      trackException(err, "session.persistence", hashUserId(session.userId));
     }
   }
 }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -24,10 +24,21 @@ import {
 import { sanitizeFileName } from "./artifacts/store.js";
 import { weixinMessageToPrompt } from "./adapter/inbound.js";
 import type { WeChatAcpConfig } from "./config.js";
-import { BRIDGE_COMMANDS, resolveCommandAliases, resolveCommandNames } from "./config.js";
+import {
+  BRIDGE_COMMANDS,
+  buildAgentSessionScope,
+  resolveCommandAliases,
+  resolveCommandNames,
+} from "./config.js";
 import { InjectionMonitor } from "./inject/monitor.js";
 import type { InjectedMessage } from "./inject/types.js";
-import { resolveUserTarget, updateLastActiveUser } from "./storage/state.js";
+import {
+  getPersistedSessionId,
+  removePersistedSession,
+  resolveUserTarget,
+  updateLastActiveUser,
+  updatePersistedSession,
+} from "./storage/state.js";
 import { trackEvent, trackException, hashUserId } from "./telemetry/index.js";
 
 const ACP_CONFIG_COMMAND = BRIDGE_COMMANDS.acpConfig;
@@ -142,6 +153,12 @@ export class WeChatAcpBridge {
           trackException(err, "artifact_mcp");
         }
       }
+      const resumePolicy = this.config.session.resume ?? "off";
+      if (resumePolicy !== "off" && !this.config.storage.stateFile) {
+        throw new Error("Session resume requires storage.stateFile");
+      }
+      const sessionScope = buildAgentSessionScope(this.config.agent);
+      const stateFile = this.config.storage.stateFile;
       this.sessionManager = new SessionManager({
         agentCommand: this.config.agent.command,
         agentArgs: this.config.agent.args,
@@ -150,6 +167,28 @@ export class WeChatAcpBridge {
         agentPreset: this.config.agent.preset ?? "raw",
         idleTimeoutMs: this.config.session.idleTimeoutMs,
         maxConcurrentUsers: this.config.session.maxConcurrentUsers,
+        resumePolicy,
+        getPersistedSessionId:
+          resumePolicy !== "off" && stateFile
+            ? async (userId) => {
+                await this.stateUpdate.catch(() => {});
+                return getPersistedSessionId(stateFile, userId, sessionScope);
+              }
+            : undefined,
+        persistSessionId:
+          resumePolicy !== "off" && stateFile
+            ? (userId, sessionId) =>
+                this.enqueueStateUpdate(() =>
+                  updatePersistedSession(stateFile, userId, sessionScope, sessionId),
+                )
+            : undefined,
+        removePersistedSessionId:
+          resumePolicy !== "off" && stateFile
+            ? (userId) =>
+                this.enqueueStateUpdate(() =>
+                  removePersistedSession(stateFile, userId, sessionScope),
+                )
+            : undefined,
         turnEndMessage: this.config.session.turnEndMessage,
         showThoughts: this.config.agent.showThoughts,
         showDiffs: this.config.agent.showDiffs ?? false,
@@ -647,13 +686,19 @@ export class WeChatAcpBridge {
 
   private rememberActiveUser(userId: string, contextToken: string): void {
     if (!this.config.storage.stateFile) return;
-    this.stateUpdate = this.stateUpdate
-      .catch(() => {})
-      .then(() => updateLastActiveUser(this.config.storage.stateFile!, userId, contextToken));
-    this.stateUpdate.catch((err) => {
+    const update = this.enqueueStateUpdate(() =>
+      updateLastActiveUser(this.config.storage.stateFile!, userId, contextToken),
+    );
+    update.catch((err) => {
       this.log(`Failed to persist last active user: ${String(err)}`);
       trackException(sanitizeStateError(err), "state", hashUserId(userId));
     });
+  }
+
+  private enqueueStateUpdate(update: () => Promise<void>): Promise<void> {
+    const pending = this.stateUpdate.catch(() => {}).then(update);
+    this.stateUpdate = pending;
+    return pending;
   }
 
   private async sendReply(userId: string, contextToken: string, text: string): Promise<void> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,9 @@
 
 import path from "node:path";
 import os from "node:os";
+import crypto from "node:crypto";
+
+export type SessionResumePolicy = "off" | "auto" | "required";
 
 export interface AgentCommandConfig {
   command: string;
@@ -152,6 +155,12 @@ export interface WeChatAcpConfig {
     idleTimeoutMs: number;
     maxConcurrentUsers: number;
     /**
+     * Whether persisted ACP sessions should be loaded after bridge restarts.
+     * `auto` falls back to a new session only when loading is unsupported or
+     * the saved session no longer exists. `required` rejects those fallbacks.
+     */
+    resume?: SessionResumePolicy;
+    /**
      * Optional standalone message sent after an ACP prompt turn completes.
      * Omit or set to an empty string to disable the completion indicator.
      */
@@ -229,6 +238,7 @@ export function defaultConfig(opts?: { instance?: string }): WeChatAcpConfig {
     session: {
       idleTimeoutMs: 1440 * 60_000, // 24 hours
       maxConcurrentUsers: 10,
+      resume: "off",
     },
     daemon: {
       enabled: false,
@@ -243,6 +253,35 @@ export function defaultConfig(opts?: { instance?: string }): WeChatAcpConfig {
       inboxDir: path.join(storageDir, "inbox"),
     },
   };
+}
+
+export function parseSessionResumePolicy(value: unknown): SessionResumePolicy {
+  if (value === "off" || value === "auto" || value === "required") {
+    return value;
+  }
+  throw new Error(
+    `Invalid session resume policy: ${JSON.stringify(value)}. ` +
+      'Expected "off", "auto", or "required".',
+  );
+}
+
+/**
+ * Build a stable, opaque key for persisted sessions. Preset identities stay
+ * stable when bundled command arguments evolve; raw commands intentionally
+ * treat any command-line change as a different agent configuration.
+ */
+export function buildAgentSessionScope(
+  agent: Pick<WeChatAcpConfig["agent"], "preset" | "command" | "args" | "cwd">,
+): string {
+  const cwd = path.resolve(agent.cwd);
+  const identity = agent.preset
+    ? { kind: "preset", id: agent.preset, cwd }
+    : { kind: "raw", command: agent.command, args: agent.args, cwd };
+  const digest = crypto
+    .createHash("sha256")
+    .update(JSON.stringify(identity))
+    .digest("hex");
+  return `v1:${digest}`;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,15 +7,18 @@ export type {
 	AgentCommandConfig,
 	AgentPreset,
 	ResolvedAgentConfig,
+	SessionResumePolicy,
 	WeChatAcpConfig,
 } from "./config.js";
 export {
 	BUILT_IN_AGENTS,
 	BRIDGE_COMMANDS,
+	buildAgentSessionScope,
 	defaultConfig,
 	defaultStorageDir,
 	listBuiltInAgents,
 	parseAgentCommand,
+	parseSessionResumePolicy,
 	resolveAgentSelection,
 	resolveCommandAliases,
 	resolveCommandNames,

--- a/src/storage/state.ts
+++ b/src/storage/state.ts
@@ -8,6 +8,12 @@ const MAX_STORED_USERS = 100;
 export interface UserState {
   contextToken: string;
   lastSeenAt: string;
+  sessions?: Record<string, PersistedSessionState>;
+}
+
+export interface PersistedSessionState {
+  sessionId: string;
+  savedAt: string;
 }
 
 export interface BridgeState {
@@ -48,15 +54,74 @@ export async function updateLastActiveUser(
   contextToken: string,
 ): Promise<void> {
   const state = await loadState(stateFile);
+  const existing = state.users?.[userId];
   state.lastActiveUserId = userId;
   state.users = {
     ...(state.users ?? {}),
     [userId]: {
+      ...existing,
       contextToken,
       lastSeenAt: new Date().toISOString(),
     },
   };
   state.users = pruneUsers(state.users);
+  await saveState(stateFile, state);
+}
+
+export async function getPersistedSessionId(
+  stateFile: string,
+  userId: string,
+  scope: string,
+): Promise<string | undefined> {
+  const state = await loadState(stateFile);
+  return state.users?.[userId]?.sessions?.[scope]?.sessionId;
+}
+
+export async function updatePersistedSession(
+  stateFile: string,
+  userId: string,
+  scope: string,
+  sessionId: string,
+): Promise<void> {
+  const state = await loadState(stateFile);
+  const existing = state.users?.[userId];
+  if (!existing) {
+    throw new Error(`Cannot persist ACP session for unknown user ${userId}`);
+  }
+  state.users = {
+    ...(state.users ?? {}),
+    [userId]: {
+      ...existing,
+      sessions: {
+        ...(existing.sessions ?? {}),
+        [scope]: {
+          sessionId,
+          savedAt: new Date().toISOString(),
+        },
+      },
+    },
+  };
+  await saveState(stateFile, state);
+}
+
+export async function removePersistedSession(
+  stateFile: string,
+  userId: string,
+  scope: string,
+): Promise<void> {
+  const state = await loadState(stateFile);
+  const existing = state.users?.[userId];
+  if (!existing?.sessions?.[scope]) return;
+
+  const sessions = { ...existing.sessions };
+  delete sessions[scope];
+  state.users = {
+    ...(state.users ?? {}),
+    [userId]: {
+      ...existing,
+      ...(Object.keys(sessions).length > 0 ? { sessions } : { sessions: undefined }),
+    },
+  };
   await saveState(stateFile, state);
 }
 

--- a/tests/agent-manager.test.ts
+++ b/tests/agent-manager.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { spawnAgent } from "../src/acp/agent-manager.js";
+import { killAgent } from "../src/acp/agent-manager.js";
 import { WeChatAcpClient } from "../src/acp/client.js";
 
 test("spawnAgent aborts an agent stuck during ACP initialization", async () => {
@@ -24,4 +25,194 @@ test("spawnAgent aborts an agent stuck during ACP initialization", async () => {
   setTimeout(() => controller.abort(), 25);
 
   await assert.rejects(spawning);
+});
+
+function fakeAgentScript(opts: {
+  loadSession: boolean;
+  loadErrorCode?: number;
+}): string {
+  return `
+    const readline = require("node:readline");
+    const rl = readline.createInterface({ input: process.stdin });
+    const send = (message) => process.stdout.write(JSON.stringify(message) + "\\n");
+    rl.on("line", (line) => {
+      const request = JSON.parse(line);
+      if (request.method === "initialize") {
+        send({
+          jsonrpc: "2.0",
+          id: request.id,
+          result: {
+            protocolVersion: 1,
+            agentCapabilities: { loadSession: ${opts.loadSession} },
+          },
+        });
+      } else if (request.method === "session/load") {
+        ${
+          opts.loadErrorCode === undefined
+            ? `
+        send({
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: {
+            sessionId: request.params.sessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: "historical reply" },
+            },
+          },
+        });
+        send({
+          jsonrpc: "2.0",
+          id: request.id,
+          result: { configOptions: [] },
+        });`
+            : `
+        send({
+          jsonrpc: "2.0",
+          id: request.id,
+          error: { code: ${opts.loadErrorCode}, message: "load failed" },
+        });`
+        }
+      } else if (request.method === "session/new") {
+        send({
+          jsonrpc: "2.0",
+          id: request.id,
+          result: { sessionId: "new-session", configOptions: [] },
+        });
+      }
+    });
+  `;
+}
+
+function makeClient(messages: string[]): WeChatAcpClient {
+  return new WeChatAcpClient({
+    sendTyping: async () => {},
+    onThoughtFlush: async () => {},
+    onMessageFlush: async (text) => {
+      messages.push(text);
+    },
+    log: () => {},
+    showThoughts: false,
+  });
+}
+
+test("spawnAgent loads a supported persisted session without forwarding replay", async () => {
+  const messages: string[] = [];
+  const info = await spawnAgent({
+    command: process.execPath,
+    args: ["-e", fakeAgentScript({ loadSession: true })],
+    cwd: process.cwd(),
+    client: makeClient(messages),
+    resumePolicy: "auto",
+    persistedSessionId: "saved-session",
+    log: () => {},
+  });
+
+  try {
+    assert.equal(info.sessionId, "saved-session");
+    assert.equal(info.sessionOutcome, "loaded");
+    assert.deepEqual(messages, []);
+  } finally {
+    killAgent(info.process);
+  }
+});
+
+test("spawnAgent auto mode creates a session when loading is unsupported", async () => {
+  const info = await spawnAgent({
+    command: process.execPath,
+    args: ["-e", fakeAgentScript({ loadSession: false })],
+    cwd: process.cwd(),
+    client: makeClient([]),
+    resumePolicy: "auto",
+    persistedSessionId: "saved-session",
+    log: () => {},
+  });
+
+  try {
+    assert.equal(info.sessionId, "new-session");
+    assert.equal(info.sessionOutcome, "unsupported");
+  } finally {
+    killAgent(info.process);
+  }
+});
+
+test("spawnAgent auto mode only falls back for resource-not-found", async () => {
+  const notFound = await spawnAgent({
+    command: process.execPath,
+    args: ["-e", fakeAgentScript({ loadSession: true, loadErrorCode: -32002 })],
+    cwd: process.cwd(),
+    client: makeClient([]),
+    resumePolicy: "auto",
+    persistedSessionId: "missing-session",
+    log: () => {},
+  });
+  try {
+    assert.equal(notFound.sessionOutcome, "not_found");
+    assert.equal(notFound.sessionId, "new-session");
+  } finally {
+    killAgent(notFound.process);
+  }
+
+  await assert.rejects(
+    spawnAgent({
+      command: process.execPath,
+      args: ["-e", fakeAgentScript({ loadSession: true, loadErrorCode: -32603 })],
+      cwd: process.cwd(),
+      client: makeClient([]),
+      resumePolicy: "auto",
+      persistedSessionId: "broken-session",
+      log: () => {},
+    }),
+    /load failed/,
+  );
+});
+
+test("spawnAgent required mode rejects an agent without session loading", async () => {
+  await assert.rejects(
+    spawnAgent({
+      command: process.execPath,
+      args: ["-e", fakeAgentScript({ loadSession: false })],
+      cwd: process.cwd(),
+      client: makeClient([]),
+      resumePolicy: "required",
+      persistedSessionId: "saved-session",
+      log: () => {},
+    }),
+    /does not support loading persisted ACP session/,
+  );
+});
+
+test("spawnAgent required mode allows a user's first session", async () => {
+  const info = await spawnAgent({
+    command: process.execPath,
+    args: ["-e", fakeAgentScript({ loadSession: false })],
+    cwd: process.cwd(),
+    client: makeClient([]),
+    resumePolicy: "required",
+    log: () => {},
+  });
+  try {
+    assert.equal(info.sessionId, "new-session");
+    assert.equal(info.sessionOutcome, "new");
+  } finally {
+    killAgent(info.process);
+  }
+});
+
+test("spawnAgent off mode ignores a persisted session", async () => {
+  const info = await spawnAgent({
+    command: process.execPath,
+    args: ["-e", fakeAgentScript({ loadSession: true })],
+    cwd: process.cwd(),
+    client: makeClient([]),
+    resumePolicy: "off",
+    persistedSessionId: "saved-session",
+    log: () => {},
+  });
+  try {
+    assert.equal(info.sessionId, "new-session");
+    assert.equal(info.sessionOutcome, "new");
+  } finally {
+    killAgent(info.process);
+  }
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildAgentSessionScope,
+  parseSessionResumePolicy,
+} from "../src/config.js";
+
+test("preset session scope ignores bundled command changes", () => {
+  const first = buildAgentSessionScope({
+    preset: "copilot",
+    command: "npx",
+    args: ["@github/copilot", "--acp"],
+    cwd: ".",
+  });
+  const second = buildAgentSessionScope({
+    preset: "copilot",
+    command: "copilot",
+    args: ["--acp", "--new-default"],
+    cwd: ".",
+  });
+
+  assert.equal(first, second);
+});
+
+test("raw agent session scope includes command, args, and cwd", () => {
+  const base = {
+    command: "agent",
+    args: ["--acp"],
+    cwd: ".",
+  };
+  assert.notEqual(
+    buildAgentSessionScope(base),
+    buildAgentSessionScope({ ...base, args: ["--acp", "--other"] }),
+  );
+  assert.notEqual(
+    buildAgentSessionScope(base),
+    buildAgentSessionScope({ ...base, cwd: ".." }),
+  );
+});
+
+test("session resume policy accepts only documented modes", () => {
+  assert.equal(parseSessionResumePolicy("off"), "off");
+  assert.equal(parseSessionResumePolicy("auto"), "auto");
+  assert.equal(parseSessionResumePolicy("required"), "required");
+  assert.throws(() => parseSessionResumePolicy("yes"), /Invalid session resume policy/);
+});

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -35,6 +35,7 @@ test("concurrent session creation reserves maxConcurrentUsers capacity", async (
         connection: {} as never,
         sessionId: userId,
         configOptions: [],
+        sessionOutcome: "new",
       },
       configOptions: [],
       queue: [],
@@ -70,6 +71,7 @@ test("SessionManager.stop waits for every MCP lease before reporting failures", 
     onReply: async () => {},
     sendTyping: async () => {},
   });
+
   const events: string[] = [];
   const sessions = (
     manager as unknown as { sessions: Map<string, UserSession> }
@@ -86,6 +88,7 @@ test("SessionManager.stop waits for every MCP lease before reporting failures", 
       connection: {} as never,
       sessionId: userId,
       configOptions: [],
+      sessionOutcome: "new",
     },
     mcpLease: { mcpServer: {} as never, close },
     configOptions: [],
@@ -118,6 +121,37 @@ test("SessionManager.stop waits for every MCP lease before reporting failures", 
     "second-start",
     "first-failed",
     "second-finished",
+  ]);
+});
+
+test("session creation failures are surfaced to the WeChat user", async () => {
+  const replies: string[] = [];
+  const manager = new SessionManager({
+    agentCommand: "unused",
+    agentArgs: [],
+    agentCwd: process.cwd(),
+    idleTimeoutMs: 0,
+    maxConcurrentUsers: 1,
+    showThoughts: false,
+    log: () => {},
+    onReply: async (_userId, _contextToken, text) => {
+      replies.push(text);
+    },
+    sendTyping: async () => {},
+  });
+  const internal = manager as unknown as {
+    createSession(userId: string, contextToken: string): Promise<UserSession>;
+  };
+  internal.createSession = async () => {
+    throw new Error("persisted session could not be loaded");
+  };
+
+  await assert.rejects(
+    manager.enqueue("user-1", { prompt: [], contextToken: "context-1" }),
+    /persisted session could not be loaded/,
+  );
+  assert.deepEqual(replies, [
+    "⚠️ Agent session error: persisted session could not be loaded",
   ]);
 });
 
@@ -154,6 +188,7 @@ function makeTurnSession(opts: {
       } as never,
       sessionId: "session-1",
       configOptions: [],
+      sessionOutcome: "new",
     },
     configOptions: [],
     queue: [{
@@ -355,6 +390,7 @@ test("turn end message delivery failure does not fail a completed prompt", async
     },
     sendTyping: async () => {},
   });
+
   const session = makeTurnSession({
     flushText: "Final answer",
     producedMessage: true,
@@ -384,4 +420,35 @@ test("turn end message delivery failure does not fail a completed prompt", async
     logs.some((message) => message.includes("Agent prompt error")),
     false,
   );
+});
+
+test("a new ACP session is persisted after its first completed prompt", async () => {
+  const persisted: string[] = [];
+  const manager = new SessionManager({
+    agentCommand: "unused",
+    agentArgs: [],
+    agentCwd: process.cwd(),
+    idleTimeoutMs: 0,
+    maxConcurrentUsers: 1,
+    resumePolicy: "auto",
+    persistSessionId: async (userId, sessionId) => {
+      persisted.push(`${userId}:${sessionId}`);
+    },
+    showThoughts: false,
+    log: () => {},
+    onReply: async () => {},
+    sendTyping: async () => {},
+  });
+  const session = makeTurnSession({
+    flushText: "Done",
+    producedMessage: true,
+    events: [],
+  });
+
+  await (
+    manager as unknown as { processQueue(session: UserSession): Promise<void> }
+  ).processQueue(session);
+
+  assert.deepEqual(persisted, ["user-1:session-1"]);
+  assert.equal(session.sessionIdPersisted, true);
 });

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  getPersistedSessionId,
+  loadState,
+  removePersistedSession,
+  updateLastActiveUser,
+  updatePersistedSession,
+} from "../src/storage/state.js";
+
+test("session persistence preserves user routing state and supports removal", async (t) => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "wechat-acp-state-"));
+  t.after(() => fs.rm(dir, { recursive: true, force: true }));
+  const stateFile = path.join(dir, "state.json");
+
+  await updateLastActiveUser(stateFile, "user-1", "context-1");
+  await updatePersistedSession(stateFile, "user-1", "scope-1", "session-1");
+  await updateLastActiveUser(stateFile, "user-1", "context-2");
+
+  assert.equal(
+    await getPersistedSessionId(stateFile, "user-1", "scope-1"),
+    "session-1",
+  );
+  const state = await loadState(stateFile);
+  assert.equal(state.users?.["user-1"]?.contextToken, "context-2");
+  assert.ok(state.users?.["user-1"]?.sessions?.["scope-1"]?.savedAt);
+
+  await removePersistedSession(stateFile, "user-1", "scope-1");
+  assert.equal(
+    await getPersistedSessionId(stateFile, "user-1", "scope-1"),
+    undefined,
+  );
+  assert.equal((await loadState(stateFile)).users?.["user-1"]?.contextToken, "context-2");
+});
+
+test("persisting a session requires an existing user record", async (t) => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "wechat-acp-state-"));
+  t.after(() => fs.rm(dir, { recursive: true, force: true }));
+  const stateFile = path.join(dir, "state.json");
+
+  await assert.rejects(
+    updatePersistedSession(stateFile, "unknown", "scope", "session"),
+    /unknown user/,
+  );
+});


### PR DESCRIPTION
## Summary

- add opt-in `off`, `auto`, and `required` session resume policies through CLI and JSON config
- persist per-user ACP session IDs with stable preset/raw-agent scopes and negotiate `loadSession` support at runtime
- suppress ACP history replay during restore, reconnect fresh MCP leases, and surface non-recoverable load failures to WeChat

## Behavior

- defaults to `off` for backward compatibility
- `auto` falls back only when loading is unsupported or the saved session no longer exists
- `required` permits a user's first session but never silently replaces an existing saved session
- preset scopes use preset ID + absolute cwd; raw scopes use command + args + absolute cwd

## Validation

- TypeScript build
- full test suite (134 tests)
- real Copilot ACP cross-process `session/load` smoke test with zero replay messages delivered