### PR TITLE
fix: track Windows agent process trees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,17 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: |
+          $tests = Get-ChildItem tests -Filter *.ts | ForEach-Object { $_.FullName }
+          node --import tsx/esm --test $tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@agentclientprotocol/sdk": "^0.16.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "applicationinsights": "^2.9.6",
+        "koffi": "3.1.5",
         "qrcode-terminal": "^0.12.0",
         "zod": "^4.4.3"
       },
@@ -606,6 +607,231 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-arm64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.5.tgz",
+      "integrity": "sha512-IpqITl2fJi3QN9bTtNnygWPdK7ScSjw3xtGu8e6feYGvimCysu+spgI5KyeslY2jTnqxGS9xr8pLAbLhGJ8edA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-x64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.5.tgz",
+      "integrity": "sha512-4Tia4BS5EV/+vN9eIrdToanVe+U/2VqTZCBgOzoUbPKjgky51eqM+3J4qdRUvmYJohcJNPob5/hsxeItUZrl1g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-arm64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.5.tgz",
+      "integrity": "sha512-bP94uzseFO79NG3flpU3WxfyvltD+jzC/kN8FDZLi8J0VUZNW1Wmu8yq87KEzjX1qT9KyX4Y+elVbGqHXHTv2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-ia32": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.5.tgz",
+      "integrity": "sha512-raFXXAPHzvCQWhaoMUF+Cc2ZWgg2UBU0RVoowHZhaw9nQYPC1pERcPRH+JA+SNIN6g4d2GFW6uPFc+QbUhsagA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-x64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.5.tgz",
+      "integrity": "sha512-h6RyBZmPMBIDWTABkJIhzDdYwSnYAJvTacHpEjbT55Arkmw1H15Rl7CFtXuEuBrqh+uivoCrRgA6vszl9CsJ9g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-arm64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.5.tgz",
+      "integrity": "sha512-u0vCmKPu4yQDhl/ri1J6U3vDnvYtYjoZaIWb+oMbRXhVZeiqdE53MGPb+q2A7Dj2n9IbYloAfEICQbL6l0pmiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-ia32": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.5.tgz",
+      "integrity": "sha512-Xa5JbumWglwPVZgrJcLhqyC1wCWlfm7+C00p3FuOTNGp0qoYuf2/tOoAh0/q7+taVm30cMopu/6lRHwdmF6I/w==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-loong64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.5.tgz",
+      "integrity": "sha512-F3i2CeTcqVBUQiSRUBSEzX1VgtXmLLiZb/ouZtXHkWpTLhJNd9TH7s3CizTofci0VRqlKdexGUYhK5vzPDAAHA==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-riscv64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.5.tgz",
+      "integrity": "sha512-2TgQuzy+4PfDg+rw3kOmN6lywEWdzKT3eaLPbOp0b/9DaN7CLBJ/QIR5GhGsMNpeI30zU0YzFeYFxoVoJ/LqFw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-x64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.5.tgz",
+      "integrity": "sha512-2yaIg/1V0m4CiAUMzG4CIlWmq1WJ+QBMlFfaGr9su+OH5fuIqC7V3BbMiB03IwIl1VofIZO5JA4Db4lID8tpbw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-ia32": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.5.tgz",
+      "integrity": "sha512-8/OXd+u9omMooykhvdJPEP7u6FFzzrrFo9gOmSHc9/DPt3XkVYOtSsE97PDk6zYaAzwIYHSKjHvIXsfFwFc7sg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-x64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.5.tgz",
+      "integrity": "sha512-SpeqldKkuDk2aTj5PVWumy7eq6Tr2GtBPAOI1NiDHhg8xe433KraxrA9V9UjEd+1+kSGJQGR04nQByN3MPA9PQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-arm64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.5.tgz",
+      "integrity": "sha512-uej3YAEKAhlfVPoIo5sOwtxhTLRVJ01LgtWrKGpnnAQU3C+Ilmaxdh+Oc2xc1G3NK30N5eCVJpyO9r3pjKC6Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-ia32": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.5.tgz",
+      "integrity": "sha512-d42jv2f4PwtJGNJS19Xfn/BRtGsBNNVkw0O0K5tkIGI+yNq4MnPTSUsaGbDIkCLNsCgk/LFqAaE8BExyCdrujA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-x64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.5.tgz",
+      "integrity": "sha512-Pyo1WEHEP6Ek2NEn2pquwJzSPLOdY4vymoPSz0an1DgvFWSkOyBYYkGVoxL1ajfj5I1pPdXysYqixtVTzAtOfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
     "node_modules/@microsoft/applicationinsights-web-snippet": {
@@ -1827,6 +2053,32 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/koffi": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.1.5.tgz",
+      "integrity": "sha512-XVwwrxg0Ca6IEUQF4YtGIU4XN0LSselFYpYvgfhh8wafCunhEEx5hPr7LZhp5QyeFA/LcRsKHTqncCdjWjWAlg==",
+      "hasInstallScript": true,
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      },
+      "optionalDependencies": {
+        "@koromix/koffi-darwin-arm64": "3.1.5",
+        "@koromix/koffi-darwin-x64": "3.1.5",
+        "@koromix/koffi-freebsd-arm64": "3.1.5",
+        "@koromix/koffi-freebsd-ia32": "3.1.5",
+        "@koromix/koffi-freebsd-x64": "3.1.5",
+        "@koromix/koffi-linux-arm64": "3.1.5",
+        "@koromix/koffi-linux-ia32": "3.1.5",
+        "@koromix/koffi-linux-loong64": "3.1.5",
+        "@koromix/koffi-linux-riscv64": "3.1.5",
+        "@koromix/koffi-linux-x64": "3.1.5",
+        "@koromix/koffi-openbsd-ia32": "3.1.5",
+        "@koromix/koffi-openbsd-x64": "3.1.5",
+        "@koromix/koffi-win32-arm64": "3.1.5",
+        "@koromix/koffi-win32-ia32": "3.1.5",
+        "@koromix/koffi-win32-x64": "3.1.5"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@agentclientprotocol/sdk": "^0.16.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "applicationinsights": "^2.9.6",
+    "koffi": "3.1.5",
     "qrcode-terminal": "^0.12.0",
     "zod": "^4.4.3"
   },

--- a/src/acp/agent-manager.ts
+++ b/src/acp/agent-manager.ts
@@ -9,6 +9,7 @@ import packageJson from "../../package.json" with { type: "json" };
 import type { WeChatAcpClient } from "./client.js";
 import type { SessionResumePolicy } from "../config.js";
 import { trackException } from "../telemetry/index.js";
+import type { WindowsJob } from "./windows-job.js";
 
 export type AgentSessionOutcome = "new" | "loaded" | "unsupported" | "not_found";
 
@@ -38,6 +39,7 @@ const uncertainWindowsProcessTrees = new WeakMap<
   ChildProcess,
   { error: unknown }
 >();
+const windowsJobs = new WeakMap<ChildProcess, WindowsJob>();
 
 export async function spawnAgent(params: {
   command: string;
@@ -68,7 +70,7 @@ export async function spawnAgent(params: {
   }
 
   // On Windows, shell mode avoids EINVAL/ENOENT for command shims like npx/claude/gemini.
-  const useShell = process.platform === "win32";
+  const useShell = requiresWindowsShell(command);
 
   log(`Spawning agent: ${command} ${args.join(" ")} (cwd: ${cwd}, shell=${useShell})`);
 
@@ -89,6 +91,19 @@ export async function spawnAgent(params: {
   proc.on("exit", (code, signal) => {
     log(`Agent process exited: code=${code} signal=${signal}`);
   });
+
+  if (process.platform === "win32") {
+    try {
+      const { createWindowsJob } = await import("./windows-job.js");
+      if (proc.pid === undefined) {
+        throw new Error("Cannot track Windows agent process without a process ID");
+      }
+      windowsJobs.set(proc, createWindowsJob(proc.pid));
+    } catch (err) {
+      killAgent(proc);
+      throw err;
+    }
+  }
 
   try {
     if (!proc.stdin || !proc.stdout) {
@@ -227,7 +242,23 @@ export async function spawnAgent(params: {
   }
 }
 
+function requiresWindowsShell(command: string): boolean {
+  return (
+    process.platform === "win32" &&
+    !command.toLowerCase().endsWith(".exe")
+  );
+}
+
 export function killAgent(proc: ChildProcess): void {
+  const windowsJob = windowsJobs.get(proc);
+  if (windowsJob) {
+    try {
+      windowsJob.terminate();
+    } finally {
+      windowsJob.close();
+    }
+    return;
+  }
   if (process.platform !== "win32" && proc.pid !== undefined) {
     const groupPid = proc.pid;
     try {
@@ -268,6 +299,16 @@ export async function killAgentAndWait(
 ): Promise<void> {
   const platform = options.platform ?? process.platform;
   if (platform === "win32") {
+    const windowsJob = windowsJobs.get(proc);
+    if (windowsJob) {
+      try {
+        windowsJob.terminate();
+        await windowsJob.waitForEmpty(timeoutMs);
+      } finally {
+        windowsJob.close();
+      }
+      return;
+    }
     const retainedFailure = uncertainWindowsProcessTrees.get(proc);
     const wrapperExited =
       proc.exitCode !== null || proc.signalCode !== null;
@@ -277,6 +318,7 @@ export async function killAgentAndWait(
       // taskkill failure leaves evidence that cleanup is uncertain.
       return;
     }
+
     if (proc.pid === undefined) {
       throw new Error("Cannot stop agent process tree without a process ID");
     }
@@ -330,6 +372,22 @@ export async function killAgentAndWait(
     if (timeout) clearTimeout(timeout);
     proc.off("exit", settle);
     proc.off("close", settle);
+  }
+}
+
+export function hasAgentExited(proc: ChildProcess): boolean {
+  const windowsJob = windowsJobs.get(proc);
+  if (windowsJob) return !windowsJob.hasActiveProcesses();
+  return proc.exitCode !== null || proc.signalCode !== null;
+}
+
+export async function waitForAgentExit(proc: ChildProcess): Promise<void> {
+  const windowsJob = windowsJobs.get(proc);
+  if (!windowsJob) return;
+  try {
+    await windowsJob.waitForEmpty(Number.POSITIVE_INFINITY);
+  } finally {
+    windowsJob.close();
   }
 }
 

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -15,8 +15,10 @@ import {
 } from "./client.js";
 import type { AgentResourceLink } from "../artifacts/types.js";
 import {
+  hasAgentExited,
   spawnAgent,
   killAgentAndWait,
+  waitForAgentExit,
   AgentProcessCleanupError,
   type AgentProcessInfo,
 } from "./agent-manager.js";
@@ -635,8 +637,7 @@ export class SessionManager {
       this.invalidateExitedSessions(userId);
       this.sessions.set(userId, created);
       if (
-        created.agentInfo.process.exitCode !== null ||
-        created.agentInfo.process.signalCode !== null
+        hasAgentExited(created.agentInfo.process)
       ) {
         this.handleAgentExit(userId, created.agentInfo.process);
         throw created.closedError ??
@@ -976,7 +977,15 @@ export class SessionManager {
 
     // If agent process exits, clean up the session
     agentInfo.process.on("exit", () => {
-      this.handleAgentExit(userId, agentInfo.process);
+      void waitForAgentExit(agentInfo.process).then(
+        () => this.handleAgentExit(userId, agentInfo.process),
+        (err) => {
+          this.opts.log(
+            `[${userId}] Failed to wait for Windows agent process tree: ${String(err)}`,
+          );
+          this.handleAgentExit(userId, agentInfo.process);
+        },
+      );
     });
 
     sessionRef = {

--- a/src/acp/windows-job.ts
+++ b/src/acp/windows-job.ts
@@ -1,0 +1,230 @@
+import koffi from "koffi";
+
+const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x0000_2000;
+const JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9;
+const JOB_OBJECT_BASIC_ACCOUNTING_INFORMATION = 1;
+const PROCESS_TERMINATE = 0x0001;
+const PROCESS_SET_QUOTA = 0x0100;
+const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+
+const Handle = koffi.pointer(koffi.opaque("HANDLE"));
+
+const IoCounters = koffi.struct("IO_COUNTERS", {
+  ReadOperationCount: "uint64_t",
+  WriteOperationCount: "uint64_t",
+  OtherOperationCount: "uint64_t",
+  ReadTransferCount: "uint64_t",
+  WriteTransferCount: "uint64_t",
+  OtherTransferCount: "uint64_t",
+});
+
+const BasicLimitInformation = koffi.struct(
+  "JOBOBJECT_BASIC_LIMIT_INFORMATION",
+  {
+    PerProcessUserTimeLimit: "int64_t",
+    PerJobUserTimeLimit: "int64_t",
+    LimitFlags: "uint32_t",
+    MinimumWorkingSetSize: "size_t",
+    MaximumWorkingSetSize: "size_t",
+    ActiveProcessLimit: "uint32_t",
+    Affinity: "uintptr_t",
+    PriorityClass: "uint32_t",
+    SchedulingClass: "uint32_t",
+  },
+);
+
+const ExtendedLimitInformation = koffi.struct(
+  "JOBOBJECT_EXTENDED_LIMIT_INFORMATION",
+  {
+    BasicLimitInformation,
+    IoInfo: IoCounters,
+    ProcessMemoryLimit: "size_t",
+    JobMemoryLimit: "size_t",
+    PeakProcessMemoryUsed: "size_t",
+    PeakJobMemoryUsed: "size_t",
+  },
+);
+
+const BasicAccountingInformation = koffi.struct(
+  "JOBOBJECT_BASIC_ACCOUNTING_INFORMATION",
+  {
+    TotalUserTime: "int64_t",
+    TotalKernelTime: "int64_t",
+    ThisPeriodTotalUserTime: "int64_t",
+    ThisPeriodTotalKernelTime: "int64_t",
+    TotalPageFaultCount: "uint32_t",
+    TotalProcesses: "uint32_t",
+    ActiveProcesses: "uint32_t",
+    TotalTerminatedProcesses: "uint32_t",
+  },
+);
+
+const kernel32 = koffi.load("kernel32.dll");
+const CreateJobObject = kernel32.func("CreateJobObjectW", Handle, [
+  "void *",
+  "str16",
+]);
+const OpenProcess = kernel32.func("OpenProcess", Handle, [
+  "uint32_t",
+  "int",
+  "uint32_t",
+]);
+const AssignProcessToJobObject = kernel32.func(
+  "AssignProcessToJobObject",
+  "int",
+  [Handle, Handle],
+);
+const SetInformationJobObject = kernel32.func(
+  "SetInformationJobObject",
+  "int",
+  [Handle, "int", koffi.pointer(ExtendedLimitInformation), "uint32_t"],
+);
+const QueryInformationJobObject = kernel32.func(
+  "QueryInformationJobObject",
+  "int",
+  [
+    Handle,
+    "int",
+    koffi.out(koffi.pointer(BasicAccountingInformation)),
+    "uint32_t",
+    "void *",
+  ],
+);
+const TerminateJobObject = kernel32.func("TerminateJobObject", "int", [
+  Handle,
+  "uint32_t",
+]);
+const CloseHandle = kernel32.func("CloseHandle", "int", [Handle]);
+const GetLastError = kernel32.func("GetLastError", "uint32_t", []);
+
+export interface WindowsJob {
+  terminate(): void;
+  waitForEmpty(timeoutMs: number): Promise<void>;
+  close(): void;
+  hasActiveProcesses(): boolean;
+}
+
+export function createWindowsJob(pid: number): WindowsJob {
+  const job = CreateJobObject(null, null);
+  if (job === null) throwWin32Error("CreateJobObjectW");
+
+  try {
+    const limits = {
+      BasicLimitInformation: {
+        PerProcessUserTimeLimit: 0,
+        PerJobUserTimeLimit: 0,
+        LimitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        MinimumWorkingSetSize: 0,
+        MaximumWorkingSetSize: 0,
+        ActiveProcessLimit: 0,
+        Affinity: 0,
+        PriorityClass: 0,
+        SchedulingClass: 0,
+      },
+      IoInfo: {
+        ReadOperationCount: 0,
+        WriteOperationCount: 0,
+        OtherOperationCount: 0,
+        ReadTransferCount: 0,
+        WriteTransferCount: 0,
+        OtherTransferCount: 0,
+      },
+      ProcessMemoryLimit: 0,
+      JobMemoryLimit: 0,
+      PeakProcessMemoryUsed: 0,
+      PeakJobMemoryUsed: 0,
+    };
+    if (
+      !SetInformationJobObject(
+        job,
+        JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
+        limits,
+        ExtendedLimitInformation.size,
+      )
+    ) {
+      throwWin32Error("SetInformationJobObject");
+    }
+
+    const process = OpenProcess(
+      PROCESS_TERMINATE |
+        PROCESS_SET_QUOTA |
+        PROCESS_QUERY_LIMITED_INFORMATION,
+      0,
+      pid,
+    );
+    if (process === null) throwWin32Error(`OpenProcess(${pid})`);
+    try {
+      if (!AssignProcessToJobObject(job, process)) {
+        throwWin32Error(`AssignProcessToJobObject(${pid})`);
+      }
+    } finally {
+      CloseHandle(process);
+    }
+  } catch (err) {
+    CloseHandle(job);
+    throw err;
+  }
+
+  return new NativeWindowsJob(job);
+}
+
+class NativeWindowsJob implements WindowsJob {
+  private closed = false;
+  private terminated = false;
+
+  constructor(private readonly handle: unknown) {}
+
+  terminate(): void {
+    if (this.closed || this.terminated) return;
+    this.terminated = true;
+    if (!TerminateJobObject(this.handle, 1)) {
+      throwWin32Error("TerminateJobObject");
+    }
+  }
+
+  async waitForEmpty(timeoutMs: number): Promise<void> {
+    const startedAt = Date.now();
+    while (this.hasActiveProcesses()) {
+      if (Date.now() - startedAt >= timeoutMs) {
+        throw new Error(`Windows agent process tree did not exit within ${timeoutMs}ms`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    if (!CloseHandle(this.handle)) throwWin32Error("CloseHandle");
+  }
+
+  hasActiveProcesses(): boolean {
+    if (this.closed) return false;
+    const accounting = {
+      TotalUserTime: 0,
+      TotalKernelTime: 0,
+      ThisPeriodTotalUserTime: 0,
+      ThisPeriodTotalKernelTime: 0,
+      TotalPageFaultCount: 0,
+      TotalProcesses: 0,
+      ActiveProcesses: 0,
+      TotalTerminatedProcesses: 0,
+    };
+    if (
+      !QueryInformationJobObject(
+        this.handle,
+        JOB_OBJECT_BASIC_ACCOUNTING_INFORMATION,
+        accounting,
+        BasicAccountingInformation.size,
+        null,
+      )
+    ) {
+      throwWin32Error("QueryInformationJobObject");
+    }
+    return accounting.ActiveProcesses > 0;
+  }
+}
+
+function throwWin32Error(operation: string): never {
+  throw new Error(`${operation} failed with Windows error ${GetLastError()}`);
+}

--- a/tests/windows-job.test.ts
+++ b/tests/windows-job.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { createWindowsJob } from "../src/acp/windows-job.js";
+
+test(
+  "Windows job terminates a descendant after its wrapper exits",
+  { skip: process.platform !== "win32" },
+  async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "wechat-acp-job-"));
+    const scriptPath = path.join(dir, "wrapper.cjs");
+    const pidPath = path.join(dir, "agent.pid");
+    await fs.writeFile(
+      scriptPath,
+      [
+        'const { spawn } = require("node:child_process");',
+        'const fs = require("node:fs");',
+        "setTimeout(() => {",
+        '  const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { detached: true, stdio: "ignore" });',
+        "  fs.writeFileSync(process.argv[2], String(child.pid));",
+        "  child.unref();",
+        "}, 100);",
+      ].join("\n"),
+    );
+    const wrapper = spawn(process.execPath, [scriptPath, pidPath], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    const job = createWindowsJob(wrapper.pid!);
+    let agentPid: number | undefined;
+
+    try {
+      agentPid = Number(await waitForFile(pidPath));
+      assert.equal(Number.isInteger(agentPid), true);
+      if (wrapper.exitCode === null) {
+        await once(wrapper, "exit");
+      }
+      assert.equal(isProcessRunning(agentPid), true);
+      assert.equal(job.hasActiveProcesses(), true);
+
+      job.terminate();
+      await job.waitForEmpty(5_000);
+      assert.equal(isProcessRunning(agentPid), false);
+    } finally {
+      job.close();
+      if (agentPid !== undefined && isProcessRunning(agentPid)) {
+        process.kill(agentPid, "SIGKILL");
+      }
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+async function waitForFile(filePath: string): Promise<string> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      return await fs.readFile(filePath, "utf8");
+    } catch (err) {
+      if (
+        typeof err !== "object" ||
+        err === null ||
+        !("code" in err) ||
+        err.code !== "ENOENT"
+      ) {
+        throw err;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  }
+  throw new Error("Timed out waiting for agent process ID");
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "code" in err &&
+      err.code === "ESRCH"
+    ) {
+      return false;
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- Track Windows agent processes in a Job Object so cleanup reaches descendants after the shell wrapper exits.
- Wait for the tracked process tree to empty before releasing session capacity.
- Add a Windows regression test and CI job.

Closes #71