### PR TITLE
Route long tool resources to file attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
   by tool calls, including Copilot CLI `rawOutput` fallbacks and embedded image
   resources. Explicit agent message images and attached `resource_link` images
   are always sent.
+- Limit `--hide-resources`, `agent.showResources: false`, and
+  `bridge.resources off` to intermediate tool resources. Explicit agent
+  resources and files sent through `attach_file` are always delivered, and the
+  artifact MCP server remains available when tool resources are hidden. Tool
+  text resources now render inline only up to `agent.resourceInlineLimit`
+  characters, default `1000`; longer resources are sent as file attachments.
+  Configure the startup threshold with `--resource-inline-limit <chars>`, using
+  `0` to attach every non-empty tool text resource. Fixes #78.
 
 - Add `/acp-new` to clear one WeChat user's ACP conversation without restarting
   the bridge. The command stops that user's active turn and agent process, drops

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Options:
 - `--show-diffs`: forward ACP file diffs to WeChat (default: hidden)
 - `--hide-images`: suppress inline images from tool calls. Explicit agent message images and attachments are still sent.
 - `--hide-audio`: do not forward agent audio output to WeChat (default: forwarded)
-- `--hide-resources`: do not forward agent resources or generated file attachments to WeChat (default: forwarded)
+- `--hide-resources`: do not forward intermediate tool resources to WeChat (default: forwarded). Explicit agent resources and files sent with `attach_file` are still delivered.
+- `--resource-inline-limit <chars>`: render tool text resources up to this length inline and send longer ones as file attachments (default: `1000`; range: `0` to `4000`; use `0` to attach all non-empty tool text resources)
 - `inject --text <text>`: enqueue a local text message for the running daemon
 - `-V, --version`: print version and exit
 - `-h, --help`: show help
@@ -159,7 +160,8 @@ Example:
   "agent": {
     "preset": "copilot",
     "cwd": "D:/code/project",
-    "showDiffs": true
+    "showDiffs": true,
+    "resourceInlineLimit": 1000
   },
   "session": {
     "idleTimeoutMs": 86400000,
@@ -331,15 +333,15 @@ Examples:
 /acp-config set bridge.diffs on
 /acp-config set bridge.images off
 /acp-config set bridge.audio off
+/acp-config set bridge.resources off
 ```
 
 Notes:
 
 - The command only works after the WeChat user already has an active ACP session. If not, send a normal message first so the session is created.
 - Agent-specific `configId` values come from the ACP agent's `configOptions`, so that part of the list depends on the configured agent.
-- The built-in `bridge.thoughts`, `bridge.diffs`, and `bridge.audio` options control output forwarding for the current WeChat user's session. `bridge.images` controls only inline tool images; explicit response images and attached `resource_link` images are always sent. These options use the startup config as defaults, accept `on` or `off`, and are not persisted across session resets or bridge restarts.
+- The built-in `bridge.thoughts`, `bridge.diffs`, `bridge.audio`, and `bridge.resources` options control intermediate output forwarding for the current WeChat user's session. `bridge.resources off` hides tool resources, including entries from `tool_call_update.rawOutput.contents[]`. When tool resources are on, `agent.resourceInlineLimit` controls whether tool text resources are rendered inline or sent as attachments. `bridge.images` controls only inline tool images. Explicit agent resources, explicit response images, and files sent with `attach_file` are always delivered. These options use the startup config as defaults, accept `on` or `off`, and are not persisted across session resets or bridge restarts.
 - Runtime bridge changes take effect on the next agent turn. They do not change a turn that is already running.
-- `agent.showResources` remains a startup-only setting and is not shown as a runtime option.
 - This command is handled by `wechat-acp` itself and is **not** forwarded to the underlying agent.
 - You can give this command your own aliases via `commandAliases` (see [Customizing bridge command names](#customizing-bridge-command-names-aliases)).
 
@@ -464,8 +466,15 @@ are delivered as native WeChat images instead of file cards.
 
 Tool calls may also expose intermediate screenshots or video frames as inline
 images. Use `--hide-images` or `agent.showImages: false` to suppress them.
-Images that the agent explicitly emits in its response or sends through an
-attached `resource_link` are always sent.
+Images that the agent explicitly emits in its response are always sent.
+Images sent through `attach_file` are always sent.
+
+Tool text resources up to `agent.resourceInlineLimit` characters are shown
+inline. Longer tool text resources are sent as file attachments. The default is
+`1000`; set `--resource-inline-limit 0` to attach every non-empty tool text
+resource. Use `--hide-resources` or `/acp-config set bridge.resources off` to
+hide intermediate tool resources. Explicit agent resources and `attach_file`
+results are still delivered.
 
 The MCP server listens only on a random `127.0.0.1` port, requires a
 process-local bearer token, rejects browser-origin requests, and only reads
@@ -475,8 +484,8 @@ Files are limited to 25 MiB, kept briefly in memory, and consumed once.
 This also handles standard ACP `resource_link` output and Copilot CLI's
 `rawOutput.contents[type=resource_link]` compatibility shape. Agents that do
 not support HTTP MCP injection or do not forward resource links cannot use the
-active `attach_file` flow. `--hide-resources` disables both the tool injection
-and outbound resource/file delivery.
+active `attach_file` flow. Resource visibility settings do not disable the tool
+or its outbound file delivery.
 
 ## Storage
 

--- a/bin/wechat-acp.ts
+++ b/bin/wechat-acp.ts
@@ -22,6 +22,7 @@ import {
   defaultConfig,
   defaultStorageDir,
   listBuiltInAgents,
+  parseResourceInlineLimit,
   parseSessionResumePolicy,
   resolveAgentSelection,
   validateCommandAliases,
@@ -85,7 +86,10 @@ Options:
   --show-diffs        Forward ACP file diffs to WeChat (default: hidden)
   --hide-images       Do not forward intermediate inline tool images to WeChat
   --hide-audio        Do not forward agent audio output to WeChat (default: forwarded)
-  --hide-resources    Do not forward agent embedded resources to WeChat (default: forwarded)
+  --hide-resources    Do not forward intermediate tool resources
+  --resource-inline-limit <chars>
+                       Attach longer text resources as files (default: 1000)
+                       Valid range: 0-4000; 0 attaches every non-empty text resource
   --text <text>       Message text for "inject"
   --file <path>       Read injected message text from a file
   --to <target>       Injection target (default: ${DEFAULT_INJECTION_TARGET})
@@ -150,6 +154,7 @@ function parseArgs(argv: string[]): {
   hideImages: boolean;
   hideAudio: boolean;
   hideResources: boolean;
+  resourceInlineLimit?: number;
   verbose: boolean;
   version: boolean;
   help: boolean;
@@ -242,6 +247,9 @@ function parseArgs(argv: string[]): {
         break;
       case "--hide-resources":
         result.hideResources = true;
+        break;
+      case "--resource-inline-limit":
+        result.resourceInlineLimit = Number(args[++i]);
         break;
       case "-v":
       case "--verbose":
@@ -537,6 +545,14 @@ async function main(): Promise<void> {
   if (args.hideImages) config.agent.showImages = false;
   if (args.hideAudio) config.agent.showAudio = false;
   if (args.hideResources) config.agent.showResources = false;
+  try {
+    config.agent.resourceInlineLimit = parseResourceInlineLimit(
+      args.resourceInlineLimit ?? config.agent.resourceInlineLimit,
+    );
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
+    process.exit(1);
+  }
   config.daemon.enabled = args.daemon;
 
   // Handle daemon mode

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -937,6 +937,7 @@ export class WeChatAcpClient implements acp.Client {
     file: AgentFile,
     turn: TurnState,
     source: ImageSource,
+    delivery?: { allowNativeImage?: boolean },
   ): Promise<boolean> {
     const opts = turn.opts;
     const fileName = sanitizeFileName(file.name);
@@ -944,12 +945,19 @@ export class WeChatAcpClient implements acp.Client {
     const mimeType =
       sanitizeInlineLabel(file.mimeType).split(";")[0].trim().toLowerCase() ||
       "application/octet-stream";
-    if (source === "tool" && opts.showImages === false && mimeType.startsWith("image/")) {
+    const allowNativeImage = delivery?.allowNativeImage ?? true;
+    if (
+      allowNativeImage &&
+      source === "tool" &&
+      opts.showImages === false &&
+      mimeType.startsWith("image/")
+    ) {
       opts.log(`[file] skipped tool image (showImages=false, ${label})`);
       return true;
     }
     const decodedBytes = decodedBase64ByteLength(file.data);
     if (
+      allowNativeImage &&
       (source !== "tool" || opts.showImages !== false) &&
       opts.onImageFlush &&
       SUPPORTED_IMAGE_MIME_TYPES.has(mimeType) &&
@@ -1171,10 +1179,7 @@ export class WeChatAcpClient implements acp.Client {
           .split(";")[0]
           .trim()
           .toLowerCase();
-        const resolvedMime = declaredMime || inferMimeType(attachmentName);
-        const mimeType = resolvedMime.startsWith("image/")
-          ? "text/plain"
-          : resolvedMime;
+        const mimeType = declaredMime || inferMimeType(attachmentName);
         opts.log(
           `[resource] attaching text resource ${name} (${resource.text.length} chars > ${inlineLimit})`,
         );
@@ -1186,6 +1191,7 @@ export class WeChatAcpClient implements acp.Client {
           },
           turn,
           source,
+          { allowNativeImage: false },
         );
         return false;
       }

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -12,7 +12,9 @@ import {
   type AgentFile,
   type AgentResourceLink,
   MAX_AGENT_FILE_BYTES,
+  isArtifactResourceUri,
 } from "../artifacts/types.js";
+import { DEFAULT_RESOURCE_INLINE_LIMIT } from "../config.js";
 import { TEXT_CHUNK_LIMIT } from "../weixin/send.js";
 
 export type { AgentFile } from "../artifacts/types.js";
@@ -279,6 +281,7 @@ export interface WeChatAcpClientOpts {
   showImages?: boolean;
   showAudio?: boolean;
   showResources?: boolean;
+  resourceInlineLimit?: number;
 }
 
 /**
@@ -366,6 +369,7 @@ export class WeChatAcpClient implements acp.Client {
       showDiffs: boolean;
       showImages: boolean;
       showAudio: boolean;
+      showResources: boolean;
     },
   ): Promise<void> {
     return this.enqueue(async () => {
@@ -488,7 +492,7 @@ export class WeChatAcpClient implements acp.Client {
         if (update.status === "completed" && update.content) {
           for (const content of update.content) {
             if (content.type === "content" && content.content.type === "resource_link") {
-              await this.maybeSendResourceLink(content.content, turn, "explicit");
+              await this.maybeSendResourceLink(content.content, turn, "tool");
             }
           }
         }
@@ -543,7 +547,7 @@ export class WeChatAcpClient implements acp.Client {
               }
             } else if (c.type === "content" && c.content.type === "resource_link") {
               resourceLinkContentBlocks++;
-              if (await this.maybeSendResourceLink(c.content, turn, "explicit")) {
+              if (await this.maybeSendResourceLink(c.content, turn, "tool")) {
                 resourceLinkImages++;
               }
             }
@@ -846,7 +850,7 @@ export class WeChatAcpClient implements acp.Client {
           ...(typeof size === "number" ? { size } : {}),
         },
         turn,
-        "explicit",
+        "tool",
       )) {
         images++;
       }
@@ -861,19 +865,25 @@ export class WeChatAcpClient implements acp.Client {
   ): Promise<boolean> {
     const opts = turn.opts;
     const name = sanitizeInlineLabel(link.name ?? resourceDisplayName(link.uri));
+    const explicitArtifact = isArtifactResourceUri(link.uri);
     const mimeType = sanitizeInlineLabel(link.mimeType ?? "")
       .split(";")[0]
       .trim()
       .toLowerCase();
-    if (source === "tool" && opts.showImages === false && mimeType.startsWith("image/")) {
+    if (
+      source === "tool" &&
+      !explicitArtifact &&
+      opts.showImages === false &&
+      mimeType.startsWith("image/")
+    ) {
       opts.log(`[resource-link] skipped tool image (showImages=false, ${name})`);
       return true;
     }
     const routesToImagePipeline =
       SUPPORTED_IMAGE_MIME_TYPES.has(mimeType) &&
-      (source !== "tool" || opts.showImages !== false) &&
+      (source !== "tool" || explicitArtifact || opts.showImages !== false) &&
       Boolean(opts.onImageFlush);
-    if (opts.showResources === false) {
+    if (source === "tool" && !explicitArtifact && opts.showResources === false) {
       opts.log(`[resource-link] skipped (showResources=false, ${name})`);
       return routesToImagePipeline;
     }
@@ -898,7 +908,11 @@ export class WeChatAcpClient implements acp.Client {
         opts.log(`[resource-link] unavailable: ${name}`);
         return false;
       }
-      return await this.maybeSendFile(file, turn, source);
+      return await this.maybeSendFile(
+        file,
+        turn,
+        explicitArtifact ? "explicit" : source,
+      );
     } catch (err) {
       turn.chunks.push(`\n⚠️ [file ${name} could not be resolved]\n`);
       turn.producedMessage = true;
@@ -1131,7 +1145,7 @@ export class WeChatAcpClient implements acp.Client {
       SUPPORTED_IMAGE_MIME_TYPES.has(baseMime) &&
       (source !== "tool" || opts.showImages !== false) &&
       Boolean(opts.onImageFlush);
-    if (opts.showResources === false) {
+    if (source === "tool" && opts.showResources === false) {
       opts.log(`[resource] skipped (showResources=false, ${name})`);
       return routesToImagePipeline;
     }
@@ -1139,6 +1153,29 @@ export class WeChatAcpClient implements acp.Client {
     if ("text" in resource) {
       if (!resource.text.trim()) {
         opts.log(`[resource] skipped empty text resource: ${name}`);
+        return false;
+      }
+      const inlineLimit = opts.resourceInlineLimit ?? DEFAULT_RESOURCE_INLINE_LIMIT;
+      if (source === "tool" && resource.text.length > inlineLimit) {
+        const declaredMime = sanitizeInlineLabel(resource.mimeType ?? "")
+          .split(";")[0]
+          .trim()
+          .toLowerCase();
+        const mimeType = declaredMime.startsWith("image/")
+          ? "text/plain"
+          : declaredMime || "text/plain";
+        opts.log(
+          `[resource] attaching text resource ${name} (${resource.text.length} chars > ${inlineLimit})`,
+        );
+        await this.maybeSendFile(
+          {
+            data: Buffer.from(resource.text, "utf8").toString("base64"),
+            name,
+            mimeType,
+          },
+          turn,
+          source,
+        );
         return false;
       }
       const rendered = renderTextResource(name, resource.mimeType, resource.text);

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -14,6 +14,7 @@ import {
   MAX_AGENT_FILE_BYTES,
   isArtifactResourceUri,
 } from "../artifacts/types.js";
+import { inferMimeType, sanitizeFileName } from "../artifacts/store.js";
 import { DEFAULT_RESOURCE_INLINE_LIMIT } from "../config.js";
 import { TEXT_CHUNK_LIMIT } from "../weixin/send.js";
 
@@ -136,13 +137,12 @@ function base64DecodedByteUpperBound(data: string): number {
 }
 
 /**
- * Human-readable name for a resource: the last path segment of its URI,
- * percent-decoded and sanitized to a single line. Falls back to the full
- * URI when there is no useful path segment (e.g. `untitled:Untitled-1`,
- * an authority with no path like `https://example.com`, or an empty URI),
- * and to `resource` when nothing printable survives sanitization.
+ * Source name for a resource: the last path segment of its URI,
+ * percent-decoded. Falls back to the full URI when there is no useful path
+ * segment (e.g. `untitled:Untitled-1`, an authority with no path like
+ * `https://example.com`, or an empty URI), and to `resource` when blank.
  */
-function resourceDisplayName(uri: string): string {
+function resourceNameFromUri(uri: string): string {
   const trimmed = uri.trim();
   if (!trimmed) return "resource";
   const stripped = trimmed.replace(/[?#].*$/, "");
@@ -170,7 +170,15 @@ function resourceDisplayName(uri: string): string {
       name = last;
     }
   }
-  return sanitizeInlineLabel(name) || "resource";
+  return name || "resource";
+}
+
+function resourceDisplayName(uri: string): string {
+  return sanitizeInlineLabel(resourceNameFromUri(uri)) || "resource";
+}
+
+function resourceAttachmentName(uri: string): string {
+  return sanitizeFileName(resourceNameFromUri(uri));
 }
 
 function resourceFenceLanguage(name: string, mimeType?: string | null): string {
@@ -931,12 +939,13 @@ export class WeChatAcpClient implements acp.Client {
     source: ImageSource,
   ): Promise<boolean> {
     const opts = turn.opts;
-    const name = sanitizeInlineLabel(file.name) || "artifact";
+    const fileName = sanitizeFileName(file.name);
+    const label = sanitizeInlineLabel(fileName) || "artifact";
     const mimeType =
       sanitizeInlineLabel(file.mimeType).split(";")[0].trim().toLowerCase() ||
       "application/octet-stream";
     if (source === "tool" && opts.showImages === false && mimeType.startsWith("image/")) {
-      opts.log(`[file] skipped tool image (showImages=false, ${name})`);
+      opts.log(`[file] skipped tool image (showImages=false, ${label})`);
       return true;
     }
     const decodedBytes = decodedBase64ByteLength(file.data);
@@ -946,37 +955,37 @@ export class WeChatAcpClient implements acp.Client {
       SUPPORTED_IMAGE_MIME_TYPES.has(mimeType) &&
       base64DecodedByteUpperBound(file.data) <= MAX_IMAGE_BYTES
     ) {
-      opts.log(`[file] routing image file ${name} through image pipeline (${mimeType}, ${decodedBytes} bytes)`);
+      opts.log(`[file] routing image file ${label} through image pipeline (${mimeType}, ${decodedBytes} bytes)`);
       await this.maybeSendImage({ data: file.data, mimeType }, turn, source);
       return true;
     }
 
     if (!opts.onFileFlush) {
-      turn.chunks.push(`\n📎 [file: ${name} (${mimeType}) - delivery unavailable]\n`);
+      turn.chunks.push(`\n📎 [file: ${label} (${mimeType}) - delivery unavailable]\n`);
       turn.producedMessage = true;
-      opts.log(`[file] skipped (no file sink configured, ${name})`);
+      opts.log(`[file] skipped (no file sink configured, ${label})`);
       return false;
     }
 
     if (decodedBytes > MAX_AGENT_FILE_BYTES) {
-      turn.chunks.push(`\n⚠️ [file ${name} is too large to deliver]\n`);
+      turn.chunks.push(`\n⚠️ [file ${label} is too large to deliver]\n`);
       turn.producedMessage = true;
       opts.log(
-        `[file] skipped oversized file ${name} (${decodedBytes} bytes > ${MAX_AGENT_FILE_BYTES})`,
+        `[file] skipped oversized file ${label} (${decodedBytes} bytes > ${MAX_AGENT_FILE_BYTES})`,
       );
       return false;
     }
 
     await this.maybeFlushMessage(turn);
     try {
-      await opts.onFileFlush({ data: file.data, name, mimeType });
-      opts.log(`[file] sent ${name} (${mimeType}, ${decodedBytes} bytes)`);
+      await opts.onFileFlush({ data: file.data, name: fileName, mimeType });
+      opts.log(`[file] sent ${label} (${mimeType}, ${decodedBytes} bytes)`);
       turn.producedMessage = true;
       return false;
     } catch (err) {
-      turn.chunks.push(`\n⚠️ [file ${name} could not be delivered]\n`);
+      turn.chunks.push(`\n⚠️ [file ${label} could not be delivered]\n`);
       turn.producedMessage = true;
-      opts.log(`[file] delivery failed for ${name}: ${String(err)}`);
+      opts.log(`[file] delivery failed for ${label}: ${String(err)}`);
       return false;
     }
   }
@@ -1157,20 +1166,22 @@ export class WeChatAcpClient implements acp.Client {
       }
       const inlineLimit = opts.resourceInlineLimit ?? DEFAULT_RESOURCE_INLINE_LIMIT;
       if (source === "tool" && resource.text.length > inlineLimit) {
+        const attachmentName = resourceAttachmentName(resource.uri);
         const declaredMime = sanitizeInlineLabel(resource.mimeType ?? "")
           .split(";")[0]
           .trim()
           .toLowerCase();
-        const mimeType = declaredMime.startsWith("image/")
+        const resolvedMime = declaredMime || inferMimeType(attachmentName);
+        const mimeType = resolvedMime.startsWith("image/")
           ? "text/plain"
-          : declaredMime || "text/plain";
+          : resolvedMime;
         opts.log(
           `[resource] attaching text resource ${name} (${resource.text.length} chars > ${inlineLimit})`,
         );
         await this.maybeSendFile(
           {
             data: Buffer.from(resource.text, "utf8").toString("base64"),
-            name,
+            name: attachmentName,
             mimeType,
           },
           turn,

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -89,6 +89,7 @@ export interface RuntimeBridgeSettings {
   diffs: boolean;
   images: boolean;
   audio: boolean;
+  resources: boolean;
 }
 
 export type RuntimeBridgeSetting = keyof RuntimeBridgeSettings;
@@ -116,6 +117,7 @@ export interface SessionManagerOpts {
   showImages?: boolean;
   showAudio?: boolean;
   showResources?: boolean;
+  resourceInlineLimit?: number;
   createMcpLease?: () => SessionMcpLease;
   agentShutdownTimeoutMs?: number;
   killAgentProcess?: (
@@ -955,6 +957,7 @@ export class SessionManager {
       showImages: this.opts.showImages ?? true,
       showAudio: this.opts.showAudio ?? true,
       showResources: this.opts.showResources ?? true,
+      resourceInlineLimit: this.opts.resourceInlineLimit,
     });
 
     const mcpLease = this.opts.createMcpLease?.();
@@ -1139,6 +1142,7 @@ export class SessionManager {
             showDiffs: outputSettings.diffs,
             showImages: outputSettings.images,
             showAudio: outputSettings.audio,
+            showResources: outputSettings.resources,
           });
           await this.awaitAgentOperation(
             session,
@@ -1552,6 +1556,7 @@ export class SessionManager {
         diffs: this.opts.showDiffs ?? false,
         images: this.opts.showImages ?? true,
         audio: this.opts.showAudio ?? true,
+        resources: this.opts.showResources ?? true,
       };
       this.runtimeBridgeSettings.set(session, settings);
     }

--- a/src/artifacts/store.ts
+++ b/src/artifacts/store.ts
@@ -6,7 +6,9 @@ import { fileURLToPath } from "node:url";
 import {
   AgentFile,
   AgentResourceLink,
+  ARTIFACT_RESOURCE_URI_PREFIX,
   MAX_AGENT_FILE_BYTES,
+  isArtifactResourceUri,
 } from "./types.js";
 
 const DEFAULT_TOTAL_BYTES = 100 * 1024 * 1024;
@@ -91,7 +93,7 @@ export class ArtifactStore {
       this.totalBytes += file.byteLength;
 
       return {
-        uri: `wechat-acp://artifact/${id}`,
+        uri: `${ARTIFACT_RESOURCE_URI_PREFIX}${id}`,
         name,
         mimeType,
         size: file.byteLength,
@@ -102,8 +104,8 @@ export class ArtifactStore {
   async resolveResourceLink(
     link: AgentResourceLink,
   ): Promise<AgentFile | null> {
-    if (link.uri.startsWith("wechat-acp://artifact/")) {
-      return this.consume(link.uri.slice("wechat-acp://artifact/".length));
+    if (isArtifactResourceUri(link.uri)) {
+      return this.consume(link.uri.slice(ARTIFACT_RESOURCE_URI_PREFIX.length));
     }
 
     let filePath: string;

--- a/src/artifacts/types.ts
+++ b/src/artifacts/types.ts
@@ -1,4 +1,9 @@
 export const MAX_AGENT_FILE_BYTES = 25 * 1024 * 1024;
+export const ARTIFACT_RESOURCE_URI_PREFIX = "wechat-acp://artifact/";
+
+export function isArtifactResourceUri(uri: string): boolean {
+  return uri.startsWith(ARTIFACT_RESOURCE_URI_PREFIX);
+}
 
 export interface AgentFile {
   data: string;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -67,6 +67,7 @@ const RUNTIME_BRIDGE_CONFIG_OPTIONS: ReadonlyArray<{
   { id: "bridge.diffs", setting: "diffs", name: "Diffs" },
   { id: "bridge.images", setting: "images", name: "Tool Images" },
   { id: "bridge.audio", setting: "audio", name: "Audio" },
+  { id: "bridge.resources", setting: "resources", name: "Tool Resources" },
 ];
 
 interface MessageBuffer {
@@ -174,16 +175,14 @@ export class WeChatAcpBridge {
 
     try {
       // 2. Start the local artifact MCP server and create SessionManager
-      if (this.config.agent.showResources ?? true) {
-        try {
-          this.artifactMcpServer = await startArtifactMcpServer({
-            rootDir: this.config.agent.cwd,
-            log: this.log,
-          });
-        } catch (err) {
-          this.log(`Artifact MCP unavailable; agent file attachments disabled: ${String(err)}`);
-          trackException(err, "artifact_mcp");
-        }
+      try {
+        this.artifactMcpServer = await startArtifactMcpServer({
+          rootDir: this.config.agent.cwd,
+          log: this.log,
+        });
+      } catch (err) {
+        this.log(`Artifact MCP unavailable; agent file attachments disabled: ${String(err)}`);
+        trackException(err, "artifact_mcp");
       }
       const resumePolicy = this.config.session.resume ?? "off";
       if (resumePolicy !== "off" && !this.config.storage.stateFile) {
@@ -227,6 +226,7 @@ export class WeChatAcpBridge {
         showImages: this.config.agent.showImages ?? true,
         showAudio: this.config.agent.showAudio ?? true,
         showResources: this.config.agent.showResources ?? true,
+        resourceInlineLimit: this.config.agent.resourceInlineLimit,
         createMcpLease: this.artifactMcpServer
           ? () => this.artifactMcpServer!.createLease()
           : undefined,

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,9 @@ import crypto from "node:crypto";
 
 export type SessionResumePolicy = "off" | "auto" | "required";
 
+export const DEFAULT_RESOURCE_INLINE_LIMIT = 1000;
+export const MAX_RESOURCE_INLINE_LIMIT = 4000;
+
 export interface AgentCommandConfig {
   command: string;
   args: string[];
@@ -144,13 +147,21 @@ export interface WeChatAcpConfig {
      */
     showAudio?: boolean;
     /**
-     * Render agent-produced ACP embedded `resource` content blocks in
-     * WeChat: text resources inline as fenced code blocks, image blobs
-     * through the image pipeline, other blobs as a one-line placeholder.
+     * Render intermediate ACP tool `resource` output in WeChat: text resources
+     * inline as fenced code blocks, image blobs through the image pipeline,
+     * other blobs as a one-line placeholder. Explicit agent resources and
+     * files sent through the bridge artifact tool are always delivered.
      * Defaults to `true`; set to `false` (or pass `--hide-resources`)
-     * to drop them.
+     * to drop them. Active sessions can override this with
+     * `bridge.resources` through `/acp-config`.
      */
     showResources?: boolean;
+    /**
+     * Maximum tool text-resource length to render inline. Longer resources
+     * are sent as file attachments. Set to `0` to attach every non-empty tool
+     * text resource. Defaults to 1000 characters.
+     */
+    resourceInlineLimit?: number;
   };
   agents: Record<string, AgentPreset>;
   session: {
@@ -235,6 +246,7 @@ export function defaultConfig(opts?: { instance?: string }): WeChatAcpConfig {
       showImages: true,
       showAudio: true,
       showResources: true,
+      resourceInlineLimit: DEFAULT_RESOURCE_INLINE_LIMIT,
     },
     agents: { ...BUILT_IN_AGENTS },
     session: {
@@ -264,6 +276,21 @@ export function parseSessionResumePolicy(value: unknown): SessionResumePolicy {
   throw new Error(
     `Invalid session resume policy: ${JSON.stringify(value)}. ` +
       'Expected "off", "auto", or "required".',
+  );
+}
+
+export function parseResourceInlineLimit(value: unknown): number {
+  if (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value <= MAX_RESOURCE_INLINE_LIMIT
+  ) {
+    return value;
+  }
+  throw new Error(
+    `Invalid resource inline limit: ${JSON.stringify(value)}. ` +
+      `Expected an integer from 0 to ${MAX_RESOURCE_INLINE_LIMIT}.`,
   );
 }
 

--- a/tests/bridge-new-session.test.ts
+++ b/tests/bridge-new-session.test.ts
@@ -378,6 +378,7 @@ test("a config update that finishes after reset cannot send a stale reply", asyn
           diffs: boolean;
           images: boolean;
           audio: boolean;
+          resources: boolean;
         };
         setSessionConfigOption(): Promise<typeof option[]>;
       };
@@ -389,6 +390,7 @@ test("a config update that finishes after reset cannot send a stale reply", asyn
       diffs: false,
       images: true,
       audio: true,
+      resources: true,
     }),
     setSessionConfigOption: async () => {
       updateStarted();
@@ -426,6 +428,7 @@ test("acp-config updates runtime bridge settings without calling the agent", asy
     diffs: false,
     images: true,
     audio: true,
+    resources: true,
   };
   const updates: Array<{ setting: string; value: boolean }> = [];
   (
@@ -456,17 +459,17 @@ test("acp-config updates runtime bridge settings without calling the agent", asy
 
   await bridge.handleMessage(
     textMessage(
-      `${BRIDGE_COMMANDS.acpConfig} set bridge.images off`,
+      `${BRIDGE_COMMANDS.acpConfig} set bridge.resources off`,
       "context-config",
     ),
   );
 
-  assert.deepEqual(updates, [{ setting: "images", value: false }]);
+  assert.deepEqual(updates, [{ setting: "resources", value: false }]);
   assert.equal(bridge.enqueued.length, 0);
   assert.ok(
     bridge.sent.some(({ segment }) =>
-      segment.includes("bridge.images = off") &&
-      segment.includes("**Tool Images**") &&
+      segment.includes("bridge.resources = off") &&
+      segment.includes("**Tool Resources**") &&
       segment.includes("Runtime Bridge Config") &&
       segment.includes("ACP Session Config")
     ),

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -772,6 +772,35 @@ test("text resource attachment preserves a long basename and extension", async (
   );
 });
 
+test("text resource attachment preserves image MIME without native image routing", async () => {
+  const files: AgentFile[] = [];
+  const images: AgentImage[] = [];
+  const client = makeClient({
+    onFileFlush: async (file) => { files.push(file); },
+    onImageFlush: async (image) => { images.push(image); },
+  });
+
+  await emitToolCallResource(client, {
+    uri: "file:///workspace/vector.svg",
+    mimeType: "image/svg+xml",
+    text: `<svg>${"x".repeat(1001)}</svg>`,
+  });
+  await emitToolCallResource(client, {
+    uri: "file:///workspace/declared.png",
+    mimeType: "image/png",
+    text: "x".repeat(1001),
+  });
+
+  assert.deepEqual(
+    files.map(({ name, mimeType }) => ({ name, mimeType })),
+    [
+      { name: "vector.svg", mimeType: "image/svg+xml" },
+      { name: "declared.png", mimeType: "image/png" },
+    ],
+  );
+  assert.equal(images.length, 0);
+});
+
 test("resourceInlineLimit=0 delivers every non-empty text resource as a file", async () => {
   const files: AgentFile[] = [];
   const client = makeClient({

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -36,6 +36,7 @@ function makeClient(opts: {
   showImages?: boolean;
   showAudio?: boolean;
   showResources?: boolean;
+  resourceInlineLimit?: number;
   sendDelay?: number;
   log?: (msg: string) => void;
 }): WeChatAcpClient {
@@ -63,6 +64,7 @@ function makeClient(opts: {
     showImages: opts.showImages,
     showAudio: opts.showAudio,
     showResources: opts.showResources,
+    resourceInlineLimit: opts.resourceInlineLimit,
   });
 }
 
@@ -723,6 +725,44 @@ test("text resource in completed tool_call_update renders as a fenced block with
   assert.equal(client.hasProducedMessage, true, "resource-only turn counts as produced output");
 });
 
+test("text resource above the inline limit is delivered as a file attachment", async () => {
+  const files: AgentFile[] = [];
+  const client = makeClient({
+    onFileFlush: async (file) => { files.push(file); },
+  });
+  const body = JSON.stringify({ content: "x".repeat(1000) });
+
+  await emitToolCallResource(client, {
+    uri: "file:///package.json",
+    mimeType: "application/json; charset=utf-8",
+    text: body,
+  });
+
+  assert.equal(await client.flush(), "");
+  assert.equal(files.length, 1);
+  assert.equal(files[0].name, "package.json");
+  assert.equal(files[0].mimeType, "application/json");
+  assert.equal(Buffer.from(files[0].data, "base64").toString("utf8"), body);
+  assert.equal(client.hasProducedMessage, true);
+});
+
+test("resourceInlineLimit=0 delivers every non-empty text resource as a file", async () => {
+  const files: AgentFile[] = [];
+  const client = makeClient({
+    resourceInlineLimit: 0,
+    onFileFlush: async (file) => { files.push(file); },
+  });
+
+  await emitToolCallResource(client, {
+    uri: "file:///note.txt",
+    text: "short",
+  });
+
+  assert.equal(await client.flush(), "");
+  assert.equal(files.length, 1);
+  assert.equal(Buffer.from(files[0].data, "base64").toString("utf8"), "short");
+});
+
 test("text resource in agent_message_chunk renders in stream order with surrounding text", async () => {
   const flushed: string[] = [];
   const client = makeClient({ onMessageFlush: async (t) => { flushed.push(t); } });
@@ -762,7 +802,7 @@ test("resource fence language falls back to the file extension when MIME is abse
 });
 
 test("oversized text resource truncates with an explicit tail inside the fence", async () => {
-  const client = makeClient({});
+  const client = makeClient({ resourceInlineLimit: Number.MAX_SAFE_INTEGER });
 
   const body = "x".repeat(4000 + 1234);
   await emitToolCallResource(client, { uri: "file:///big.txt", text: body });
@@ -775,7 +815,7 @@ test("oversized text resource truncates with an explicit tail inside the fence",
 });
 
 test("oversized resource with long name and MIME still fits one segment", async () => {
-  const client = makeClient({});
+  const client = makeClient({ resourceInlineLimit: Number.MAX_SAFE_INTEGER });
 
   const name = "a".repeat(300) + ".txt";
   await emitToolCallResource(client, {
@@ -1055,11 +1095,12 @@ test("padded image at the decoded limit falls back to file delivery", async () =
   assert.equal(files[0].name, "limit.png");
 });
 
-test("image resource_link remains a native image when tool images are hidden", async () => {
+test("attach_file image remains native when tool images and resources are hidden", async () => {
   const images: AgentImage[] = [];
   const files: AgentFile[] = [];
   const client = makeClient({
     showImages: false,
+    showResources: false,
     resolveResourceLink: async () => ({
       data: PNG_BASE64,
       name: "hidden-image.jpg",
@@ -1073,17 +1114,14 @@ test("image resource_link remains a native image when tool images are hidden", a
     },
   });
 
-  await client.sessionUpdate({
-    update: {
-      sessionUpdate: "agent_message_chunk",
-      content: {
-        type: "resource_link",
-        uri: "wechat-acp://artifact/hidden-image",
-        name: "hidden-image.jpg",
-        mimeType: "image/jpeg",
-      },
-    },
-  } as never);
+  await emitToolCallRawOutputImage(client, {
+    contents: [{
+      type: "resource_link",
+      uri: "wechat-acp://artifact/hidden-image",
+      name: "hidden-image.jpg",
+      mimeType: "image/jpeg",
+    }],
+  });
 
   assert.deepEqual(images, [{ data: PNG_BASE64, mimeType: "image/jpeg" }]);
   assert.equal(files.length, 0);
@@ -1163,7 +1201,7 @@ test("resource_link in tool_call_update preserves text-before-file ordering", as
   assert.deepEqual(order, ["text:before", "file:output.txt"]);
 });
 
-test("showResources=false does not resolve or deliver resource links", async () => {
+test("showResources=false keeps explicit agent resource links", async () => {
   let resolverCalls = 0;
   const files: AgentFile[] = [];
   const client = makeClient({
@@ -1171,8 +1209,8 @@ test("showResources=false does not resolve or deliver resource links", async () 
     resolveResourceLink: async () => {
       resolverCalls++;
       return {
-        data: Buffer.from("hidden").toString("base64"),
-        name: "hidden.txt",
+        data: Buffer.from("explicit").toString("base64"),
+        name: "explicit.txt",
         mimeType: "text/plain",
       };
     },
@@ -1186,14 +1224,76 @@ test("showResources=false does not resolve or deliver resource links", async () 
       sessionUpdate: "agent_message_chunk",
       content: {
         type: "resource_link",
-        uri: "wechat-acp://artifact/hidden",
-        name: "hidden.txt",
+        uri: "file:///workspace/explicit.txt",
+        name: "explicit.txt",
       },
     },
   } as never);
 
+  assert.equal(resolverCalls, 1);
+  assert.equal(files.length, 1);
+  assert.equal(files[0].name, "explicit.txt");
+  assert.equal(await client.flush(), "");
+});
+
+test("showResources=false hides ordinary tool resource links", async () => {
+  let resolverCalls = 0;
+  const files: AgentFile[] = [];
+  const client = makeClient({
+    showResources: false,
+    resolveResourceLink: async () => {
+      resolverCalls++;
+      return {
+        data: Buffer.from("hidden").toString("base64"),
+        name: "hidden.txt",
+        mimeType: "text/plain",
+      };
+    },
+    onFileFlush: async (file) => { files.push(file); },
+  });
+
+  await emitToolCallRawOutputImage(client, {
+    contents: [{
+      type: "resource_link",
+      uri: "file:///workspace/hidden.txt",
+      name: "hidden.txt",
+      mimeType: "text/plain",
+    }],
+  });
+
   assert.equal(resolverCalls, 0);
   assert.equal(files.length, 0);
+  assert.equal(await client.flush(), "");
+});
+
+test("showResources=false keeps attach_file artifact links", async () => {
+  let resolverCalls = 0;
+  const files: AgentFile[] = [];
+  const client = makeClient({
+    showResources: false,
+    resolveResourceLink: async () => {
+      resolverCalls++;
+      return {
+        data: Buffer.from("attachment").toString("base64"),
+        name: "attachment.txt",
+        mimeType: "text/plain",
+      };
+    },
+    onFileFlush: async (file) => { files.push(file); },
+  });
+
+  await emitToolCallRawOutputImage(client, {
+    contents: [{
+      type: "resource_link",
+      uri: "wechat-acp://artifact/attachment",
+      name: "attachment.txt",
+      mimeType: "text/plain",
+    }],
+  });
+
+  assert.equal(resolverCalls, 1);
+  assert.equal(files.length, 1);
+  assert.equal(files[0].name, "attachment.txt");
   assert.equal(await client.flush(), "");
 });
 
@@ -1227,7 +1327,7 @@ test("hidden image resource_link suppresses the mirrored rawOutput image fallbac
         type: "content",
         content: {
           type: "resource_link",
-          uri: "wechat-acp://artifact/hidden-image",
+          uri: "file:///workspace/hidden-image.png",
           name: "hidden.png",
           mimeType: "image/png",
         },
@@ -1242,18 +1342,41 @@ test("hidden image resource_link suppresses the mirrored rawOutput image fallbac
 
 test("showResources=false drops resources without rendering", async () => {
   const images: AgentImage[] = [];
+  const files: AgentFile[] = [];
   const client = makeClient({
     onImageFlush: async (img) => { images.push(img); },
+    onFileFlush: async (file) => { files.push(file); },
     showResources: false,
   });
   client.newTurn();
 
-  await emitToolCallResource(client, { uri: "file:///a.txt", text: "hello" });
+  await emitToolCallResource(client, { uri: "file:///a.txt", text: "x".repeat(1001) });
   await emitToolCallResource(client, { uri: "file:///b.png", mimeType: "image/png", blob: PNG_BASE64 });
 
   assert.equal(images.length, 0);
+  assert.equal(files.length, 0);
   assert.equal(client.hasProducedMessage, false);
   assert.equal(await client.flush(), "", "no output for intentionally hidden resources");
+});
+
+test("showResources=false keeps explicit agent resources inline", async () => {
+  const files: AgentFile[] = [];
+  const client = makeClient({
+    showResources: false,
+    resourceInlineLimit: 0,
+    onFileFlush: async (file) => { files.push(file); },
+  });
+  const body = "x".repeat(1001);
+
+  await emitMessageChunkResource(client, {
+    uri: "file:///explicit.txt",
+    text: body,
+  });
+
+  const text = await client.flush();
+  assert.match(text, /📎 explicit\.txt/);
+  assert.match(text, new RegExp(`x{${body.length}}`));
+  assert.equal(files.length, 0);
 });
 
 test("empty text resource is skipped without rendering an empty fence", async () => {
@@ -1436,7 +1559,7 @@ test("MIME parameters do not defeat the fence language hint", async () => {
 });
 
 test("adversarial backtick run keeps the fence bounded and contained", async () => {
-  const client = makeClient({});
+  const client = makeClient({ resourceInlineLimit: Number.MAX_SAFE_INTEGER });
   client.newTurn();
 
   const body = "start\n" + "`".repeat(3000) + "\nend";

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -746,6 +746,32 @@ test("text resource above the inline limit is delivered as a file attachment", a
   assert.equal(client.hasProducedMessage, true);
 });
 
+test("text resource attachment preserves a long basename and extension", async () => {
+  const files: AgentFile[] = [];
+  const logs: string[] = [];
+  const client = makeClient({
+    onFileFlush: async (file) => { files.push(file); },
+    log: (message) => { logs.push(message); },
+  });
+  const name = `${"a".repeat(130)}.json`;
+
+  await emitToolCallResource(client, {
+    uri: `file:///workspace/${name}`,
+    text: "x".repeat(1001),
+  });
+
+  assert.equal(files.length, 1);
+  assert.equal(files[0].name, name);
+  assert.equal(files[0].mimeType, "application/json");
+  assert.ok(
+    logs.some((message) =>
+      message.startsWith("[resource] attaching text resource ") &&
+      message.includes("... (1001 chars > 1000)")
+    ),
+    "the log keeps the capped inline label",
+  );
+});
+
 test("resourceInlineLimit=0 delivers every non-empty text resource as a file", async () => {
   const files: AgentFile[] = [];
   const client = makeClient({

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -4,7 +4,9 @@ import { test } from "node:test";
 import {
   BRIDGE_COMMANDS,
   buildAgentSessionScope,
+  defaultConfig,
   matchBridgeCommand,
+  parseResourceInlineLimit,
   parseSessionResumePolicy,
   validateCommandAliases,
 } from "../src/config.js";
@@ -47,6 +49,17 @@ test("session resume policy accepts only documented modes", () => {
   assert.equal(parseSessionResumePolicy("auto"), "auto");
   assert.equal(parseSessionResumePolicy("required"), "required");
   assert.throws(() => parseSessionResumePolicy("yes"), /Invalid session resume policy/);
+});
+
+test("resource inline limit defaults to 1000 and accepts 0 through 4000", () => {
+  assert.equal(defaultConfig().agent.resourceInlineLimit, 1000);
+  assert.equal(parseResourceInlineLimit(0), 0);
+  assert.equal(parseResourceInlineLimit(1000), 1000);
+  assert.equal(parseResourceInlineLimit(4000), 4000);
+  assert.throws(() => parseResourceInlineLimit(-1), /Invalid resource inline limit/);
+  assert.throws(() => parseResourceInlineLimit(4001), /Invalid resource inline limit/);
+  assert.throws(() => parseResourceInlineLimit(1.5), /Invalid resource inline limit/);
+  assert.throws(() => parseResourceInlineLimit("1000"), /Invalid resource inline limit/);
 });
 
 test("acp-more aliases validate and bare aliases match only the full message", () => {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -182,6 +182,7 @@ test("runtime bridge settings are scoped to a session and applied at the next tu
     showDiffs: false,
     showImages: true,
     showAudio: true,
+    showResources: true,
     log: () => {},
     onReply: async () => {},
     sendTyping: async () => {},
@@ -205,11 +206,13 @@ test("runtime bridge settings are scoped to a session and applied at the next tu
     diffs: false,
     images: true,
     audio: true,
+    resources: true,
   });
   manager.setRuntimeBridgeSetting(session.userId, "thoughts", false);
   manager.setRuntimeBridgeSetting(session.userId, "diffs", true);
   manager.setRuntimeBridgeSetting(session.userId, "images", false);
   manager.setRuntimeBridgeSetting(session.userId, "audio", false);
+  manager.setRuntimeBridgeSetting(session.userId, "resources", false);
 
   await internal.processQueue(session);
 
@@ -218,6 +221,7 @@ test("runtime bridge settings are scoped to a session and applied at the next tu
     showDiffs: true,
     showImages: false,
     showAudio: false,
+    showResources: false,
   }]);
 
   const replacementSession = makeTurnSession({
@@ -231,6 +235,7 @@ test("runtime bridge settings are scoped to a session and applied at the next tu
     diffs: false,
     images: true,
     audio: true,
+    resources: true,
   });
   assert.equal(manager.getRuntimeBridgeSettings("other-user"), undefined);
 });


### PR DESCRIPTION
## Summary

- add a configurable `1000` character inline limit for tool text resources, with longer content sent as file attachments
- scope `showResources`, `--hide-resources`, and `bridge.resources` to intermediate tool output
- keep explicit agent resources and `attach_file` results visible when tool resources are hidden
- keep the artifact MCP server available regardless of the tool resource visibility setting
- identify bridge-owned attachment links by their `wechat-acp://artifact/` URI

## Testing

- `npm run build`
- `node --import tsx/esm --test tests/client.test.ts tests/config.test.ts tests/session.test.ts tests/bridge-new-session.test.ts`
- `node --import tsx/esm --test --test-name-pattern "artifact MCP requires auth" tests/artifact.test.ts`

Closes #78