### PR TITLE
Add /acp-more pending text fetch command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Add `/acp-more` to re-deliver text segments that iLink rejected after normal
+  retries. Pending segments expire after 10 minutes, drain in order on the
+  existing per-user send chain, stop on the first persistent fetch failure, and
+  are cleared by a newer real agent prompt. The command and aliases such as
+  `"/acp-fetch-msg"` or `"."` are intercepted without creating an ACP turn.
+  This covers reported text send failures only; successful sends that iLink
+  silently drops cannot be detected. Fixes #45.
 - Add opt-in ACP session persistence across bridge restarts. Configure
   `session.resume` or pass `--session-resume <off|auto|required>`. The bridge
   checks the agent's advertised `loadSession` capability at runtime, restores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Add `/acp-more` to re-deliver text segments that iLink rejected after normal
   retries. Pending segments expire after 10 minutes, drain in order on the
   existing per-user send chain, stop on the first persistent fetch failure, and
-  are cleared by a newer real agent prompt. The command and aliases such as
-  `"/acp-fetch-msg"` or `"."` are intercepted without creating an ACP turn.
+  are cleared by a newer real agent prompt. Custom aliases, including bare
+  exact-match aliases, are intercepted without creating an ACP turn.
   This covers reported text send failures only; successful sends that iLink
   silently drops cannot be detected. Fixes #45.
 - Add opt-in ACP session persistence across bridge restarts. Configure

--- a/README.md
+++ b/README.md
@@ -224,8 +224,7 @@ command to one or more custom aliases via the `commandAliases` config map:
 {
   "commandAliases": {
     "/acp-cancel": ["/cancel", "/取消", "取消"],
-    "/acp-config": ["/config", "/设置"],
-    "/acp-more": ["/acp-fetch-msg", "."]
+    "/acp-config": ["/config", "/设置"]
   }
 }
 ```
@@ -282,8 +281,8 @@ retries. That segment and the remaining segments stay pending for the next
 in memory, limited to 50 text segments per active user, and does not include
 images, audio, or files.
 
-Aliases work through `commandAliases`. A bare alias such as `"."` must match the
-whole message, so it is intercepted before the normal ACP enqueue path.
+Aliases work through `commandAliases`. Bare aliases must match the whole
+message, so they are intercepted before the normal ACP enqueue path.
 
 This mitigation can only retain failures reported by iLink. If iLink returns
 success but silently drops a message, the bridge cannot detect or replay it.

--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ command to one or more custom aliases via the `commandAliases` config map:
 {
   "commandAliases": {
     "/acp-cancel": ["/cancel", "/取消", "取消"],
-    "/acp-config": ["/config", "/设置"]
+    "/acp-config": ["/config", "/设置"],
+    "/acp-more": ["/acp-fetch-msg", "."]
   }
 }
 ```
@@ -250,7 +251,7 @@ Two alias styles are supported:
 
 Notes:
 
-- Keys must be a known bridge command (`/acp-config`, `/acp-cancel`, `/acp-prompt-start`, or `/acp-prompt-done`).
+- Keys must be a known bridge command (`/acp-config`, `/acp-cancel`, `/acp-more`, `/acp-prompt-start`, or `/acp-prompt-done`).
 - An alias may not collide with a built-in command name or be mapped to
   more than one command. Invalid configs are rejected at startup.
 
@@ -262,6 +263,30 @@ Notes:
 - Replies are formatted for WeChat before sending.
 - Typing indicators are sent when supported by the WeChat API.
 - Sessions are cleaned up after inactivity (set `idleTimeoutMs` to `0` to disable idle cleanup).
+
+## Fetching text that iLink rejected
+
+WeChat iLink limits how many outbound messages can use one inbound context
+token. If a long agent reply reaches that limit and iLink reports send failures,
+the bridge keeps the failed text segments for 10 minutes. Send this command in
+a new WeChat message to deliver them with its fresh context token:
+
+```text
+/acp-more
+```
+
+The command is handled by the bridge and never becomes an ACP prompt. It sends
+pending segments in order and stops at the first segment that still fails after
+retries. That segment and the remaining segments stay pending for the next
+`/acp-more`. A new normal agent prompt clears older pending output. Storage is
+in memory, limited to 50 text segments per active user, and does not include
+images, audio, or files.
+
+Aliases work through `commandAliases`. A bare alias such as `"."` must match the
+whole message, so it is intercepted before the normal ACP enqueue path.
+
+This mitigation can only retain failures reported by iLink. If iLink returns
+success but silently drops a message, the bridge cannot detect or replay it.
 
 ## WeChat ACP config command
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -586,7 +586,7 @@ export class WeChatAcpBridge {
       return this.sendReply(userId, contextToken, `⚠️ Nothing buffered. Send ${BUFFER_START_COMMAND}${this.aliasHint(BUFFER_START_COMMAND)} first, then send messages before ${BUFFER_DONE_COMMAND}${this.aliasHint(BUFFER_DONE_COMMAND)}.`);
     }
 
-    this.beginAgentPrompt(userId, buffer.contextToken);
+    this.beginAgentPrompt(userId, contextToken);
 
     // Remove from map immediately so new messages during the await
     // are not appended to a stale buffer.
@@ -645,10 +645,15 @@ export class WeChatAcpBridge {
       hashUserId(userId),
     );
 
-    await this.sessionManager!.enqueue(userId, {
-      prompt: buffer.blocks,
-      contextToken: buffer.contextToken,
-    });
+    await this.enqueueBufferedPrompt(userId, contextToken, buffer.blocks);
+  }
+
+  protected async enqueueBufferedPrompt(
+    userId: string,
+    contextToken: string,
+    prompt: acp.ContentBlock[],
+  ): Promise<void> {
+    await this.sessionManager!.enqueue(userId, { prompt, contextToken });
   }
 
   private appendToBuffer(
@@ -688,7 +693,9 @@ export class WeChatAcpBridge {
         buffer.blocks.push(...prompt);
         buffer.contextToken = contextToken;
         buffer.lastUpdatedAt = Date.now();
-        this.resetBufferTimer(userId);
+        if (this.messageBuffers.has(userId)) {
+          this.resetBufferTimer(userId);
+        }
 
         this.log(`Buffered message from ${userId}, now ${buffer.blocks.length} block(s)`);
       });

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -27,9 +27,10 @@ import type { WeChatAcpConfig } from "./config.js";
 import {
   BRIDGE_COMMANDS,
   buildAgentSessionScope,
+  matchBridgeCommand,
   resolveCommandAliases,
-  resolveCommandNames,
 } from "./config.js";
+import { drainPendingText, PendingTextRegistry } from "./pending-text.js";
 import { InjectionMonitor } from "./inject/monitor.js";
 import type { InjectedMessage } from "./inject/types.js";
 import {
@@ -43,10 +44,13 @@ import { trackEvent, trackException, hashUserId } from "./telemetry/index.js";
 
 const ACP_CONFIG_COMMAND = BRIDGE_COMMANDS.acpConfig;
 const ACP_CANCEL_COMMAND = BRIDGE_COMMANDS.acpCancel;
+const ACP_MORE_COMMAND = BRIDGE_COMMANDS.acpMore;
 const BUFFER_START_COMMAND = BRIDGE_COMMANDS.promptStart;
 const BUFFER_DONE_COMMAND = BRIDGE_COMMANDS.promptDone;
 const BUFFER_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const BUFFER_MAX_BLOCKS = 50;
+const PENDING_TEXT_TTL_MS = 10 * 60 * 1000;
+const PENDING_TEXT_MAX_SEGMENTS = 50;
 const SEGMENT_SEND_MAX_ATTEMPTS = 3;
 const SEGMENT_SEND_RETRY_BASE_MS = 300;
 
@@ -77,6 +81,7 @@ export class WeChatAcpBridge {
   // (e.g. a command reply racing an active session flush) cannot interleave
   // their segments and arrive out of order (issue #38).
   private sendChains = new Map<string, Promise<void>>();
+  private pendingText: PendingTextRegistry;
   // Per-user message buffer for /acp-prompt-start.../acp-prompt-done multi-part compose
   private messageBuffers = new Map<string, {
     blocks: acp.ContentBlock[];
@@ -96,6 +101,11 @@ export class WeChatAcpBridge {
   constructor(config: WeChatAcpConfig, log?: (msg: string) => void) {
     this.config = config;
     this.log = log ?? ((msg: string) => console.log(`[wechat-acp] ${msg}`));
+    this.pendingText = new PendingTextRegistry({
+      ttlMs: PENDING_TEXT_TTL_MS,
+      maxUsers: Math.max(1, config.session.maxConcurrentUsers),
+      maxSegmentsPerUser: PENDING_TEXT_MAX_SEGMENTS,
+    });
   }
 
   async start(opts?: {
@@ -199,7 +209,7 @@ export class WeChatAcpBridge {
           ? () => this.artifactMcpServer!.createLease()
           : undefined,
         log: this.log,
-        onReply: (userId, contextToken, text) => this.sendReply(userId, contextToken, text),
+        onReply: (userId, contextToken, text) => this.sendAgentReply(userId, contextToken, text),
         onReplyImage: (userId, contextToken, image) => this.sendImageReply(userId, contextToken, image),
         onReplyAudio: (userId, contextToken, audio) => this.sendAudioReply(userId, contextToken, audio),
         onReplyFile: (userId, contextToken, file) => this.sendFileReply(userId, contextToken, file),
@@ -228,7 +238,12 @@ export class WeChatAcpBridge {
         storageDir: this.config.storage.dir,
         abortSignal: this.abortController.signal,
         log: this.log,
-        onMessage: (msg) => this.handleMessage(msg),
+        onMessage: (msg) => {
+          this.handleMessage(msg).catch((err) => {
+            this.log(`Failed to handle message: ${String(err)}`);
+            trackException(err, "message");
+          });
+        },
       });
     } catch (err) {
       try {
@@ -274,7 +289,7 @@ export class WeChatAcpBridge {
     }
   }
 
-  private handleMessage(msg: WeixinMessage): void {
+  async handleMessage(msg: WeixinMessage): Promise<void> {
     // Only process user messages (not bot's own messages)
     if (msg.message_type !== MessageType.USER) return;
 
@@ -299,19 +314,18 @@ export class WeChatAcpBridge {
 
     const acpConfigCommand = this.extractAcpConfigCommand(msg);
     if (acpConfigCommand) {
-      this.handleAcpConfigCommand(acpConfigCommand, userId, contextToken).catch((err) => {
-        this.log(`Failed to handle ACP config command from ${userId}: ${String(err)}`);
-        trackException(err, "command", hashUserId(userId));
-      });
+      await this.handleAcpConfigCommand(acpConfigCommand, userId, contextToken);
       return;
     }
 
     const acpCancelCommand = this.extractAcpCancelCommand(msg);
     if (acpCancelCommand) {
-      this.handleAcpCancelCommand(acpCancelCommand, userId, contextToken).catch((err) => {
-        this.log(`Failed to handle ACP cancel command from ${userId}: ${String(err)}`);
-        trackException(err, "command", hashUserId(userId));
-      });
+      await this.handleAcpCancelCommand(acpCancelCommand, userId, contextToken);
+      return;
+    }
+
+    if (this.extractBridgeCommand(msg, ACP_MORE_COMMAND)) {
+      await this.handleAcpMoreCommand(userId, contextToken);
       return;
     }
 
@@ -323,10 +337,7 @@ export class WeChatAcpBridge {
 
     // /acp-prompt-done — flush buffer and send to agent
     if (this.isBufferDoneCommand(msg)) {
-      this.handleBufferDone(userId, contextToken).catch((err) => {
-        this.log(`Failed to flush message buffer for ${userId}: ${String(err)}`);
-        trackException(err, "buffer", hashUserId(userId));
-      });
+      await this.handleBufferDone(userId, contextToken);
       return;
     }
 
@@ -336,18 +347,14 @@ export class WeChatAcpBridge {
       return;
     }
 
-    // Convert and enqueue — fire-and-forget (don't block the poll loop)
+    this.beginAgentPrompt(userId, contextToken);
     const waitForFlush = this.bufferFlushing.get(userId);
-    const enqueue = waitForFlush
+    await (waitForFlush
       ? waitForFlush.then(() => this.enqueueMessage(msg, userId, contextToken))
-      : this.enqueueMessage(msg, userId, contextToken);
-    enqueue.catch((err) => {
-      this.log(`Failed to enqueue message from ${userId}: ${String(err)}`);
-      trackException(err, "enqueue", hashUserId(userId));
-    });
+      : this.enqueueMessage(msg, userId, contextToken));
   }
 
-  private async enqueueMessage(
+  protected async enqueueMessage(
     msg: WeixinMessage,
     userId: string,
     contextToken: string,
@@ -368,6 +375,7 @@ export class WeChatAcpBridge {
     }
 
     const target = await resolveUserTarget(this.config.storage.stateFile, job.target, job.contextToken);
+    this.beginAgentPrompt(target.userId, target.contextToken);
     const prompt: acp.ContentBlock[] = [{ type: "text", text: job.text }];
     this.log(`[inject] enqueue ${job.id} for ${target.userId}`);
     trackEvent(
@@ -486,6 +494,30 @@ export class WeChatAcpBridge {
     await this.sendReply(userId, contextToken, this.formatAcpCancelResult(result, drainQueue));
   }
 
+  protected async handleAcpMoreCommand(userId: string, contextToken: string): Promise<void> {
+    return this.queueSendTask(userId, async () => {
+      const result = await drainPendingText(
+        this.pendingText,
+        userId,
+        (segment) => this.sendTextSegment(userId, contextToken, segment),
+      );
+      trackEvent(
+        "command.acp_more",
+        {
+          userIdHash: hashUserId(userId),
+          pendingCount: result.pendingCount,
+          sentCount: result.sentCount,
+          remainingCount: result.remainingCount,
+        },
+        hashUserId(userId),
+      );
+      if (result.pendingCount === 0) {
+        await this.sendTextSegment(userId, contextToken, "No pending messages right now.");
+      }
+      this.cancelTypingIndicator(userId, contextToken).catch(() => {});
+    });
+  }
+
   private formatAcpCancelResult(
     result: { cancelledTurn: boolean; droppedQueueCount: number },
     drainQueue: boolean,
@@ -553,6 +585,8 @@ export class WeChatAcpBridge {
     if (!buffer) {
       return this.sendReply(userId, contextToken, `⚠️ Nothing buffered. Send ${BUFFER_START_COMMAND}${this.aliasHint(BUFFER_START_COMMAND)} first, then send messages before ${BUFFER_DONE_COMMAND}${this.aliasHint(BUFFER_DONE_COMMAND)}.`);
     }
+
+    this.beginAgentPrompt(userId, buffer.contextToken);
 
     // Remove from map immediately so new messages during the await
     // are not appended to a stale buffer.
@@ -706,68 +740,58 @@ export class WeChatAcpBridge {
     // that segments from separate sendReply calls cannot interleave (issue #38).
     // The stored link swallows errors so one failed reply doesn't break the
     // chain for the next caller, while the returned promise still propagates.
-    const previous = this.sendChains.get(userId) ?? Promise.resolve();
-    const current = previous
-      .catch(() => {})
-      .then(() => this.deliverReply(userId, contextToken, text));
-    this.sendChains.set(
-      userId,
-      current.catch(() => {}),
+    return this.queueSendTask(userId, () => this.deliverReply(userId, contextToken, text));
+  }
+
+  protected beginAgentPrompt(userId: string, contextToken: string): void {
+    this.pendingText.supersede(userId, contextToken);
+  }
+
+  protected async sendAgentReply(
+    userId: string,
+    contextToken: string,
+    text: string,
+  ): Promise<void> {
+    const generation = this.pendingText.generationForContext(userId, contextToken);
+    return this.queueSendTask(userId, () =>
+      this.deliverReply(userId, contextToken, text, generation),
     );
+  }
+
+  private queueSendTask(userId: string, task: () => Promise<void>): Promise<void> {
+    const previous = this.sendChains.get(userId) ?? Promise.resolve();
+    const current = previous.catch(() => {}).then(task);
+    this.sendChains.set(userId, current.catch(() => {}));
     return current;
   }
 
-  private async deliverReply(userId: string, contextToken: string, text: string): Promise<void> {
+  private async deliverReply(
+    userId: string,
+    contextToken: string,
+    text: string,
+    generation?: number,
+  ): Promise<void> {
     const segments = splitText(text, TEXT_CHUNK_LIMIT);
     const startedAt = Date.now();
     let segmentsSent = 0;
-    let anyFailed = false;
+    const failedSegments: string[] = [];
 
     for (const segment of segments) {
-      // Generate one stable idempotency key per segment *before* the retry
-      // loop so that all attempts for the same segment reuse the same
-      // client_id. The iLink gateway de-duplicates by client_id, so a retry
-      // after a transient hard error (connection reset, 5xx) will not produce
-      // a duplicate message even if the first attempt was already received.
-      const segmentClientId = `wechat-acp-${crypto.randomUUID()}`;
-      let sent = false;
-
-      for (let attempt = 1; attempt <= SEGMENT_SEND_MAX_ATTEMPTS; attempt++) {
-        try {
-          await this.paceConsecutiveSend(userId);
-          await sendTextMessage(
-            userId,
-            segment,
-            {
-              baseUrl: this.tokenData!.baseUrl,
-              token: this.tokenData!.token,
-              contextToken,
-            },
-            segmentClientId,
-          );
-          sent = true;
-          break;
-        } catch (err) {
-          trackException(err, "reply.segment", hashUserId(userId));
-          if (attempt < SEGMENT_SEND_MAX_ATTEMPTS) {
-            await new Promise((r) => setTimeout(r, SEGMENT_SEND_RETRY_BASE_MS * attempt));
-          }
-        }
-      }
-
-      if (sent) {
+      if (await this.sendTextSegment(userId, contextToken, segment)) {
         segmentsSent++;
       } else {
-        // Log the drop but continue — a single failed segment must not
-        // prevent the remaining segments from being delivered.
-        anyFailed = true;
+        failedSegments.push(segment);
       }
     }
 
-    if (anyFailed) {
+    if (generation !== undefined) {
+      this.pendingText.recordFailures(userId, generation, failedSegments);
+    }
+
+    if (failedSegments.length > 0) {
       trackException(
         new Error(
-          `deliverReply: ${segments.length - segmentsSent}/${segments.length} segment(s) failed to send after retries`,
+          `deliverReply: ${failedSegments.length}/${segments.length} segment(s) failed to send after retries`,
         ),
         "reply",
         hashUserId(userId),
@@ -790,18 +814,40 @@ export class WeChatAcpBridge {
     this.cancelTypingIndicator(userId, contextToken).catch(() => {});
   }
 
+  protected async sendTextSegment(
+    userId: string,
+    contextToken: string,
+    segment: string,
+  ): Promise<boolean> {
+    const segmentClientId = `wechat-acp-${crypto.randomUUID()}`;
+    for (let attempt = 1; attempt <= SEGMENT_SEND_MAX_ATTEMPTS; attempt++) {
+      try {
+        await this.paceConsecutiveSend(userId);
+        await sendTextMessage(
+          userId,
+          segment,
+          {
+            baseUrl: this.tokenData!.baseUrl,
+            token: this.tokenData!.token,
+            contextToken,
+          },
+          segmentClientId,
+        );
+        return true;
+      } catch (err) {
+        trackException(err, "reply.segment", hashUserId(userId));
+        if (attempt < SEGMENT_SEND_MAX_ATTEMPTS) {
+          await new Promise((r) => setTimeout(r, SEGMENT_SEND_RETRY_BASE_MS * attempt));
+        }
+      }
+    }
+    return false;
+  }
+
   private async sendImageReply(userId: string, contextToken: string, image: AgentImage): Promise<void> {
     // Ride the same per-user chain as text replies so an image cannot
     // interleave with the segments of a concurrent text reply.
-    const previous = this.sendChains.get(userId) ?? Promise.resolve();
-    const current = previous
-      .catch(() => {})
-      .then(() => this.deliverImage(userId, contextToken, image));
-    this.sendChains.set(
-      userId,
-      current.catch(() => {}),
-    );
-    return current;
+    return this.queueSendTask(userId, () => this.deliverImage(userId, contextToken, image));
   }
 
   private async deliverImage(userId: string, contextToken: string, image: AgentImage): Promise<void> {
@@ -883,15 +929,9 @@ export class WeChatAcpBridge {
   ): Promise<void> {
     // Ride the same per-user chain as text and image replies so a file cannot
     // interleave with the segments of a concurrent reply.
-    const previous = this.sendChains.get(userId) ?? Promise.resolve();
-    const current = previous
-      .catch(() => {})
-      .then(() => this.deliverFile(userId, contextToken, file, telemetryKind));
-    this.sendChains.set(
-      userId,
-      current.catch(() => {}),
+    return this.queueSendTask(userId, () =>
+      this.deliverFile(userId, contextToken, file, telemetryKind),
     );
-    return current;
   }
 
   private async deliverFile(
@@ -1070,22 +1110,7 @@ export class WeChatAcpBridge {
     const item = items[0];
     if (item?.type !== 1 || !item.text_item?.text) return null;
 
-    const text = item.text_item.text.trim();
-    const names = resolveCommandNames(canonical, this.config.commandAliases);
-    for (const name of names) {
-      // Exact match → normalize to the canonical command with no arguments.
-      // This is the only matching mode for bare-phrase aliases (no leading
-      // "/"), e.g. a voice-transcribed "取消", which must match the whole
-      // message to avoid false positives.
-      if (text === name) return canonical;
-      // Slash-prefixed names (the canonical command and "/"-style aliases)
-      // also support trailing arguments. Replace the matched name with the
-      // canonical command so handlers always see a single, stable token.
-      if (name.startsWith("/") && text.startsWith(`${name} `)) {
-        return canonical + text.slice(name.length);
-      }
-    }
-    return null;
+    return matchBridgeCommand(item.text_item.text, canonical, this.config.commandAliases);
   }
 
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -103,6 +103,7 @@ export const BUILT_IN_AGENTS: Record<string, AgentPreset> = {
 export const BRIDGE_COMMANDS = {
   acpConfig: "/acp-config",
   acpCancel: "/acp-cancel",
+  acpMore: "/acp-more",
   promptStart: "/acp-prompt-start",
   promptDone: "/acp-prompt-done",
 } as const;
@@ -364,6 +365,21 @@ export function resolveCommandNames(
   aliases?: Record<string, string[]>,
 ): string[] {
   return [canonical, ...resolveCommandAliases(canonical, aliases).filter((a) => a !== canonical)];
+}
+
+export function matchBridgeCommand(
+  text: string,
+  canonical: string,
+  aliases?: Record<string, string[]>,
+): string | null {
+  const trimmed = text.trim();
+  for (const name of resolveCommandNames(canonical, aliases)) {
+    if (trimmed === name) return canonical;
+    if (name.startsWith("/") && trimmed.startsWith(`${name} `)) {
+      return canonical + trimmed.slice(name.length);
+    }
+  }
+  return null;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export {
 	resolveAgentSelection,
 	resolveCommandAliases,
 	resolveCommandNames,
+	matchBridgeCommand,
 	validateCommandAliases,
 	validateInstanceName,
 } from "./config.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ export {
 	resolveAgentSelection,
 	resolveCommandAliases,
 	resolveCommandNames,
-	matchBridgeCommand,
 	validateCommandAliases,
 	validateInstanceName,
 } from "./config.js";

--- a/src/pending-text.ts
+++ b/src/pending-text.ts
@@ -1,0 +1,152 @@
+export interface PendingTextSnapshot {
+  generation: number;
+  segments: string[];
+}
+
+interface PendingTextEntry {
+  generation: number;
+  segments: string[];
+  expiresAt: number;
+  contexts: Map<string, number>;
+  lastUsedAt: number;
+}
+
+export interface PendingTextRegistryOptions {
+  ttlMs: number;
+  maxUsers: number;
+  maxSegmentsPerUser: number;
+  maxContextsPerUser?: number;
+  now?: () => number;
+}
+
+/**
+ * Bounded in-memory storage for failed text segments. Prompt generations keep
+ * late failures from an older turn from restoring output after a newer prompt.
+ */
+export class PendingTextRegistry {
+  private readonly entries = new Map<string, PendingTextEntry>();
+  private readonly now: () => number;
+  private readonly maxContextsPerUser: number;
+
+  constructor(private readonly options: PendingTextRegistryOptions) {
+    this.now = options.now ?? Date.now;
+    this.maxContextsPerUser = options.maxContextsPerUser ?? 50;
+  }
+
+  supersede(userId: string, contextToken: string): number {
+    const entry = this.getOrCreateEntry(userId);
+    entry.generation++;
+    entry.segments = [];
+    entry.expiresAt = 0;
+    entry.lastUsedAt = this.now();
+    entry.contexts.set(contextToken, entry.generation);
+    while (entry.contexts.size > this.maxContextsPerUser) {
+      const oldest = entry.contexts.keys().next().value;
+      if (oldest === undefined) break;
+      entry.contexts.delete(oldest);
+    }
+    return entry.generation;
+  }
+
+  generationForContext(userId: string, contextToken: string): number | undefined {
+    const entry = this.entries.get(userId);
+    if (!entry) return undefined;
+    entry.lastUsedAt = this.now();
+    return entry.contexts.get(contextToken);
+  }
+
+  recordFailures(userId: string, generation: number, segments: string[]): boolean {
+    if (segments.length === 0) return true;
+    const entry = this.entries.get(userId);
+    if (!entry || entry.generation !== generation) return false;
+    entry.segments = [...entry.segments, ...segments].slice(0, this.options.maxSegmentsPerUser);
+    entry.expiresAt = this.now() + this.options.ttlMs;
+    entry.lastUsedAt = this.now();
+    return true;
+  }
+
+  snapshot(userId: string): PendingTextSnapshot | null {
+    const entry = this.entries.get(userId);
+    if (!entry) return null;
+    entry.lastUsedAt = this.now();
+    if (entry.expiresAt > 0 && entry.expiresAt <= this.now()) {
+      entry.segments = [];
+      entry.expiresAt = 0;
+    }
+    if (entry.segments.length === 0) return null;
+    return { generation: entry.generation, segments: [...entry.segments] };
+  }
+
+  replace(userId: string, generation: number, segments: string[]): boolean {
+    const entry = this.entries.get(userId);
+    if (!entry || entry.generation !== generation) return false;
+    entry.segments = segments.slice(0, this.options.maxSegmentsPerUser);
+    entry.expiresAt = entry.segments.length > 0 ? this.now() + this.options.ttlMs : 0;
+    entry.lastUsedAt = this.now();
+    return true;
+  }
+
+  private getOrCreateEntry(userId: string): PendingTextEntry {
+    const existing = this.entries.get(userId);
+    if (existing) return existing;
+    while (this.entries.size >= this.options.maxUsers) {
+      let oldestUser: string | undefined;
+      let oldestTime = Number.POSITIVE_INFINITY;
+      for (const [candidateUser, entry] of this.entries) {
+        if (entry.lastUsedAt < oldestTime) {
+          oldestTime = entry.lastUsedAt;
+          oldestUser = candidateUser;
+        }
+      }
+      if (oldestUser === undefined) break;
+      this.entries.delete(oldestUser);
+    }
+    const entry: PendingTextEntry = {
+      generation: 0,
+      segments: [],
+      expiresAt: 0,
+      contexts: new Map(),
+      lastUsedAt: this.now(),
+    };
+    this.entries.set(userId, entry);
+    return entry;
+  }
+}
+
+export interface DrainPendingTextResult {
+  pendingCount: number;
+  sentCount: number;
+  remainingCount: number;
+}
+
+export async function drainPendingText(
+  registry: PendingTextRegistry,
+  userId: string,
+  send: (segment: string) => Promise<boolean>,
+): Promise<DrainPendingTextResult> {
+  const snapshot = registry.snapshot(userId);
+  if (!snapshot) {
+    return { pendingCount: 0, sentCount: 0, remainingCount: 0 };
+  }
+
+  let sentCount = 0;
+  for (let index = 0; index < snapshot.segments.length; index++) {
+    if (!(await send(snapshot.segments[index]!))) {
+      const remainder = snapshot.segments.slice(index);
+      const retained = registry.replace(userId, snapshot.generation, remainder);
+      return {
+        pendingCount: snapshot.segments.length,
+        sentCount,
+        remainingCount: retained ? remainder.length : 0,
+      };
+    }
+    sentCount++;
+  }
+
+  registry.replace(userId, snapshot.generation, []);
+  return {
+    pendingCount: snapshot.segments.length,
+    sentCount,
+    remainingCount: 0,
+  };
+}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -32,6 +32,7 @@ export type EventName =
   | "command.acp_config.view"
   | "command.acp_config.set"
   | "command.acp_cancel"
+  | "command.acp_more"
   | "command.buffer_start"
   | "command.buffer_done"
   | "session.created"

--- a/tests/bridge-more.test.ts
+++ b/tests/bridge-more.test.ts
@@ -7,6 +7,7 @@ import { MessageType, type WeixinMessage } from "../src/weixin/types.js";
 
 class TestBridge extends WeChatAcpBridge {
   readonly enqueued: string[] = [];
+  readonly buffered: Array<{ contextToken: string; prompt: acp.ContentBlock[] }> = [];
   readonly sent: Array<{ contextToken: string; segment: string }> = [];
   sendBehavior: (
     contextToken: string,
@@ -19,6 +20,14 @@ class TestBridge extends WeChatAcpBridge {
     contextToken: string,
   ): Promise<void> {
     this.enqueued.push(contextToken);
+  }
+
+  protected override async enqueueBufferedPrompt(
+    _userId: string,
+    contextToken: string,
+    prompt: acp.ContentBlock[],
+  ): Promise<void> {
+    this.buffered.push({ contextToken, prompt });
   }
 
   protected override async sendTextSegment(
@@ -135,5 +144,23 @@ test("queued old reply cannot restore pending output after a newer prompt", asyn
     { contextToken: "context-blocker", segment: "No pending messages right now." },
     { contextToken: "context-old", segment: "stale output" },
     { contextToken: "context-fetch", segment: "No pending messages right now." },
+  ]);
+});
+
+test("buffer flush uses the fresh acp-prompt-done context token", async () => {
+  const bridge = makeBridge();
+
+  await bridge.handleMessage(
+    textMessage(BRIDGE_COMMANDS.promptStart, "context-start"),
+  );
+  await bridge.handleMessage(textMessage("buffered prompt", "context-content"));
+  await bridge.handleMessage(
+    textMessage(BRIDGE_COMMANDS.promptDone, "context-done"),
+  );
+
+  assert.equal(bridge.buffered.length, 1);
+  assert.equal(bridge.buffered[0]!.contextToken, "context-done");
+  assert.deepEqual(bridge.buffered[0]!.prompt, [
+    { type: "text", text: "buffered prompt" },
   ]);
 });

--- a/tests/bridge-more.test.ts
+++ b/tests/bridge-more.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { WeChatAcpBridge } from "../src/bridge.js";
+import { BRIDGE_COMMANDS, defaultConfig } from "../src/config.js";
+import { MessageType, type WeixinMessage } from "../src/weixin/types.js";
+
+class TestBridge extends WeChatAcpBridge {
+  readonly enqueued: string[] = [];
+  readonly sent: Array<{ contextToken: string; segment: string }> = [];
+  sendBehavior: (
+    contextToken: string,
+    segment: string,
+  ) => boolean | Promise<boolean> = () => true;
+
+  protected override async enqueueMessage(
+    _msg: WeixinMessage,
+    _userId: string,
+    contextToken: string,
+  ): Promise<void> {
+    this.enqueued.push(contextToken);
+  }
+
+  protected override async sendTextSegment(
+    _userId: string,
+    contextToken: string,
+    segment: string,
+  ): Promise<boolean> {
+    this.sent.push({ contextToken, segment });
+    return this.sendBehavior(contextToken, segment);
+  }
+
+  beginPrompt(contextToken: string): void {
+    this.beginAgentPrompt("user", contextToken);
+  }
+
+  queueAgentReply(contextToken: string, text: string): Promise<void> {
+    return this.sendAgentReply("user", contextToken, text);
+  }
+}
+
+function textMessage(text: string, contextToken: string): WeixinMessage {
+  return {
+    from_user_id: "user",
+    context_token: contextToken,
+    message_type: MessageType.USER,
+    item_list: [{ type: 1, text_item: { text } }],
+  };
+}
+
+function makeBridge(): TestBridge {
+  const config = defaultConfig();
+  config.storage.stateFile = undefined;
+  config.commandAliases = {
+    [BRIDGE_COMMANDS.acpMore]: ["/acp-fetch-msg", "."],
+  };
+  return new TestBridge(config, () => {});
+}
+
+test("acp-more is intercepted without enqueueing an ACP turn", async () => {
+  const bridge = makeBridge();
+
+  await bridge.handleMessage(textMessage(BRIDGE_COMMANDS.acpMore, "context-more"));
+
+  assert.deepEqual(bridge.enqueued, []);
+  assert.deepEqual(bridge.sent, [
+    { contextToken: "context-more", segment: "No pending messages right now." },
+  ]);
+});
+
+test("bare dot alias is intercepted only as the complete message", async () => {
+  const bridge = makeBridge();
+
+  await bridge.handleMessage(textMessage(".", "context-dot"));
+  assert.deepEqual(bridge.enqueued, []);
+  await bridge.handleMessage(textMessage(". keep this prompt", "context-prompt"));
+
+  assert.deepEqual(bridge.sent, [
+    { contextToken: "context-dot", segment: "No pending messages right now." },
+  ]);
+  assert.deepEqual(bridge.enqueued, ["context-prompt"]);
+});
+
+test("normal delivery retains only failed segments and still attempts later segments", async () => {
+  const bridge = makeBridge();
+  const first = "a".repeat(4000);
+  const second = "later segment";
+  bridge.beginPrompt("context-agent");
+  bridge.sendBehavior = (contextToken, segment) =>
+    contextToken !== "context-agent" || segment !== first;
+
+  await bridge.queueAgentReply("context-agent", `${first}\n${second}`);
+  await bridge.handleMessage(textMessage(BRIDGE_COMMANDS.acpMore, "context-more"));
+
+  assert.deepEqual(bridge.sent, [
+    { contextToken: "context-agent", segment: first },
+    { contextToken: "context-agent", segment: second },
+    { contextToken: "context-more", segment: first },
+  ]);
+  assert.deepEqual(bridge.enqueued, []);
+});
+
+test("queued old reply cannot restore pending output after a newer prompt", async () => {
+  const bridge = makeBridge();
+  let releaseBlocker!: () => void;
+  let blockerStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    blockerStarted = resolve;
+  });
+  const blocked = new Promise<void>((resolve) => {
+    releaseBlocker = resolve;
+  });
+  bridge.sendBehavior = async (contextToken) => {
+    if (contextToken === "context-blocker") {
+      blockerStarted();
+      await blocked;
+      return true;
+    }
+    return contextToken !== "context-old";
+  };
+
+  bridge.beginPrompt("context-old");
+  const blocker = bridge.handleMessage(
+    textMessage(BRIDGE_COMMANDS.acpMore, "context-blocker"),
+  );
+  await started;
+  const oldReply = bridge.queueAgentReply("context-old", "stale output");
+  bridge.beginPrompt("context-new");
+  releaseBlocker();
+  await blocker;
+  await oldReply;
+  await bridge.handleMessage(textMessage(BRIDGE_COMMANDS.acpMore, "context-fetch"));
+
+  assert.deepEqual(bridge.sent, [
+    { contextToken: "context-blocker", segment: "No pending messages right now." },
+    { contextToken: "context-old", segment: "stale output" },
+    { contextToken: "context-fetch", segment: "No pending messages right now." },
+  ]);
+});

--- a/tests/bridge-more.test.ts
+++ b/tests/bridge-more.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import type { ContentBlock } from "@agentclientprotocol/sdk";
 
 import { WeChatAcpBridge } from "../src/bridge.js";
 import { BRIDGE_COMMANDS, defaultConfig } from "../src/config.js";
@@ -7,7 +8,7 @@ import { MessageType, type WeixinMessage } from "../src/weixin/types.js";
 
 class TestBridge extends WeChatAcpBridge {
   readonly enqueued: string[] = [];
-  readonly buffered: Array<{ contextToken: string; prompt: acp.ContentBlock[] }> = [];
+  readonly buffered: Array<{ contextToken: string; prompt: ContentBlock[] }> = [];
   readonly sent: Array<{ contextToken: string; segment: string }> = [];
   sendBehavior: (
     contextToken: string,
@@ -25,7 +26,7 @@ class TestBridge extends WeChatAcpBridge {
   protected override async enqueueBufferedPrompt(
     _userId: string,
     contextToken: string,
-    prompt: acp.ContentBlock[],
+    prompt: ContentBlock[],
   ): Promise<void> {
     this.buffered.push({ contextToken, prompt });
   }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -2,8 +2,11 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  BRIDGE_COMMANDS,
   buildAgentSessionScope,
+  matchBridgeCommand,
   parseSessionResumePolicy,
+  validateCommandAliases,
 } from "../src/config.js";
 
 test("preset session scope ignores bundled command changes", () => {
@@ -44,4 +47,20 @@ test("session resume policy accepts only documented modes", () => {
   assert.equal(parseSessionResumePolicy("auto"), "auto");
   assert.equal(parseSessionResumePolicy("required"), "required");
   assert.throws(() => parseSessionResumePolicy("yes"), /Invalid session resume policy/);
+});
+
+test("acp-more aliases validate and bare aliases match only the full message", () => {
+  const aliases = {
+    [BRIDGE_COMMANDS.acpMore]: ["/acp-fetch-msg", "."],
+  };
+  assert.doesNotThrow(() => validateCommandAliases(aliases));
+  assert.equal(
+    matchBridgeCommand("/acp-fetch-msg", BRIDGE_COMMANDS.acpMore, aliases),
+    BRIDGE_COMMANDS.acpMore,
+  );
+  assert.equal(
+    matchBridgeCommand(".", BRIDGE_COMMANDS.acpMore, aliases),
+    BRIDGE_COMMANDS.acpMore,
+  );
+  assert.equal(matchBridgeCommand(". extra", BRIDGE_COMMANDS.acpMore, aliases), null);
 });

--- a/tests/pending-text.test.ts
+++ b/tests/pending-text.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  drainPendingText,
+  PendingTextRegistry,
+} from "../src/pending-text.js";
+
+function makeRegistry(opts?: {
+  now?: () => number;
+  maxUsers?: number;
+  maxSegmentsPerUser?: number;
+}): PendingTextRegistry {
+  return new PendingTextRegistry({
+    ttlMs: 10 * 60_000,
+    maxUsers: opts?.maxUsers ?? 10,
+    maxSegmentsPerUser: opts?.maxSegmentsPerUser ?? 50,
+    now: opts?.now,
+  });
+}
+
+test("records only the failed text segments for the active prompt", () => {
+  const registry = makeRegistry();
+  const generation = registry.supersede("user", "context-1");
+
+  assert.equal(registry.recordFailures("user", generation, ["failed-2", "failed-4"]), true);
+  assert.deepEqual(registry.snapshot("user")?.segments, ["failed-2", "failed-4"]);
+});
+
+test("drains pending text in order", async () => {
+  const registry = makeRegistry();
+  const generation = registry.supersede("user", "context-1");
+  registry.recordFailures("user", generation, ["one", "two", "three"]);
+  const sent: string[] = [];
+
+  const result = await drainPendingText(registry, "user", async (segment) => {
+    sent.push(segment);
+    return true;
+  });
+
+  assert.deepEqual(sent, ["one", "two", "three"]);
+  assert.deepEqual(result, { pendingCount: 3, sentCount: 3, remainingCount: 0 });
+  assert.equal(registry.snapshot("user"), null);
+});
+
+test("stops after the first persistent fetch failure and preserves the remainder", async () => {
+  const registry = makeRegistry();
+  const generation = registry.supersede("user", "context-1");
+  registry.recordFailures("user", generation, ["one", "two", "three"]);
+  const attempted: string[] = [];
+
+  const result = await drainPendingText(registry, "user", async (segment) => {
+    attempted.push(segment);
+    return segment !== "two";
+  });
+
+  assert.deepEqual(attempted, ["one", "two"]);
+  assert.deepEqual(result, { pendingCount: 3, sentCount: 1, remainingCount: 2 });
+  assert.deepEqual(registry.snapshot("user")?.segments, ["two", "three"]);
+});
+
+test("reports no pending text without invoking the sender", async () => {
+  const registry = makeRegistry();
+  let called = false;
+
+  const result = await drainPendingText(registry, "user", async () => {
+    called = true;
+    return true;
+  });
+
+  assert.equal(called, false);
+  assert.deepEqual(result, { pendingCount: 0, sentCount: 0, remainingCount: 0 });
+});
+
+test("expires pending text and bounds users and segments", () => {
+  let now = 0;
+  const registry = makeRegistry({
+    now: () => now,
+    maxUsers: 2,
+    maxSegmentsPerUser: 2,
+  });
+  const firstGeneration = registry.supersede("first", "context-1");
+  registry.recordFailures("first", firstGeneration, ["one", "two", "three"]);
+  assert.deepEqual(registry.snapshot("first")?.segments, ["one", "two"]);
+
+  now = 1;
+  registry.supersede("second", "context-2");
+  now = 2;
+  registry.supersede("third", "context-3");
+  assert.equal(registry.snapshot("first"), null);
+
+  const thirdGeneration = registry.generationForContext("third", "context-3")!;
+  registry.recordFailures("third", thirdGeneration, ["pending"]);
+  now += 10 * 60_000;
+  assert.equal(registry.snapshot("third"), null);
+});
+
+test("a newer prompt rejects late failures and fetch remainder from the old prompt", async () => {
+  const registry = makeRegistry();
+  const oldGeneration = registry.supersede("user", "old-context");
+  registry.recordFailures("user", oldGeneration, ["old-one", "old-two"]);
+
+  const drain = drainPendingText(registry, "user", async (segment) => {
+    registry.supersede("user", "new-context");
+    return segment !== "old-one";
+  });
+
+  assert.deepEqual(await drain, { pendingCount: 2, sentCount: 0, remainingCount: 0 });
+  assert.equal(registry.recordFailures("user", oldGeneration, ["late-old"]), false);
+  assert.equal(registry.snapshot("user"), null);
+});

--- a/tests/pending-text.test.ts
+++ b/tests/pending-text.test.ts
@@ -95,7 +95,7 @@ test("expires pending text and bounds users and segments", () => {
   assert.equal(registry.snapshot("third"), null);
 });
 
-test("a newer prompt rejects late failures and fetch remainder from the old prompt", async () => {
+test("a newer prompt rejects late failures and drops the old fetch remainder", async () => {
   const registry = makeRegistry();
   const oldGeneration = registry.supersede("user", "old-context");
   registry.recordFailures("user", oldGeneration, ["old-one", "old-two"]);


### PR DESCRIPTION
## Problem

WeChat iLink allows only about 10 outbound messages for one inbound context token. Users currently send another prompt such as `hi` to get the rest, but that creates a real queued ACP turn.

## Fix

- Add `/acp-more` as a bridge command with configurable slash and exact bare aliases.
- Keep only text segments that still fail after normal retries.
- Drain pending text in order on the existing per-user send chain and stop after the first persistent fetch failure.
- Expire pending text after 10 minutes and bound storage by active users and 50 segments per user.
- Clear old pending output when a new real prompt arrives. Prompt generations prevent late failures from restoring stale output.
- Document that successful sends silently dropped by iLink cannot be detected.

## Tests

- `npm run build`
- Focused command, capture, drain, expiry, bounds, buffered-context, and stale-generation tests: 15 passed.
- Full Node test runner: 145 tests found, 138 passed. One existing artifact test fails on Windows without symlink permission. Six existing agent-manager tests are cancelled because the current Windows spawn path under `C:\Program Files` is not quoted.
- Remaining unaffected suite after excluding those two existing Windows-only files: 132 passed.

Fixes #45
