### PR TITLE
fix: reserve capacity while exited turns drain

### DIFF
--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -531,8 +531,7 @@ export class SessionManager {
       );
     }
     if (
-      this.reservedSessionCount() >=
-      this.opts.maxConcurrentUsers
+      !this.hasSessionCapacity(userId)
     ) {
       const eviction = this.evictOldest();
       if (eviction) {
@@ -549,8 +548,7 @@ export class SessionManager {
           },
           (err) => {
             if (
-              this.reservedSessionCount() >=
-              this.opts.maxConcurrentUsers
+              !this.hasSessionCapacity(userId)
             ) {
               throw err;
             }
@@ -567,8 +565,7 @@ export class SessionManager {
       }
     }
     if (
-      this.reservedSessionCount() >=
-      this.opts.maxConcurrentUsers
+      !this.hasSessionCapacity(userId)
     ) {
       return Promise.reject(
         new Error(
@@ -831,9 +828,15 @@ export class SessionManager {
       .map(([userId]) => userId);
     return new Set([
       ...this.sessions.keys(),
+      ...this.exitedSessions.keys(),
       ...this.pendingSessions.keys(),
       ...cleanupUsersWithLiveResources,
     ]).size;
+  }
+
+  private hasSessionCapacity(userId: string): boolean {
+    if (this.exitedSessions.has(userId)) return true;
+    return this.reservedSessionCount() < this.opts.maxConcurrentUsers;
   }
 
   private async createSession(

--- a/tests/session-reset.test.ts
+++ b/tests/session-reset.test.ts
@@ -1000,6 +1000,7 @@ test("replacement permanently suppresses a buffered response from an exited proc
   const exiting = makeExitingProcess();
   const replies: string[] = [];
   const manager = makeManager({
+    maxConcurrentUsers: 1,
     killAgentProcess: async () => {},
     onReply: async (_userId, _contextToken, text) => {
       replies.push(text);
@@ -1011,6 +1012,7 @@ test("replacement permanently suppresses a buffered response from an exited proc
   );
   const internal = lifecycleInternals(manager);
   const replacement = makeSession("target");
+  const createdUsers: string[] = [];
   const creation = internal as typeof internal & {
     createSession(
       userId: string,
@@ -1022,7 +1024,10 @@ test("replacement permanently suppresses a buffered response from an exited proc
       contextToken: string,
     ): Promise<UserSession>;
   };
-  creation.createSession = async () => replacement;
+  creation.createSession = async (userId) => {
+    createdUsers.push(userId);
+    return userId === "target" ? replacement : makeSession(userId);
+  };
   internal.sessions.set("target", turn.session);
   const rejected = assert.rejects(turn.completion, /replaced/i);
   const processing = internal.processQueue(turn.session);
@@ -1030,10 +1035,16 @@ test("replacement permanently suppresses a buffered response from an exited proc
 
   internal.handleAgentExit("target", exiting.process);
   exiting.emitExit();
+  await assert.rejects(
+    creation.getOrCreateSession("other", "other-context"),
+    /Maximum concurrent sessions reached/,
+  );
+  assert.deepEqual(createdUsers, []);
   assert.equal(
     await creation.getOrCreateSession("target", "replacement-context"),
     replacement,
   );
+  assert.deepEqual(createdUsers, ["target"]);
   internal.sessions.delete("target");
   turn.resolvePrompt();
 


### PR DESCRIPTION
## Problem

PR #70 lets an active response drain briefly after its agent wrapper exits. During that window, the exited session still owns process and MCP resources but was omitted from the capacity reservation. A different user could therefore start a session beyond `maxConcurrentUsers`.

## Fix

- Count users with draining exited sessions as reserved capacity.
- Let the same user create a replacement in their existing reserved slot.
- Cover both the blocked cross-user creation and allowed same-user replacement.

## Tests

- `npm run build`
- Session reset suite: 30 passed
- Full Windows suite: 205 tests, with 197 passed, 1 known symlink `EPERM` failure, 6 known shell-quoting cancellations, and 1 platform skip

Follow-up to #70.
