### PR TITLE
Limit showImages to inline tool output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Limit `--hide-images` and `agent.showImages: false` to inline images emitted
+  by tool calls, including Copilot CLI `rawOutput` fallbacks and embedded image
+  resources. Explicit agent message images and attached `resource_link` images
+  are always sent.
+
 - Add `/acp-new` to clear one WeChat user's ACP conversation without restarting
   the bridge. The command stops that user's active turn and agent process, drops
   queued and buffered messages, removes the persisted session ID for every

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Options:
 - `--no-inbox`: do not save received files; the agent only sees a size notice.
 - `--hide-thoughts`: do not forward agent thinking to WeChat (default: forwarded)
 - `--show-diffs`: forward ACP file diffs to WeChat (default: hidden)
-- `--hide-images`: do not forward agent image output to WeChat (default: forwarded)
+- `--hide-images`: suppress inline images from tool calls. Explicit agent message images and attachments are still sent.
 - `--hide-audio`: do not forward agent audio output to WeChat (default: forwarded)
 - `--hide-resources`: do not forward agent resources or generated file attachments to WeChat (default: forwarded)
 - `inject --text <text>`: enqueue a local text message for the running daemon
@@ -454,6 +454,11 @@ When the ACP agent advertises HTTP MCP support, `wechat-acp` injects a local
 created under the configured working directory, and the bridge sends that
 snapshot back as a WeChat file message. Files whose type is a supported image
 are delivered as native WeChat images instead of file cards.
+
+Tool calls may also expose intermediate screenshots or video frames as inline
+images. Use `--hide-images` or `agent.showImages: false` to suppress them.
+Images that the agent explicitly emits in its response or sends through an
+attached `resource_link` are always sent.
 
 The MCP server listens only on a random `127.0.0.1` port, requires a
 process-local bearer token, rejects browser-origin requests, and only reads

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Notes:
 
 - The command only works after the WeChat user already has an active ACP session. If not, send a normal message first so the session is created.
 - Agent-specific `configId` values come from the ACP agent's `configOptions`, so that part of the list depends on the configured agent.
-- The built-in `bridge.thoughts`, `bridge.diffs`, `bridge.images`, and `bridge.audio` options control output forwarding for the current WeChat user's session. They use the startup config as defaults, accept `on` or `off`, and are not persisted across session resets or bridge restarts.
+- The built-in `bridge.thoughts`, `bridge.diffs`, and `bridge.audio` options control output forwarding for the current WeChat user's session. `bridge.images` controls only inline tool images; explicit response images and attached `resource_link` images are always sent. These options use the startup config as defaults, accept `on` or `off`, and are not persisted across session resets or bridge restarts.
 - Runtime bridge changes take effect on the next agent turn. They do not change a turn that is already running.
 - `agent.showResources` remains a startup-only setting and is not shown as a runtime option.
 - This command is handled by `wechat-acp` itself and is **not** forwarded to the underlying agent.

--- a/bin/wechat-acp.ts
+++ b/bin/wechat-acp.ts
@@ -83,7 +83,7 @@ Options:
                       Send a standalone message after each completed agent turn
   --hide-thoughts     Do not forward agent thinking to WeChat (default: forwarded)
   --show-diffs        Forward ACP file diffs to WeChat (default: hidden)
-  --hide-images       Do not forward agent image output to WeChat (default: forwarded)
+  --hide-images       Do not forward intermediate inline tool images to WeChat
   --hide-audio        Do not forward agent audio output to WeChat (default: forwarded)
   --hide-resources    Do not forward agent embedded resources to WeChat (default: forwarded)
   --text <text>       Message text for "inject"

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -24,6 +24,8 @@ export interface AgentImage {
   mimeType: string;
 }
 
+type ImageSource = "explicit" | "tool";
+
 /** Raster formats WeChat can render as native image messages. */
 const SUPPORTED_IMAGE_MIME_TYPES = new Set([
   "image/png",
@@ -459,13 +461,13 @@ export class WeChatAcpClient implements acp.Client {
             turn.producedMessage = true;
           }
         } else if (update.content.type === "image") {
-          await this.maybeSendImage(update.content, turn);
+          await this.maybeSendImage(update.content, turn, "explicit");
         } else if (update.content.type === "audio") {
           await this.maybeSendAudio(update.content, turn);
         } else if (update.content.type === "resource") {
-          await this.maybeRenderResource(update.content.resource, turn);
+          await this.maybeRenderResource(update.content.resource, turn, "explicit");
         } else if (update.content.type === "resource_link") {
-          await this.maybeSendResourceLink(update.content, turn);
+          await this.maybeSendResourceLink(update.content, turn, "explicit");
         }
         // Throttle typing indicators
         await this.maybeSendTyping(turn);
@@ -477,7 +479,7 @@ export class WeChatAcpClient implements acp.Client {
         if (update.status === "completed" && update.content) {
           for (const content of update.content) {
             if (content.type === "content" && content.content.type === "resource_link") {
-              await this.maybeSendResourceLink(content.content, turn);
+              await this.maybeSendResourceLink(content.content, turn, "explicit");
             }
           }
         }
@@ -522,17 +524,17 @@ export class WeChatAcpClient implements acp.Client {
               turn.producedMessage = true;
             } else if (c.type === "content" && c.content.type === "image") {
               imageContentBlocks++;
-              await this.maybeSendImage(c.content, turn);
+              await this.maybeSendImage(c.content, turn, "tool");
             } else if (c.type === "content" && c.content.type === "audio") {
               await this.maybeSendAudio(c.content, turn);
             } else if (c.type === "content" && c.content.type === "resource") {
               resourceContentBlocks++;
-              if (await this.maybeRenderResource(c.content.resource, turn)) {
+              if (await this.maybeRenderResource(c.content.resource, turn, "tool")) {
                 resourceImages++;
               }
             } else if (c.type === "content" && c.content.type === "resource_link") {
               resourceLinkContentBlocks++;
-              if (await this.maybeSendResourceLink(c.content, turn)) {
+              if (await this.maybeSendResourceLink(c.content, turn, "explicit")) {
                 resourceLinkImages++;
               }
             }
@@ -695,7 +697,7 @@ export class WeChatAcpClient implements acp.Client {
         mimeType.trim()
       ) {
         images++;
-        await this.maybeSendImage({ data, mimeType }, turn);
+        await this.maybeSendImage({ data, mimeType }, turn, "tool");
       }
     }
     return images;
@@ -767,7 +769,7 @@ export class WeChatAcpClient implements acp.Client {
           continue;
         }
         resources++;
-        if (await this.maybeRenderResource(clean, turn)) {
+        if (await this.maybeRenderResource(clean, turn, "tool")) {
           images++;
         }
       }
@@ -794,7 +796,7 @@ export class WeChatAcpClient implements acp.Client {
         blob: data,
         ...(typeof mimeType === "string" ? { mimeType } : {}),
       };
-      if (await this.maybeRenderResource(clean, turn)) {
+      if (await this.maybeRenderResource(clean, turn, "tool")) {
         images++;
       }
     }
@@ -835,6 +837,7 @@ export class WeChatAcpClient implements acp.Client {
           ...(typeof size === "number" ? { size } : {}),
         },
         turn,
+        "explicit",
       )) {
         images++;
       }
@@ -845,6 +848,7 @@ export class WeChatAcpClient implements acp.Client {
   private async maybeSendResourceLink(
     link: AgentResourceLink,
     turn: TurnState,
+    source: ImageSource,
   ): Promise<boolean> {
     const opts = turn.opts;
     const name = sanitizeInlineLabel(link.name ?? resourceDisplayName(link.uri));
@@ -852,9 +856,13 @@ export class WeChatAcpClient implements acp.Client {
       .split(";")[0]
       .trim()
       .toLowerCase();
+    if (source === "tool" && opts.showImages === false && mimeType.startsWith("image/")) {
+      opts.log(`[resource-link] skipped tool image (showImages=false, ${name})`);
+      return true;
+    }
     const routesToImagePipeline =
       SUPPORTED_IMAGE_MIME_TYPES.has(mimeType) &&
-      opts.showImages !== false &&
+      (source !== "tool" || opts.showImages !== false) &&
       Boolean(opts.onImageFlush);
     if (opts.showResources === false) {
       opts.log(`[resource-link] skipped (showResources=false, ${name})`);
@@ -881,7 +889,7 @@ export class WeChatAcpClient implements acp.Client {
         opts.log(`[resource-link] unavailable: ${name}`);
         return false;
       }
-      return await this.maybeSendFile(file, turn);
+      return await this.maybeSendFile(file, turn, source);
     } catch (err) {
       turn.chunks.push(`\n⚠️ [file ${name} could not be resolved]\n`);
       turn.producedMessage = true;
@@ -894,21 +902,29 @@ export class WeChatAcpClient implements acp.Client {
    * Deliver a resolved file and return whether it was routed through the
    * native image pipeline. A successful generic file delivery returns false.
    */
-  private async maybeSendFile(file: AgentFile, turn: TurnState): Promise<boolean> {
+  private async maybeSendFile(
+    file: AgentFile,
+    turn: TurnState,
+    source: ImageSource,
+  ): Promise<boolean> {
     const opts = turn.opts;
     const name = sanitizeInlineLabel(file.name) || "artifact";
     const mimeType =
       sanitizeInlineLabel(file.mimeType).split(";")[0].trim().toLowerCase() ||
       "application/octet-stream";
+    if (source === "tool" && opts.showImages === false && mimeType.startsWith("image/")) {
+      opts.log(`[file] skipped tool image (showImages=false, ${name})`);
+      return true;
+    }
     const decodedBytes = decodedBase64ByteLength(file.data);
     if (
-      opts.showImages !== false &&
+      (source !== "tool" || opts.showImages !== false) &&
       opts.onImageFlush &&
       SUPPORTED_IMAGE_MIME_TYPES.has(mimeType) &&
       base64DecodedByteUpperBound(file.data) <= MAX_IMAGE_BYTES
     ) {
       opts.log(`[file] routing image file ${name} through image pipeline (${mimeType}, ${decodedBytes} bytes)`);
-      await this.maybeSendImage({ data: file.data, mimeType }, turn);
+      await this.maybeSendImage({ data: file.data, mimeType }, turn, source);
       return true;
     }
 
@@ -955,12 +971,13 @@ export class WeChatAcpClient implements acp.Client {
   private async maybeSendImage(
     image: { data: string; mimeType: string },
     turn: TurnState,
+    source: ImageSource,
   ): Promise<void> {
     const opts = turn.opts;
     // Trim once here so every image path (content block, message chunk,
     // rawOutput fallback) validates and delivers the same normalized value.
     const mimeType = image.mimeType.trim();
-    if (opts.showImages === false) {
+    if (source === "tool" && opts.showImages === false) {
       opts.log(`[image] skipped (showImages=false, ${mimeType})`);
       return;
     }
@@ -1076,6 +1093,7 @@ export class WeChatAcpClient implements acp.Client {
   private async maybeRenderResource(
     resource: acp.EmbeddedResource["resource"],
     turn: TurnState,
+    source: ImageSource,
   ): Promise<boolean> {
     const opts = turn.opts;
     const name = resourceDisplayName(resource.uri);
@@ -1090,10 +1108,19 @@ export class WeChatAcpClient implements acp.Client {
     // through to the visible placeholder instead.
     const mime = sanitizeInlineLabel(resource.mimeType ?? "");
     const baseMime = mime.split(";")[0].trim().toLowerCase();
+    if (
+      !("text" in resource) &&
+      source === "tool" &&
+      opts.showImages === false &&
+      baseMime.startsWith("image/")
+    ) {
+      opts.log(`[resource] skipped tool image (showImages=false, ${name})`);
+      return true;
+    }
     const routesToImagePipeline =
       !("text" in resource) &&
       SUPPORTED_IMAGE_MIME_TYPES.has(baseMime) &&
-      opts.showImages !== false &&
+      (source !== "tool" || opts.showImages !== false) &&
       Boolean(opts.onImageFlush);
     if (opts.showResources === false) {
       opts.log(`[resource] skipped (showResources=false, ${name})`);
@@ -1127,7 +1154,7 @@ export class WeChatAcpClient implements acp.Client {
     if (routesToImagePipeline) {
       // Route through the image pipeline so an image handed back as an
       // embedded resource behaves exactly like an image content block.
-      await this.maybeSendImage({ data: resource.blob, mimeType: baseMime }, turn);
+      await this.maybeSendImage({ data: resource.blob, mimeType: baseMime }, turn, source);
       return true;
     }
 
@@ -1150,6 +1177,7 @@ export class WeChatAcpClient implements acp.Client {
         mimeType: baseMime || "application/octet-stream",
       },
       turn,
+      source,
     );
     return false;
   }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -65,7 +65,7 @@ const RUNTIME_BRIDGE_CONFIG_OPTIONS: ReadonlyArray<{
 }> = [
   { id: "bridge.thoughts", setting: "thoughts", name: "Thoughts" },
   { id: "bridge.diffs", setting: "diffs", name: "Diffs" },
-  { id: "bridge.images", setting: "images", name: "Images" },
+  { id: "bridge.images", setting: "images", name: "Tool Images" },
   { id: "bridge.audio", setting: "audio", name: "Audio" },
 ];
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -132,9 +132,9 @@ export interface WeChatAcpConfig {
     showThoughts: boolean;
     showDiffs?: boolean;
     /**
-     * Render agent-produced ACP `image` content blocks as native WeChat
-     * image messages. Defaults to `true`; set to `false` (or pass
-     * `--hide-images`) to drop them.
+     * Render inline images produced inside ACP tool calls. Defaults to `true`;
+     * set to `false` (or pass `--hide-images`) to suppress intermediate tool
+     * images. Explicit agent message images and attachments are always sent.
      */
     showImages?: boolean;
     /**

--- a/tests/bridge-new-session.test.ts
+++ b/tests/bridge-new-session.test.ts
@@ -456,16 +456,17 @@ test("acp-config updates runtime bridge settings without calling the agent", asy
 
   await bridge.handleMessage(
     textMessage(
-      `${BRIDGE_COMMANDS.acpConfig} set bridge.diffs on`,
+      `${BRIDGE_COMMANDS.acpConfig} set bridge.images off`,
       "context-config",
     ),
   );
 
-  assert.deepEqual(updates, [{ setting: "diffs", value: true }]);
+  assert.deepEqual(updates, [{ setting: "images", value: false }]);
   assert.equal(bridge.enqueued.length, 0);
   assert.ok(
     bridge.sent.some(({ segment }) =>
-      segment.includes("bridge.diffs = on") &&
+      segment.includes("bridge.images = off") &&
+      segment.includes("**Tool Images**") &&
       segment.includes("Runtime Bridge Config") &&
       segment.includes("ACP Session Config")
     ),

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -477,7 +477,7 @@ test("text before an image is flushed first so ordering is preserved", async () 
   assert.equal(tail, "anything else?");
 });
 
-test("showImages=false drops images without calling the sink", async () => {
+test("showImages=false drops tool images without calling the sink", async () => {
   const images: AgentImage[] = [];
   const client = makeClient({
     onImageFlush: async (img) => { images.push(img); },
@@ -490,6 +490,79 @@ test("showImages=false drops images without calling the sink", async () => {
   assert.equal(images.length, 0);
   assert.equal(client.hasProducedMessage, false);
   assert.equal(await client.flush(), "", "no placeholder for intentionally hidden images");
+});
+
+test("showImages=false hides tool images but keeps explicit agent images", async () => {
+  const images: AgentImage[] = [];
+  const client = makeClient({
+    onImageFlush: async (img) => { images.push(img); },
+    showImages: false,
+  });
+  client.newTurn();
+
+  await emitToolCallImage(client, { data: PNG_BASE64, mimeType: "image/png" });
+  await emitToolCallRawOutputImage(client, {
+    binaryResultsForLlm: [{ type: "image", data: PNG_BASE64, mimeType: "image/png" }],
+  });
+  await emitMessageChunkImage(client, { data: PNG_BASE64, mimeType: "image/jpeg" });
+
+  assert.deepEqual(images, [{ data: PNG_BASE64, mimeType: "image/jpeg" }]);
+  assert.equal(client.hasProducedMessage, true, "explicit agent image counts as output");
+});
+
+test("showImages=false drops tool image resources without file fallback", async () => {
+  const images: AgentImage[] = [];
+  const files: AgentFile[] = [];
+  const client = makeClient({
+    onImageFlush: async (img) => { images.push(img); },
+    onFileFlush: async (file) => { files.push(file); },
+    showImages: false,
+  });
+  client.newTurn();
+
+  await emitToolCallResource(client, {
+    uri: "file:///frame.png",
+    mimeType: "image/png",
+    blob: PNG_BASE64,
+  });
+
+  assert.equal(images.length, 0);
+  assert.equal(files.length, 0);
+  assert.equal(client.hasProducedMessage, false);
+  assert.equal(await client.flush(), "");
+});
+
+test("showImages=false keeps explicit image resource links", async () => {
+  const images: AgentImage[] = [];
+  const client = makeClient({
+    resolveResourceLink: async () => ({
+      data: PNG_BASE64,
+      name: "requested-frame.png",
+      mimeType: "image/png",
+    }),
+    onImageFlush: async (img) => { images.push(img); },
+    showImages: false,
+  });
+  client.newTurn();
+
+  await client.sessionUpdate({
+    update: {
+      sessionUpdate: "tool_call_update",
+      toolCallId: "tc-attachment-1",
+      status: "completed",
+      content: [{
+        type: "content",
+        content: {
+          type: "resource_link",
+          uri: "wechat-acp://artifact/requested-frame",
+          name: "requested-frame.png",
+          mimeType: "image/png",
+        },
+      }],
+    },
+  } as never);
+
+  assert.deepEqual(images, [{ data: PNG_BASE64, mimeType: "image/png" }]);
 });
 
 test("unsupported mime type is skipped silently", async () => {
@@ -982,7 +1055,7 @@ test("padded image at the decoded limit falls back to file delivery", async () =
   assert.equal(files[0].name, "limit.png");
 });
 
-test("image resource_link falls back to file delivery when images are hidden", async () => {
+test("image resource_link remains a native image when tool images are hidden", async () => {
   const images: AgentImage[] = [];
   const files: AgentFile[] = [];
   const client = makeClient({
@@ -1012,10 +1085,8 @@ test("image resource_link falls back to file delivery when images are hidden", a
     },
   } as never);
 
-  assert.equal(images.length, 0);
-  assert.deepEqual(files, [
-    { data: PNG_BASE64, name: "hidden-image.jpg", mimeType: "image/jpeg" },
-  ]);
+  assert.deepEqual(images, [{ data: PNG_BASE64, mimeType: "image/jpeg" }]);
+  assert.equal(files.length, 0);
 });
 
 test("completed tool_call resource_link is delivered for Codex-style output", async () => {
@@ -1292,7 +1363,7 @@ test("unsupported image blob resource falls back to the placeholder instead of v
   assert.match(text, /📎 \[resource: scan\.tiff \(image\/tiff, ~\d+ bytes\) - binary content not rendered\]/);
 });
 
-test("image blob resource with showImages=false surfaces as a placeholder, not a silent drop", async () => {
+test("explicit image blob resource remains visible when tool images are hidden", async () => {
   const images: AgentImage[] = [];
   const client = makeClient({
     onImageFlush: async (img) => { images.push(img); },
@@ -1300,16 +1371,15 @@ test("image blob resource with showImages=false surfaces as a placeholder, not a
   });
   client.newTurn();
 
-  await emitToolCallResource(client, {
+  await emitMessageChunkResource(client, {
     uri: "file:///chart.png",
     mimeType: "image/png",
     blob: PNG_BASE64,
   });
 
-  assert.equal(images.length, 0, "hidden images must not hit the image sink");
-  assert.equal(client.hasProducedMessage, true, "resource-only turn still counts as produced output");
-  const text = await client.flush();
-  assert.match(text, /📎 \[resource: chart\.png \(image\/png, ~\d+ bytes\) - binary content not rendered\]/);
+  assert.deepEqual(images, [{ data: PNG_BASE64, mimeType: "image/png" }]);
+  assert.equal(client.hasProducedMessage, true);
+  assert.equal(await client.flush(), "");
 });
 
 test("image blob resource without an image sink surfaces as a placeholder", async () => {


### PR DESCRIPTION
## Summary

- make `showImages` and `--hide-images` suppress only inline tool images
- keep explicit agent message images and `resource_link` attachments enabled
- cover standard tool images, embedded resources, and Copilot CLI `rawOutput` fallbacks
- update CLI and configuration documentation

## Testing

- `node --import tsx/esm --test tests/client.test.ts`
- `npm run build`

Closes #76