### PR TITLE
Add runtime bridge settings to /acp-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,12 +327,19 @@ Examples:
 /acp-config set model gpt-5-mini
 /acp-config set mode plan
 /acp-config set reasoning_effort low
+/acp-config set bridge.thoughts off
+/acp-config set bridge.diffs on
+/acp-config set bridge.images off
+/acp-config set bridge.audio off
 ```
 
 Notes:
 
 - The command only works after the WeChat user already has an active ACP session. If not, send a normal message first so the session is created.
-- Available `configId` values come directly from the ACP agent's `configOptions`, so the exact list depends on the configured agent.
+- Agent-specific `configId` values come from the ACP agent's `configOptions`, so that part of the list depends on the configured agent.
+- The built-in `bridge.thoughts`, `bridge.diffs`, `bridge.images`, and `bridge.audio` options control output forwarding for the current WeChat user's session. They use the startup config as defaults, accept `on` or `off`, and are not persisted across session resets or bridge restarts.
+- Runtime bridge changes take effect on the next agent turn. They do not change a turn that is already running.
+- `agent.showResources` remains a startup-only setting and is not shown as a runtime option.
 - This command is handled by `wechat-acp` itself and is **not** forwarded to the underlying agent.
 - You can give this command your own aliases via `commandAliases` (see [Customizing bridge command names](#customizing-bridge-command-names-aliases)).
 
@@ -533,7 +540,7 @@ WECHAT_ACP_TELEMETRY=0 npx wechat-acp --agent copilot
 - `message.received` — message arrived; only the categorical kind (`text` / `image` / `voice` / `file` / `video` / `empty`) and a hashed user id
 - `message.injected` — local injection queued for processing; only target kind (`last-active-user` / `explicit`) and a hashed user id
 - `command.acp_config.view` — `/acp-config` invoked to list options; whether a session exists and the option count
-- `command.acp_config.set` — `/acp-config set` succeeded; `configId`, option type (`select` / `boolean`), and the resolved option value (all from the agent's declared `configOptions`, never the user's raw input)
+- `command.acp_config.set`: `/acp-config set` succeeded; `configId`, option type (`select` / `boolean`), and the resolved option value (from either a built-in bridge option or the agent's declared `configOptions`, never the user's raw input)
 - `command.acp_cancel` — `/acp-cancel` invoked; whether the queue was drained, whether an in-flight turn was actually cancelled, and how many queued messages were dropped
 - `command.buffer_start` — `/acp-prompt-start` invoked to enter buffering mode
 - `command.buffer_done` — `/acp-prompt-done` invoked to flush buffer; number of content blocks collected

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -350,18 +350,27 @@ export class WeChatAcpClient implements acp.Client {
    * (issue 54). Residual undelivered buffers present at the boundary are
    * logged and discarded. Await this before sending the next prompt.
    */
-  async beginTurn(callbacks: {
-    sendTyping: () => Promise<void>;
-    onThoughtFlush: (text: string) => Promise<void>;
-    onMessageFlush: (text: string) => Promise<void>;
-    onImageFlush?: (image: AgentImage) => Promise<void>;
-    onAudioFlush?: (audio: AgentAudio) => Promise<void>;
-    onFileFlush?: (file: AgentFile) => Promise<void>;
-  }): Promise<void> {
+  async beginTurn(
+    callbacks: {
+      sendTyping: () => Promise<void>;
+      onThoughtFlush: (text: string) => Promise<void>;
+      onMessageFlush: (text: string) => Promise<void>;
+      onImageFlush?: (image: AgentImage) => Promise<void>;
+      onAudioFlush?: (audio: AgentAudio) => Promise<void>;
+      onFileFlush?: (file: AgentFile) => Promise<void>;
+    },
+    outputSettings?: {
+      showThoughts: boolean;
+      showDiffs: boolean;
+      showImages: boolean;
+      showAudio: boolean;
+    },
+  ): Promise<void> {
     return this.enqueue(async () => {
       const previous = this.turn;
       const opts: WeChatAcpClientOpts = {
         ...previous.opts,
+        ...outputSettings,
         sendTyping: callbacks.sendTyping,
         onThoughtFlush: callbacks.onThoughtFlush,
         onMessageFlush: callbacks.onMessageFlush,

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -84,6 +84,15 @@ export interface ResetSessionResult {
   droppedQueueCount: number;
 }
 
+export interface RuntimeBridgeSettings {
+  thoughts: boolean;
+  diffs: boolean;
+  images: boolean;
+  audio: boolean;
+}
+
+export type RuntimeBridgeSetting = keyof RuntimeBridgeSettings;
+
 export interface SessionMcpLease {
   mcpServer: acp.McpServer;
   close(): Promise<void>;
@@ -202,6 +211,7 @@ export class SessionManager {
   private resetOperations = new Map<string, Promise<ResetSessionResult>>();
   private cleanupStates = new Map<string, SessionCleanupState>();
   private cleanupOperations = new Map<string, Promise<void>>();
+  private runtimeBridgeSettings = new WeakMap<UserSession, RuntimeBridgeSettings>();
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
   private opts: SessionManagerOpts;
   private aborted = false;
@@ -364,6 +374,28 @@ export class SessionManager {
 
   getSessionConfigOptions(userId: string): acp.SessionConfigOption[] | undefined {
     return this.sessions.get(userId)?.configOptions;
+  }
+
+  getRuntimeBridgeSettings(userId: string): RuntimeBridgeSettings | undefined {
+    const session = this.sessions.get(userId);
+    if (!session) return undefined;
+    return { ...this.getOrCreateRuntimeBridgeSettings(session) };
+  }
+
+  setRuntimeBridgeSetting(
+    userId: string,
+    setting: RuntimeBridgeSetting,
+    value: boolean,
+  ): RuntimeBridgeSettings {
+    const session = this.sessions.get(userId);
+    if (!session) {
+      throw new Error("No active ACP session for this chat yet. Send a normal message first.");
+    }
+
+    session.lastActivity = Date.now();
+    const settings = this.getOrCreateRuntimeBridgeSettings(session);
+    settings[setting] = value;
+    return { ...settings };
   }
 
   async setSessionConfigOption(
@@ -1029,6 +1061,7 @@ export class SessionManager {
           // prompt() rejected early) delivers with its own turn's callbacks
           // before the swap, and residual undelivered buffers are discarded at
           // the boundary instead of leaking into this turn (issue 54).
+          const outputSettings = { ...this.getOrCreateRuntimeBridgeSettings(session) };
           const beginTurn = session.client.beginTurn({
             sendTyping: () =>
               this.runIfCurrent(session, () =>
@@ -1101,6 +1134,11 @@ export class SessionManager {
                     ),
                 }
               : {}),
+          }, {
+            showThoughts: outputSettings.thoughts,
+            showDiffs: outputSettings.diffs,
+            showImages: outputSettings.images,
+            showAudio: outputSettings.audio,
           });
           await this.awaitAgentOperation(
             session,
@@ -1502,5 +1540,21 @@ export class SessionManager {
       this.opts.log(`[${session.userId}] Failed to persist ACP session: ${String(err)}`);
       trackException(err, "session.persistence", hashUserId(session.userId));
     }
+  }
+
+  private getOrCreateRuntimeBridgeSettings(
+    session: UserSession,
+  ): RuntimeBridgeSettings {
+    let settings = this.runtimeBridgeSettings.get(session);
+    if (!settings) {
+      settings = {
+        thoughts: this.opts.showThoughts,
+        diffs: this.opts.showDiffs ?? false,
+        images: this.opts.showImages ?? true,
+        audio: this.opts.showAudio ?? true,
+      };
+      this.runtimeBridgeSettings.set(session, settings);
+    }
+    return settings;
   }
 }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -17,6 +17,7 @@ import type { WeixinMessage } from "./weixin/types.js";
 import {
   SessionManager,
   type ResetSessionResult,
+  type RuntimeBridgeSetting,
 } from "./acp/session.js";
 import { AUDIO_MIME_EXTENSIONS } from "./acp/client.js";
 import type { AgentImage, AgentAudio, AgentFile } from "./acp/client.js";
@@ -57,6 +58,16 @@ const PENDING_TEXT_TTL_MS = 10 * 60 * 1000;
 const PENDING_TEXT_MAX_SEGMENTS = 50;
 const SEGMENT_SEND_MAX_ATTEMPTS = 3;
 const SEGMENT_SEND_RETRY_BASE_MS = 300;
+const RUNTIME_BRIDGE_CONFIG_OPTIONS: ReadonlyArray<{
+  id: string;
+  setting: RuntimeBridgeSetting;
+  name: string;
+}> = [
+  { id: "bridge.thoughts", setting: "thoughts", name: "Thoughts" },
+  { id: "bridge.diffs", setting: "diffs", name: "Diffs" },
+  { id: "bridge.images", setting: "images", name: "Images" },
+  { id: "bridge.audio", setting: "audio", name: "Audio" },
+];
 
 interface MessageBuffer {
   blocks: acp.ContentBlock[];
@@ -679,12 +690,15 @@ export class WeChatAcpBridge {
     const args = command.trim().split(/\s+/);
     if (args.length === 1) {
       const configOptions = this.sessionManager?.getSessionConfigOptions(userId);
+      const runtimeSettings = this.sessionManager?.getRuntimeBridgeSettings(userId);
       trackEvent(
         "command.acp_config.view",
         {
           userIdHash: hashUserId(userId),
-          hasSession: !!configOptions,
-          optionCount: configOptions?.length ?? 0,
+          hasSession: !!runtimeSettings,
+          optionCount: runtimeSettings
+            ? RUNTIME_BRIDGE_CONFIG_OPTIONS.length + (configOptions?.length ?? 0)
+            : 0,
         },
         hashUserId(userId),
       );
@@ -701,26 +715,52 @@ export class WeChatAcpBridge {
       const configId = args[2]!;
       const rawValue = args.slice(3).join(" ");
       try {
-        const resolved = this.resolveAcpConfigValue(userId, configId, rawValue);
-        await this.sessionManager!.setSessionConfigOption(userId, configId, resolved.rawValue);
+        const runtimeOption = RUNTIME_BRIDGE_CONFIG_OPTIONS.find(
+          (option) => option.id === configId,
+        );
+        let displayValue: string;
+        let optionType: string;
+        if (runtimeOption) {
+          if (!this.sessionManager?.getRuntimeBridgeSettings(userId)) {
+            throw new Error(
+              "No active ACP session for this chat yet. Send a normal message first.",
+            );
+          }
+          const value = this.resolveBooleanConfigValue(configId, rawValue);
+          this.sessionManager.setRuntimeBridgeSetting(
+            userId,
+            runtimeOption.setting,
+            value,
+          );
+          displayValue = value ? "on" : "off";
+          optionType = "boolean";
+        } else {
+          const resolved = this.resolveAcpConfigValue(userId, configId, rawValue);
+          await this.sessionManager!.setSessionConfigOption(
+            userId,
+            configId,
+            resolved.rawValue,
+          );
+          displayValue = resolved.displayValue;
+          optionType = this.sessionManager!
+            .getSessionConfigOptions(userId)
+            ?.find((option) => option.id === configId)?.type ?? "unknown";
+        }
         if (!this.isMessageGenerationCurrent(userId, generation)) return;
-        const optionType = this.sessionManager!
-          .getSessionConfigOptions(userId)
-          ?.find((o) => o.id === configId)?.type;
         trackEvent(
           "command.acp_config.set",
           {
             userIdHash: hashUserId(userId),
             configId,
-            optionType: optionType ?? "unknown",
-            optionValue: resolved.displayValue,
+            optionType,
+            optionValue: displayValue,
           },
           hashUserId(userId),
         );
         await this.sendReply(
           userId,
           contextToken,
-          `✅ Updated ACP config: ${configId} = ${resolved.displayValue}\n\n${this.formatAcpConfigList(userId)}`,
+          `✅ Updated ACP config: ${configId} = ${displayValue}\n\n${this.formatAcpConfigList(userId)}`,
         );
       } catch (err) {
         if (!this.isMessageGenerationCurrent(userId, generation)) return;
@@ -1653,29 +1693,41 @@ export class WeChatAcpBridge {
 
   private formatAcpConfigList(userId: string): string {
     const configOptions = this.sessionManager?.getSessionConfigOptions(userId);
-    if (!configOptions) {
+    const runtimeSettings = this.sessionManager?.getRuntimeBridgeSettings(userId);
+    if (!runtimeSettings) {
       return this.formatAcpConfigUsage(
         "No active ACP session for this chat yet. Send a normal message first.",
       );
     }
-    if (configOptions.length === 0) {
-      return this.formatAcpConfigUsage(
-        "The current ACP agent does not expose any configurable session options.",
-      );
-    }
 
     const lines: string[] = [];
+    lines.push("⚙️ **Runtime Bridge Config**");
+    lines.push("━━━━━━━━━━━━━━━━");
+
+    for (const option of RUNTIME_BRIDGE_CONFIG_OPTIONS) {
+      lines.push("");
+      lines.push(`📌 **${option.name}**  (id: \`${option.id}\`)`);
+      lines.push(`   • Current: ${runtimeSettings[option.setting] ? "on" : "off"}`);
+      lines.push("   • Options: on | off");
+    }
+
+    lines.push("");
     lines.push("⚙️ **ACP Session Config**");
     lines.push("━━━━━━━━━━━━━━━━");
 
-    for (const option of configOptions) {
+    if (!configOptions || configOptions.length === 0) {
       lines.push("");
-      lines.push(`📌 **${option.name}**  (id: \`${option.id}\`)`);
-      lines.push(`   • Current: ${this.describeCurrentConfigValue(option)}`);
-      if (option.type === "select") {
-        lines.push(`   • Options: ${this.listConfigOptionChoices(option).join(" | ")}`);
-      } else if (option.type === "boolean") {
-        lines.push(`   • Options: true | false`);
+      lines.push("The current ACP agent does not expose any configurable session options.");
+    } else {
+      for (const option of configOptions) {
+        lines.push("");
+        lines.push(`📌 **${option.name}**  (id: \`${option.id}\`)`);
+        lines.push(`   • Current: ${this.describeCurrentConfigValue(option)}`);
+        if (option.type === "select") {
+          lines.push(`   • Options: ${this.listConfigOptionChoices(option).join(" | ")}`);
+        } else if (option.type === "boolean") {
+          lines.push(`   • Options: true | false`);
+        }
       }
     }
 
@@ -1729,14 +1781,8 @@ export class WeChatAcpBridge {
     }
 
     if (option.type === "boolean") {
-      const normalized = rawValue.trim().toLowerCase();
-      if (["true", "on", "1", "yes"].includes(normalized)) {
-        return { rawValue: true, displayValue: "true" };
-      }
-      if (["false", "off", "0", "no"].includes(normalized)) {
-        return { rawValue: false, displayValue: "false" };
-      }
-      throw new Error(`Invalid boolean value for ${configId}: ${rawValue}`);
+      const value = this.resolveBooleanConfigValue(configId, rawValue);
+      return { rawValue: value, displayValue: String(value) };
     }
 
     const candidates = this.flattenSelectOptions(option.options).filter((choice) =>
@@ -1756,6 +1802,17 @@ export class WeChatAcpBridge {
       rawValue: match.value,
       displayValue: this.describeConfigChoice(match),
     };
+  }
+
+  private resolveBooleanConfigValue(configId: string, rawValue: string): boolean {
+    const normalized = rawValue.trim().toLowerCase();
+    if (["true", "on", "1", "yes"].includes(normalized)) {
+      return true;
+    }
+    if (["false", "off", "0", "no"].includes(normalized)) {
+      return false;
+    }
+    throw new Error(`Invalid boolean value for ${configId}: ${rawValue}`);
   }
 
   private flattenSelectOptions(

--- a/tests/bridge-new-session.test.ts
+++ b/tests/bridge-new-session.test.ts
@@ -373,11 +373,23 @@ test("a config update that finishes after reset cannot send a stale reply", asyn
     bridge as unknown as {
       sessionManager: {
         getSessionConfigOptions(): typeof option[];
+        getRuntimeBridgeSettings(): {
+          thoughts: boolean;
+          diffs: boolean;
+          images: boolean;
+          audio: boolean;
+        };
         setSessionConfigOption(): Promise<typeof option[]>;
       };
     }
   ).sessionManager = {
     getSessionConfigOptions: () => [option],
+    getRuntimeBridgeSettings: () => ({
+      thoughts: true,
+      diffs: false,
+      images: true,
+      audio: true,
+    }),
     setSessionConfigOption: async () => {
       updateStarted();
       await finished;
@@ -404,6 +416,59 @@ test("a config update that finishes after reset cannot send a stale reply", asyn
   );
   assert.ok(
     bridge.sent.some(({ segment }) => segment.includes("ACP session cleared")),
+  );
+});
+
+test("acp-config updates runtime bridge settings without calling the agent", async () => {
+  const bridge = makeBridge();
+  const settings = {
+    thoughts: true,
+    diffs: false,
+    images: true,
+    audio: true,
+  };
+  const updates: Array<{ setting: string; value: boolean }> = [];
+  (
+    bridge as unknown as {
+      sessionManager: {
+        getSessionConfigOptions(): [];
+        getRuntimeBridgeSettings(): typeof settings;
+        setRuntimeBridgeSetting(
+          userId: string,
+          setting: keyof typeof settings,
+          value: boolean,
+        ): typeof settings;
+        setSessionConfigOption(): Promise<never>;
+      };
+    }
+  ).sessionManager = {
+    getSessionConfigOptions: () => [],
+    getRuntimeBridgeSettings: () => ({ ...settings }),
+    setRuntimeBridgeSetting: (_userId, setting, value) => {
+      settings[setting] = value;
+      updates.push({ setting, value });
+      return { ...settings };
+    },
+    setSessionConfigOption: async () => {
+      throw new Error("agent config must not be called");
+    },
+  };
+
+  await bridge.handleMessage(
+    textMessage(
+      `${BRIDGE_COMMANDS.acpConfig} set bridge.diffs on`,
+      "context-config",
+    ),
+  );
+
+  assert.deepEqual(updates, [{ setting: "diffs", value: true }]);
+  assert.equal(bridge.enqueued.length, 0);
+  assert.ok(
+    bridge.sent.some(({ segment }) =>
+      segment.includes("bridge.diffs = on") &&
+      segment.includes("Runtime Bridge Config") &&
+      segment.includes("ACP Session Config")
+    ),
   );
 });
 

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -170,6 +170,71 @@ test("session creation failures are surfaced to the WeChat user", async () => {
   ]);
 });
 
+test("runtime bridge settings are scoped to a session and applied at the next turn", async () => {
+  const appliedSettings: unknown[] = [];
+  const manager = new SessionManager({
+    agentCommand: "unused",
+    agentArgs: [],
+    agentCwd: process.cwd(),
+    idleTimeoutMs: 0,
+    maxConcurrentUsers: 1,
+    showThoughts: true,
+    showDiffs: false,
+    showImages: true,
+    showAudio: true,
+    log: () => {},
+    onReply: async () => {},
+    sendTyping: async () => {},
+  });
+  const session = makeTurnSession({
+    flushText: "",
+    producedMessage: true,
+    events: [],
+  });
+  session.client.beginTurn = async (_callbacks, settings) => {
+    appliedSettings.push(settings);
+  };
+  const internal = manager as unknown as {
+    sessions: Map<string, UserSession>;
+    processQueue(session: UserSession): Promise<void>;
+  };
+  internal.sessions.set(session.userId, session);
+
+  assert.deepEqual(manager.getRuntimeBridgeSettings(session.userId), {
+    thoughts: true,
+    diffs: false,
+    images: true,
+    audio: true,
+  });
+  manager.setRuntimeBridgeSetting(session.userId, "thoughts", false);
+  manager.setRuntimeBridgeSetting(session.userId, "diffs", true);
+  manager.setRuntimeBridgeSetting(session.userId, "images", false);
+  manager.setRuntimeBridgeSetting(session.userId, "audio", false);
+
+  await internal.processQueue(session);
+
+  assert.deepEqual(appliedSettings, [{
+    showThoughts: false,
+    showDiffs: true,
+    showImages: false,
+    showAudio: false,
+  }]);
+
+  const replacementSession = makeTurnSession({
+    flushText: "",
+    producedMessage: true,
+    events: [],
+  });
+  internal.sessions.set(session.userId, replacementSession);
+  assert.deepEqual(manager.getRuntimeBridgeSettings(session.userId), {
+    thoughts: true,
+    diffs: false,
+    images: true,
+    audio: true,
+  });
+  assert.equal(manager.getRuntimeBridgeSettings("other-user"), undefined);
+});
+
 function makeTurnSession(opts: {
   flushText: string;
   producedMessage: boolean;


### PR DESCRIPTION
## Summary

- add `bridge.thoughts`, `bridge.diffs`, `bridge.images`, and `bridge.audio` to `/acp-config`
- keep overrides per WeChat user session and in memory only
- snapshot settings at the start of each turn so active turns keep consistent output behavior
- keep agent-provided ACP session options unchanged

## Usage

```text
/acp-config set bridge.thoughts off
/acp-config set bridge.diffs on
/acp-config set bridge.images off
/acp-config set bridge.audio off
```

Closes #74